### PR TITLE
Fix bug where intents export would duplicate the first intent

### DIFF
--- a/src/cli/cmd/intents/export/export.go
+++ b/src/cli/cmd/intents/export/export.go
@@ -34,8 +34,6 @@ var ExportCmd = &cobra.Command{
 				return err
 			}
 
-			intentsFromMapper = append(intentsFromMapper, intentsFromMapper[0])
-
 			outputList := make([]v1alpha1.ClientIntents, 0)
 
 			for _, serviceIntents := range intentsFromMapper {


### PR DESCRIPTION
## Description
Fix bug where intents export would duplicate the first intent


## Link to Dev Task
https://www.notion.so/otterize/Duplicate-response-from-otterize-intents-export-61b6b2c234e3409f8680286716647963
https://www.notion.so/otterize/otterize-intents-export-crashes-on-empty-state-67cd4bfa0f7843338d68b08f1fcd27be
