### PR TITLE
Go report badge now links to actual report

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 ![build](https://github.com/otterize/network-mapper/actions/workflows/build.yaml/badge.svg)
-![go report](https://img.shields.io/static/v1?label=go%20report&message=A%2B&color=success)
+[![Go Report Card](https://goreportcard.com/badge/github.com/otterize/network-mapper/src)](https://goreportcard.com/report/github.com/otterize/network-mapper/src)
 [![community](https://img.shields.io/badge/slack-Otterize_Slack-purple.svg?logo=slack)](https://joinslack.otterize.com)
 
 [About](#about) | [Quick tutorial](https://docs.otterize.com/quick-tutorials/k8s-network-mapper) | [Installation instructions](#installation-instructions) | [How does the network mapper work?](#how-does-the-intents-operator-work) | [Docs](https://docs.otterize.com/components/network-mapper/) | [Contributing](#contributing) | [Slack](#slack)


### PR DESCRIPTION
### Description

Go report badge now links to actual report instead of a static `A+` badge
