### PR TITLE
Report discovered intents by namespace

### DIFF
--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -91,8 +91,7 @@ func main() {
 	_ = resolver.LoadStore(initCtx) // loads the store from the previous run
 	resolver.Register(e)
 
-	// Temporary condition to disable cloud upload until K8s integration is ready
-	if cloudConfig.Environment != "" {
+	if cloudConfig.IsCloudUploadEnabled() {
 		go func() {
 			cloudClientCtx, cloudClientCancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 			defer cloudClientCancel()

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -13,7 +13,7 @@ import (
 type FactoryFunction func(ctx context.Context, apiAddress string, tokenSource oauth2.TokenSource) CloudClient
 
 type CloudClient interface {
-	ReportDiscoveredIntents(namespace string, intents []IntentInput) bool
+	ReportDiscoveredIntents(intents []IntentInput) bool
 }
 
 type CloudClientImpl struct {
@@ -32,9 +32,9 @@ func NewClient(ctx context.Context, apiAddress string, tokenSource oauth2.TokenS
 	}
 }
 
-func (c *CloudClientImpl) ReportDiscoveredIntents(namespace string, intents []IntentInput) bool {
+func (c *CloudClientImpl) ReportDiscoveredIntents(intents []IntentInput) bool {
 	logrus.Info("Uploading intents to cloud, count: ", len(intents))
-	_, err := ReportDiscoveredIntents(c.ctx, c.client, namespace, intents)
+	_, err := ReportDiscoveredIntents(c.ctx, c.client, intents)
 	if err != nil {
 		logrus.Error("Failed to upload intents to cloud ", err)
 		return false

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -13,7 +13,7 @@ import (
 type FactoryFunction func(ctx context.Context, apiAddress string, tokenSource oauth2.TokenSource) CloudClient
 
 type CloudClient interface {
-	ReportDiscoveredSourcedIntents(environment string, source string, intents []IntentInput) bool
+	ReportDiscoveredSourcedIntents(namespace string, intents []IntentInput) bool
 }
 
 type CloudClientImpl struct {
@@ -32,9 +32,9 @@ func NewClient(ctx context.Context, apiAddress string, tokenSource oauth2.TokenS
 	}
 }
 
-func (c *CloudClientImpl) ReportDiscoveredSourcedIntents(environment string, source string, intents []IntentInput) bool {
+func (c *CloudClientImpl) ReportDiscoveredSourcedIntents(namespace string, intents []IntentInput) bool {
 	logrus.Info("Uploading intents to cloud, count: ", len(intents))
-	_, err := ReportDiscoveredSourcedIntents(c.ctx, c.client, environment, source, intents)
+	_, err := ReportDiscoveredSourcedIntents(c.ctx, c.client, namespace, intents)
 	if err != nil {
 		logrus.Error("Failed to upload intents to cloud ", err)
 		return false

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -13,7 +13,7 @@ import (
 type FactoryFunction func(ctx context.Context, apiAddress string, tokenSource oauth2.TokenSource) CloudClient
 
 type CloudClient interface {
-	ReportDiscoveredSourcedIntents(namespace string, intents []IntentInput) bool
+	ReportDiscoveredIntents(namespace string, intents []IntentInput) bool
 }
 
 type CloudClientImpl struct {
@@ -32,9 +32,9 @@ func NewClient(ctx context.Context, apiAddress string, tokenSource oauth2.TokenS
 	}
 }
 
-func (c *CloudClientImpl) ReportDiscoveredSourcedIntents(namespace string, intents []IntentInput) bool {
+func (c *CloudClientImpl) ReportDiscoveredIntents(namespace string, intents []IntentInput) bool {
 	logrus.Info("Uploading intents to cloud, count: ", len(intents))
-	_, err := ReportDiscoveredSourcedIntents(c.ctx, c.client, namespace, intents)
+	_, err := ReportDiscoveredIntents(c.ctx, c.client, namespace, intents)
 	if err != nil {
 		logrus.Error("Failed to upload intents to cloud ", err)
 		return false

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -73,10 +73,10 @@ func (v *IntentInput) GetBody() IntentBody { return v.Body }
 type IntentType string
 
 const (
-	IntentTypeHttp  IntentType = "http"
-	IntentTypeKafka IntentType = "kafka"
-	IntentTypeGrpc  IntentType = "grpc"
-	IntentTypeRedis IntentType = "redis"
+	IntentTypeHttp  IntentType = "HTTP"
+	IntentTypeKafka IntentType = "KAFKA"
+	IntentTypeGrpc  IntentType = "GRPC"
+	IntentTypeRedis IntentType = "REDIS"
 )
 
 type KafkaConfigInput struct {
@@ -93,16 +93,16 @@ func (v *KafkaConfigInput) GetOperations() []KafkaOperation { return v.Operation
 type KafkaOperation string
 
 const (
-	KafkaOperationConsume         KafkaOperation = "consume"
-	KafkaOperationProduce         KafkaOperation = "produce"
-	KafkaOperationCreate          KafkaOperation = "create"
-	KafkaOperationAlter           KafkaOperation = "alter"
-	KafkaOperationDelete          KafkaOperation = "delete"
-	KafkaOperationDescribe        KafkaOperation = "describe"
-	KafkaOperationClusteraction   KafkaOperation = "ClusterAction"
-	KafkaOperationDescribeconfigs KafkaOperation = "DescribeConfigs"
-	KafkaOperationAlterconfigs    KafkaOperation = "AlterConfigs"
-	KafkaOperationIdempotentwrite KafkaOperation = "IdempotentWrite"
+	KafkaOperationConsume         KafkaOperation = "CONSUME"
+	KafkaOperationProduce         KafkaOperation = "PRODUCE"
+	KafkaOperationCreate          KafkaOperation = "CREATE"
+	KafkaOperationAlter           KafkaOperation = "ALTER"
+	KafkaOperationDelete          KafkaOperation = "DELETE"
+	KafkaOperationDescribe        KafkaOperation = "DESCRIBE"
+	KafkaOperationClusterAction   KafkaOperation = "CLUSTER_ACTION"
+	KafkaOperationDescribeConfigs KafkaOperation = "DESCRIBE_CONFIGS"
+	KafkaOperationAlterConfigs    KafkaOperation = "ALTER_CONFIGS"
+	KafkaOperationIdempotentWrite KafkaOperation = "IDEMPOTENT_WRITE"
 )
 
 // ReportDiscoveredIntentsResponse is returned by ReportDiscoveredIntents on success.

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -97,49 +97,49 @@ const (
 	KafkaOperationIdempotentwrite KafkaOperation = "IdempotentWrite"
 )
 
-// ReportDiscoveredSourcedIntentsResponse is returned by ReportDiscoveredSourcedIntents on success.
-type ReportDiscoveredSourcedIntentsResponse struct {
-	ReportDiscoveredSourcedIntents bool `json:"reportDiscoveredSourcedIntents"`
+// ReportDiscoveredIntentsResponse is returned by ReportDiscoveredIntents on success.
+type ReportDiscoveredIntentsResponse struct {
+	ReportDiscoveredIntents bool `json:"reportDiscoveredIntents"`
 }
 
-// GetReportDiscoveredSourcedIntents returns ReportDiscoveredSourcedIntentsResponse.ReportDiscoveredSourcedIntents, and is useful for accessing the field via an interface.
-func (v *ReportDiscoveredSourcedIntentsResponse) GetReportDiscoveredSourcedIntents() bool {
-	return v.ReportDiscoveredSourcedIntents
+// GetReportDiscoveredIntents returns ReportDiscoveredIntentsResponse.ReportDiscoveredIntents, and is useful for accessing the field via an interface.
+func (v *ReportDiscoveredIntentsResponse) GetReportDiscoveredIntents() bool {
+	return v.ReportDiscoveredIntents
 }
 
-// __ReportDiscoveredSourcedIntentsInput is used internally by genqlient
-type __ReportDiscoveredSourcedIntentsInput struct {
+// __ReportDiscoveredIntentsInput is used internally by genqlient
+type __ReportDiscoveredIntentsInput struct {
 	Namespace string        `json:"namespace"`
 	Intents   []IntentInput `json:"intents"`
 }
 
-// GetNamespace returns __ReportDiscoveredSourcedIntentsInput.Namespace, and is useful for accessing the field via an interface.
-func (v *__ReportDiscoveredSourcedIntentsInput) GetNamespace() string { return v.Namespace }
+// GetNamespace returns __ReportDiscoveredIntentsInput.Namespace, and is useful for accessing the field via an interface.
+func (v *__ReportDiscoveredIntentsInput) GetNamespace() string { return v.Namespace }
 
-// GetIntents returns __ReportDiscoveredSourcedIntentsInput.Intents, and is useful for accessing the field via an interface.
-func (v *__ReportDiscoveredSourcedIntentsInput) GetIntents() []IntentInput { return v.Intents }
+// GetIntents returns __ReportDiscoveredIntentsInput.Intents, and is useful for accessing the field via an interface.
+func (v *__ReportDiscoveredIntentsInput) GetIntents() []IntentInput { return v.Intents }
 
-func ReportDiscoveredSourcedIntents(
+func ReportDiscoveredIntents(
 	ctx context.Context,
 	client graphql.Client,
 	namespace string,
 	intents []IntentInput,
-) (*ReportDiscoveredSourcedIntentsResponse, error) {
+) (*ReportDiscoveredIntentsResponse, error) {
 	req := &graphql.Request{
-		OpName: "ReportDiscoveredSourcedIntents",
+		OpName: "ReportDiscoveredIntents",
 		Query: `
-mutation ReportDiscoveredSourcedIntents ($namespace: String!, $intents: [IntentInput!]!) {
-	reportDiscoveredSourcedIntents(namespace: $namespace, intents: $intents)
+mutation ReportDiscoveredIntents ($namespace: String!, $intents: [IntentInput!]!) {
+	reportDiscoveredIntents(namespace: $namespace, intents: $intents)
 }
 `,
-		Variables: &__ReportDiscoveredSourcedIntentsInput{
+		Variables: &__ReportDiscoveredIntentsInput{
 			Namespace: namespace,
 			Intents:   intents,
 		},
 	}
 	var err error
 
-	var data ReportDiscoveredSourcedIntentsResponse
+	var data ReportDiscoveredIntentsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -109,16 +109,12 @@ func (v *ReportDiscoveredSourcedIntentsResponse) GetReportDiscoveredSourcedInten
 
 // __ReportDiscoveredSourcedIntentsInput is used internally by genqlient
 type __ReportDiscoveredSourcedIntentsInput struct {
-	Environment string        `json:"environment"`
-	Source      string        `json:"source"`
-	Intents     []IntentInput `json:"intents"`
+	Namespace string        `json:"namespace"`
+	Intents   []IntentInput `json:"intents"`
 }
 
-// GetEnvironment returns __ReportDiscoveredSourcedIntentsInput.Environment, and is useful for accessing the field via an interface.
-func (v *__ReportDiscoveredSourcedIntentsInput) GetEnvironment() string { return v.Environment }
-
-// GetSource returns __ReportDiscoveredSourcedIntentsInput.Source, and is useful for accessing the field via an interface.
-func (v *__ReportDiscoveredSourcedIntentsInput) GetSource() string { return v.Source }
+// GetNamespace returns __ReportDiscoveredSourcedIntentsInput.Namespace, and is useful for accessing the field via an interface.
+func (v *__ReportDiscoveredSourcedIntentsInput) GetNamespace() string { return v.Namespace }
 
 // GetIntents returns __ReportDiscoveredSourcedIntentsInput.Intents, and is useful for accessing the field via an interface.
 func (v *__ReportDiscoveredSourcedIntentsInput) GetIntents() []IntentInput { return v.Intents }
@@ -126,21 +122,19 @@ func (v *__ReportDiscoveredSourcedIntentsInput) GetIntents() []IntentInput { ret
 func ReportDiscoveredSourcedIntents(
 	ctx context.Context,
 	client graphql.Client,
-	environment string,
-	source string,
+	namespace string,
 	intents []IntentInput,
 ) (*ReportDiscoveredSourcedIntentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ReportDiscoveredSourcedIntents",
 		Query: `
-mutation ReportDiscoveredSourcedIntents ($environment: ID!, $source: String!, $intents: [IntentInput!]!) {
-	reportDiscoveredSourcedIntents(environment: $environment, source: $source, intents: $intents)
+mutation ReportDiscoveredSourcedIntents ($namespace: String!, $intents: [IntentInput!]!) {
+	reportDiscoveredSourcedIntents(namespace: $namespace, intents: $intents)
 }
 `,
 		Variables: &__ReportDiscoveredSourcedIntentsInput{
-			Environment: environment,
-			Source:      source,
-			Intents:     intents,
+			Namespace: namespace,
+			Intents:   intents,
 		},
 	}
 	var err error

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -48,16 +48,24 @@ func (v *IntentBody) GetTopics() []KafkaConfigInput { return v.Topics }
 func (v *IntentBody) GetResources() []HTTPConfigInput { return v.Resources }
 
 type IntentInput struct {
-	Client string     `json:"client"`
-	Server string     `json:"server"`
-	Body   IntentBody `json:"body"`
+	Namespace       string     `json:"namespace"`
+	ClientName      string     `json:"clientName"`
+	ServerName      string     `json:"serverName"`
+	ServerNamespace string     `json:"serverNamespace"`
+	Body            IntentBody `json:"body"`
 }
 
-// GetClient returns IntentInput.Client, and is useful for accessing the field via an interface.
-func (v *IntentInput) GetClient() string { return v.Client }
+// GetNamespace returns IntentInput.Namespace, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetNamespace() string { return v.Namespace }
 
-// GetServer returns IntentInput.Server, and is useful for accessing the field via an interface.
-func (v *IntentInput) GetServer() string { return v.Server }
+// GetClientName returns IntentInput.ClientName, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetClientName() string { return v.ClientName }
+
+// GetServerName returns IntentInput.ServerName, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetServerName() string { return v.ServerName }
+
+// GetServerNamespace returns IntentInput.ServerNamespace, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetServerNamespace() string { return v.ServerNamespace }
 
 // GetBody returns IntentInput.Body, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetBody() IntentBody { return v.Body }
@@ -65,22 +73,22 @@ func (v *IntentInput) GetBody() IntentBody { return v.Body }
 type IntentType string
 
 const (
-	IntentTypeHttp  IntentType = "HTTP"
-	IntentTypeKafka IntentType = "Kafka"
-	IntentTypeGrpc  IntentType = "gRPC"
-	IntentTypeRedis IntentType = "Redis"
+	IntentTypeHttp  IntentType = "http"
+	IntentTypeKafka IntentType = "kafka"
+	IntentTypeGrpc  IntentType = "grpc"
+	IntentTypeRedis IntentType = "redis"
 )
 
 type KafkaConfigInput struct {
-	Topic     string         `json:"topic"`
-	Operation KafkaOperation `json:"operation"`
+	Name       string           `json:"name"`
+	Operations []KafkaOperation `json:"operations"`
 }
 
-// GetTopic returns KafkaConfigInput.Topic, and is useful for accessing the field via an interface.
-func (v *KafkaConfigInput) GetTopic() string { return v.Topic }
+// GetName returns KafkaConfigInput.Name, and is useful for accessing the field via an interface.
+func (v *KafkaConfigInput) GetName() string { return v.Name }
 
-// GetOperation returns KafkaConfigInput.Operation, and is useful for accessing the field via an interface.
-func (v *KafkaConfigInput) GetOperation() KafkaOperation { return v.Operation }
+// GetOperations returns KafkaConfigInput.Operations, and is useful for accessing the field via an interface.
+func (v *KafkaConfigInput) GetOperations() []KafkaOperation { return v.Operations }
 
 type KafkaOperation string
 
@@ -109,12 +117,8 @@ func (v *ReportDiscoveredIntentsResponse) GetReportDiscoveredIntents() bool {
 
 // __ReportDiscoveredIntentsInput is used internally by genqlient
 type __ReportDiscoveredIntentsInput struct {
-	Namespace string        `json:"namespace"`
-	Intents   []IntentInput `json:"intents"`
+	Intents []IntentInput `json:"intents"`
 }
-
-// GetNamespace returns __ReportDiscoveredIntentsInput.Namespace, and is useful for accessing the field via an interface.
-func (v *__ReportDiscoveredIntentsInput) GetNamespace() string { return v.Namespace }
 
 // GetIntents returns __ReportDiscoveredIntentsInput.Intents, and is useful for accessing the field via an interface.
 func (v *__ReportDiscoveredIntentsInput) GetIntents() []IntentInput { return v.Intents }
@@ -122,19 +126,17 @@ func (v *__ReportDiscoveredIntentsInput) GetIntents() []IntentInput { return v.I
 func ReportDiscoveredIntents(
 	ctx context.Context,
 	client graphql.Client,
-	namespace string,
 	intents []IntentInput,
 ) (*ReportDiscoveredIntentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ReportDiscoveredIntents",
 		Query: `
-mutation ReportDiscoveredIntents ($namespace: String!, $intents: [IntentInput!]!) {
-	reportDiscoveredIntents(namespace: $namespace, intents: $intents)
+mutation ReportDiscoveredIntents ($intents: [IntentInput!]!) {
+	reportDiscoveredIntents(intents: $intents)
 }
 `,
 		Variables: &__ReportDiscoveredIntentsInput{
-			Namespace: namespace,
-			Intents:   intents,
+			Intents: intents,
 		},
 	}
 	var err error

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -1,3 +1,3 @@
-mutation ReportDiscoveredSourcedIntents($environment: ID!, $source: String!, $intents: [IntentInput!]!) {
-    reportDiscoveredSourcedIntents(environment: $environment, source: $source, intents: $intents)
+mutation ReportDiscoveredSourcedIntents($namespace: String!, $intents: [IntentInput!]!) {
+    reportDiscoveredSourcedIntents(namespace: $namespace, intents: $intents)
 }

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -1,3 +1,3 @@
-mutation ReportDiscoveredSourcedIntents($namespace: String!, $intents: [IntentInput!]!) {
-    reportDiscoveredSourcedIntents(namespace: $namespace, intents: $intents)
+mutation ReportDiscoveredIntents($namespace: String!, $intents: [IntentInput!]!) {
+    reportDiscoveredIntents(namespace: $namespace, intents: $intents)
 }

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -1,3 +1,3 @@
-mutation ReportDiscoveredIntents($namespace: String!, $intents: [IntentInput!]!) {
-    reportDiscoveredIntents(namespace: $namespace, intents: $intents)
+mutation ReportDiscoveredIntents($intents: [IntentInput!]!) {
+    reportDiscoveredIntents(intents: $intents)
 }

--- a/src/mapper/pkg/cloudclient/genqlient.yaml
+++ b/src/mapper/pkg/cloudclient/genqlient.yaml
@@ -2,7 +2,6 @@
 # https://github.com/Khan/genqlient/blob/main/docs/genqlient.yaml
 schema:
   - '../../../cloudgraphql/*.graphql'
-  - '../../../cloudgraphql/deprecated/*.graphql'
   - '../../../cloudgraphql/federation/*.graphql'
 operations:
   - genqlient.graphql

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -35,15 +35,15 @@ func (m *MockCloudClient) EXPECT() *MockCloudClientMockRecorder {
 }
 
 // ReportDiscoveredSourcedIntents mocks base method.
-func (m *MockCloudClient) ReportDiscoveredSourcedIntents(environment, source string, intents []cloudclient.IntentInput) bool {
+func (m *MockCloudClient) ReportDiscoveredSourcedIntents(namespace string, intents []cloudclient.IntentInput) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportDiscoveredSourcedIntents", environment, source, intents)
+	ret := m.ctrl.Call(m, "ReportDiscoveredSourcedIntents", namespace, intents)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // ReportDiscoveredSourcedIntents indicates an expected call of ReportDiscoveredSourcedIntents.
-func (mr *MockCloudClientMockRecorder) ReportDiscoveredSourcedIntents(environment, source, intents interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ReportDiscoveredSourcedIntents(namespace, intents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredSourcedIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredSourcedIntents), environment, source, intents)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredSourcedIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredSourcedIntents), namespace, intents)
 }

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -35,15 +35,15 @@ func (m *MockCloudClient) EXPECT() *MockCloudClientMockRecorder {
 }
 
 // ReportDiscoveredIntents mocks base method.
-func (m *MockCloudClient) ReportDiscoveredIntents(namespace string, intents []cloudclient.IntentInput) bool {
+func (m *MockCloudClient) ReportDiscoveredIntents(intents []cloudclient.IntentInput) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportDiscoveredIntents", namespace, intents)
+	ret := m.ctrl.Call(m, "ReportDiscoveredIntents", intents)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // ReportDiscoveredIntents indicates an expected call of ReportDiscoveredIntents.
-func (mr *MockCloudClientMockRecorder) ReportDiscoveredIntents(namespace, intents interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ReportDiscoveredIntents(intents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredIntents), namespace, intents)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredIntents), intents)
 }

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -34,16 +34,16 @@ func (m *MockCloudClient) EXPECT() *MockCloudClientMockRecorder {
 	return m.recorder
 }
 
-// ReportDiscoveredSourcedIntents mocks base method.
-func (m *MockCloudClient) ReportDiscoveredSourcedIntents(namespace string, intents []cloudclient.IntentInput) bool {
+// ReportDiscoveredIntents mocks base method.
+func (m *MockCloudClient) ReportDiscoveredIntents(namespace string, intents []cloudclient.IntentInput) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportDiscoveredSourcedIntents", namespace, intents)
+	ret := m.ctrl.Call(m, "ReportDiscoveredIntents", namespace, intents)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// ReportDiscoveredSourcedIntents indicates an expected call of ReportDiscoveredSourcedIntents.
-func (mr *MockCloudClientMockRecorder) ReportDiscoveredSourcedIntents(namespace, intents interface{}) *gomock.Call {
+// ReportDiscoveredIntents indicates an expected call of ReportDiscoveredIntents.
+func (mr *MockCloudClientMockRecorder) ReportDiscoveredIntents(namespace, intents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredSourcedIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredSourcedIntents), namespace, intents)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredIntents), namespace, intents)
 }

--- a/src/mapper/pkg/clouduploader/cloud_config.go
+++ b/src/mapper/pkg/clouduploader/cloud_config.go
@@ -1,0 +1,26 @@
+package clouduploader
+
+import (
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
+	"github.com/spf13/viper"
+)
+
+type Config struct {
+	ClientId       string
+	Secret         string
+	apiAddress     string
+	UploadInterval int
+}
+
+func ConfigFromViper() Config {
+	return Config{
+		Secret:         viper.GetString(config.ClientSecretKey),
+		ClientId:       viper.GetString(config.ClientIDKey),
+		apiAddress:     viper.GetString(config.CloudApiAddrKey),
+		UploadInterval: viper.GetInt(config.UploadIntervalSecondsKey),
+	}
+}
+
+func (c *Config) IsCloudUploadEnabled() bool {
+	return c.ClientId != "" && c.Secret != ""
+}

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -70,7 +70,7 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 	}
 
 	for namespace, intents := range intentsByNamespace {
-		uploadSuccess := client.ReportDiscoveredSourcedIntents(namespace, intents)
+		uploadSuccess := client.ReportDiscoveredIntents(namespace, intents)
 		if uploadSuccess {
 			c.lastUploadTimestamp = lastUpdate
 		}

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -55,9 +55,6 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 			intent.ClientName = service.Name
 			intent.Namespace = service.Namespace
 			intent.ServerName = serviceIntent.Name
-			intent.Body = cloudclient.IntentBody{
-				Type: cloudclient.IntentTypeHttp,
-			}
 
 			intents = append(intents, intent)
 		}

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -57,8 +57,8 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 	s.addIntent("client1", "server2")
 
 	intents1 := []cloudclient.IntentInput{
-		{ClientName: "client1", ServerName: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
-		{ClientName: "client1", ServerName: "server2", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
+		{ClientName: "client1", ServerName: "server1", Namespace: s.testNamespace},
+		{ClientName: "client1", ServerName: "server2", Namespace: s.testNamespace},
 	}
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.InAnyOrder(intents1)).Return(true).Times(1)
 
@@ -67,9 +67,9 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 	s.addIntent("client2", "server1")
 
 	intents2 := []cloudclient.IntentInput{
-		{ClientName: "client1", ServerName: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
-		{ClientName: "client1", ServerName: "server2", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
-		{ClientName: "client2", ServerName: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
+		{ClientName: "client1", ServerName: "server1", Namespace: s.testNamespace},
+		{ClientName: "client1", ServerName: "server2", Namespace: s.testNamespace},
+		{ClientName: "client2", ServerName: "server1", Namespace: s.testNamespace},
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.InAnyOrder(intents2)).Return(true).Times(1)
@@ -86,7 +86,7 @@ func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
 	s.addIntent("client", "server")
 
 	intents := []cloudclient.IntentInput{
-		{ClientName: "client", ServerName: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
+		{ClientName: "client", ServerName: "server", Namespace: s.testNamespace},
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)
@@ -100,7 +100,7 @@ func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
 	s.addIntent("client", "server")
 
 	intents := []cloudclient.IntentInput{
-		{ClientName: "client", ServerName: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
+		{ClientName: "client", ServerName: "server", Namespace: s.testNamespace},
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(false).Times(1)
@@ -115,7 +115,7 @@ func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
 	s.addIntent("client", "server")
 
 	intents := []cloudclient.IntentInput{
-		{ClientName: "client", ServerName: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
+		{ClientName: "client", ServerName: "server", Namespace: s.testNamespace},
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -26,9 +26,7 @@ func (s *CloudUploaderTestSuite) SetupTest() {
 	s.testNamespace = "test-namespace"
 	s.intentsHolder = resolvers.NewIntentsHolder(nil, resolvers.IntentsHolderConfig{StoreConfigMap: config.StoreConfigMapDefault, Namespace: s.testNamespace})
 	s.cloudConfig = Config{
-		ClientId:     "test-client-id",
-		Environment:  "test-environment",
-		IntentSource: "test-source",
+		ClientId: "test-client-id",
 	}
 }
 
@@ -62,7 +60,7 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 		{Client: "client1", Server: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 		{Client: "client1", Server: "server2", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.cloudConfig.Environment, s.cloudConfig.IntentSource, gomock.Eq(intents1)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.testNamespace, gomock.InAnyOrder(intents1)).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 
@@ -74,12 +72,12 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 		{Client: "client2", Server: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.cloudConfig.Environment, s.cloudConfig.IntentSource, gomock.Eq(intents2)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.testNamespace, gomock.InAnyOrder(intents2)).Return(true).Times(1)
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
 
 func (s *CloudUploaderTestSuite) TestDontUploadWithoutIntents() {
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(gomock.Any(), gomock.Any()).Times(0)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
@@ -91,7 +89,7 @@ func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
 		{Client: "client", Server: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.cloudConfig.Environment, s.cloudConfig.IntentSource, intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.testNamespace, intents).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.addIntent("client", "server")
@@ -106,11 +104,11 @@ func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(
-		s.cloudConfig.Environment, s.cloudConfig.IntentSource, intents,
+		s.testNamespace, intents,
 	).Return(false).Times(1)
 
 	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(
-		s.cloudConfig.Environment, s.cloudConfig.IntentSource, intents,
+		s.testNamespace, intents,
 	).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
@@ -124,7 +122,7 @@ func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
 		{Client: "client", Server: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.cloudConfig.Environment, s.cloudConfig.IntentSource, intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.testNamespace, intents).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -57,27 +57,27 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 	s.addIntent("client1", "server2")
 
 	intents1 := []cloudclient.IntentInput{
-		{Client: "client1", Server: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
-		{Client: "client1", Server: "server2", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
+		{ClientName: "client1", ServerName: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
+		{ClientName: "client1", ServerName: "server2", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
 	}
-	s.clientMock.EXPECT().ReportDiscoveredIntents(s.testNamespace, gomock.InAnyOrder(intents1)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.InAnyOrder(intents1)).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 
 	s.addIntent("client2", "server1")
 
 	intents2 := []cloudclient.IntentInput{
-		{Client: "client1", Server: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
-		{Client: "client1", Server: "server2", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
-		{Client: "client2", Server: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
+		{ClientName: "client1", ServerName: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
+		{ClientName: "client1", ServerName: "server2", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
+		{ClientName: "client2", ServerName: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(s.testNamespace, gomock.InAnyOrder(intents2)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.InAnyOrder(intents2)).Return(true).Times(1)
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
 
 func (s *CloudUploaderTestSuite) TestDontUploadWithoutIntents() {
-	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), gomock.Any()).Times(0)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any()).Times(0)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
@@ -86,10 +86,10 @@ func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
 	s.addIntent("client", "server")
 
 	intents := []cloudclient.IntentInput{
-		{Client: "client", Server: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
+		{ClientName: "client", ServerName: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(s.testNamespace, intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.addIntent("client", "server")
@@ -100,16 +100,12 @@ func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
 	s.addIntent("client", "server")
 
 	intents := []cloudclient.IntentInput{
-		{Client: "client", Server: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
+		{ClientName: "client", ServerName: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(
-		s.testNamespace, intents,
-	).Return(false).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(false).Times(1)
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(
-		s.testNamespace, intents,
-	).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
@@ -119,10 +115,10 @@ func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
 	s.addIntent("client", "server")
 
 	intents := []cloudclient.IntentInput{
-		{Client: "client", Server: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
+		{ClientName: "client", ServerName: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}, Namespace: s.testNamespace},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(s.testNamespace, intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -60,7 +60,7 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 		{Client: "client1", Server: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 		{Client: "client1", Server: "server2", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.testNamespace, gomock.InAnyOrder(intents1)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(s.testNamespace, gomock.InAnyOrder(intents1)).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 
@@ -72,12 +72,12 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 		{Client: "client2", Server: "server1", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.testNamespace, gomock.InAnyOrder(intents2)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(s.testNamespace, gomock.InAnyOrder(intents2)).Return(true).Times(1)
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
 
 func (s *CloudUploaderTestSuite) TestDontUploadWithoutIntents() {
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(gomock.Any(), gomock.Any()).Times(0)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), gomock.Any()).Times(0)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
@@ -89,7 +89,7 @@ func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
 		{Client: "client", Server: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.testNamespace, intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(s.testNamespace, intents).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.addIntent("client", "server")
@@ -103,11 +103,11 @@ func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
 		{Client: "client", Server: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(
+	s.clientMock.EXPECT().ReportDiscoveredIntents(
 		s.testNamespace, intents,
 	).Return(false).Times(1)
 
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(
+	s.clientMock.EXPECT().ReportDiscoveredIntents(
 		s.testNamespace, intents,
 	).Return(true).Times(1)
 
@@ -122,7 +122,7 @@ func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
 		{Client: "client", Server: "server", Body: cloudclient.IntentBody{Type: cloudclient.IntentTypeHttp}},
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredSourcedIntents(s.testNamespace, intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(s.testNamespace, intents).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -22,9 +22,6 @@ const (
 	CloudApiAddrDefault          = "https://app.otterize.com/api"
 	ClientSecretKey              = "client-secret"
 	ClientIDKey                  = "client-id"
-	CloudEnvironmentKey          = "cloud-environment"
-	UploadSourceKey              = "upload-source"
-	UploadSourceDefault          = "mapper-periodic-upload"
 	UploadIntervalSecondsKey     = "upload-interval-seconds"
 	UploadIntervalSecondsDefault = 60
 )
@@ -35,7 +32,6 @@ func init() {
 	viper.SetDefault(StoreConfigMapKey, StoreConfigMapDefault)
 	viper.SetDefault(NamespaceKey, NamespaceDefault)
 	viper.SetDefault(CloudApiAddrKey, CloudApiAddrDefault)
-	viper.SetDefault(UploadSourceKey, UploadSourceDefault)
 	viper.SetDefault(UploadIntervalSecondsKey, UploadIntervalSecondsDefault)
 	viper.SetDefault(CloudGraphQLEndpointKey, CloudGraphQLEndpointDefault)
 	viper.SetEnvPrefix(EnvPrefix)


### PR DESCRIPTION
### Description

Replace environment id and source with namespace. EnvID is no longer used to identify the connection, and source is resolved in back end

- [ ] This change adds test coverage for new/changed/fixed functionality
