### PR TITLE
Fix report discovered intents by namespace

### DIFF
--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Khan/genqlient/graphql"
 	"github.com/otterize/network-mapper/src/mapper/pkg/config"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
@@ -34,7 +35,12 @@ func NewClient(ctx context.Context, apiAddress string, tokenSource oauth2.TokenS
 
 func (c *CloudClientImpl) ReportDiscoveredIntents(intents []IntentInput) bool {
 	logrus.Info("Uploading intents to cloud, count: ", len(intents))
-	_, err := ReportDiscoveredIntents(c.ctx, c.client, intents)
+
+	intentsPtr := lo.Map(intents, func(intent IntentInput, _ int) *IntentInput {
+		return &intent
+	})
+
+	_, err := ReportDiscoveredIntents(c.ctx, c.client, intentsPtr)
 	if err != nil {
 		logrus.Error("Failed to upload intents to cloud ", err)
 		return false

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -9,15 +9,15 @@ import (
 )
 
 type HTTPConfigInput struct {
-	Path   string     `json:"path"`
-	Method HTTPMethod `json:"method"`
+	Path   *string     `json:"path"`
+	Method *HTTPMethod `json:"method"`
 }
 
 // GetPath returns HTTPConfigInput.Path, and is useful for accessing the field via an interface.
-func (v *HTTPConfigInput) GetPath() string { return v.Path }
+func (v *HTTPConfigInput) GetPath() *string { return v.Path }
 
 // GetMethod returns HTTPConfigInput.Method, and is useful for accessing the field via an interface.
-func (v *HTTPConfigInput) GetMethod() HTTPMethod { return v.Method }
+func (v *HTTPConfigInput) GetMethod() *HTTPMethod { return v.Method }
 
 type HTTPMethod string
 
@@ -33,42 +33,42 @@ const (
 )
 
 type IntentBody struct {
-	Type      IntentType         `json:"type"`
-	Topics    []KafkaConfigInput `json:"topics"`
-	Resources []HTTPConfigInput  `json:"resources"`
+	Type      *IntentType         `json:"type"`
+	Topics    []*KafkaConfigInput `json:"topics"`
+	Resources []*HTTPConfigInput  `json:"resources"`
 }
 
 // GetType returns IntentBody.Type, and is useful for accessing the field via an interface.
-func (v *IntentBody) GetType() IntentType { return v.Type }
+func (v *IntentBody) GetType() *IntentType { return v.Type }
 
 // GetTopics returns IntentBody.Topics, and is useful for accessing the field via an interface.
-func (v *IntentBody) GetTopics() []KafkaConfigInput { return v.Topics }
+func (v *IntentBody) GetTopics() []*KafkaConfigInput { return v.Topics }
 
 // GetResources returns IntentBody.Resources, and is useful for accessing the field via an interface.
-func (v *IntentBody) GetResources() []HTTPConfigInput { return v.Resources }
+func (v *IntentBody) GetResources() []*HTTPConfigInput { return v.Resources }
 
 type IntentInput struct {
-	Namespace       string     `json:"namespace"`
-	ClientName      string     `json:"clientName"`
-	ServerName      string     `json:"serverName"`
-	ServerNamespace string     `json:"serverNamespace"`
-	Body            IntentBody `json:"body"`
+	Namespace       *string     `json:"namespace"`
+	ClientName      *string     `json:"clientName"`
+	ServerName      *string     `json:"serverName"`
+	ServerNamespace *string     `json:"serverNamespace"`
+	Body            *IntentBody `json:"body"`
 }
 
 // GetNamespace returns IntentInput.Namespace, and is useful for accessing the field via an interface.
-func (v *IntentInput) GetNamespace() string { return v.Namespace }
+func (v *IntentInput) GetNamespace() *string { return v.Namespace }
 
 // GetClientName returns IntentInput.ClientName, and is useful for accessing the field via an interface.
-func (v *IntentInput) GetClientName() string { return v.ClientName }
+func (v *IntentInput) GetClientName() *string { return v.ClientName }
 
 // GetServerName returns IntentInput.ServerName, and is useful for accessing the field via an interface.
-func (v *IntentInput) GetServerName() string { return v.ServerName }
+func (v *IntentInput) GetServerName() *string { return v.ServerName }
 
 // GetServerNamespace returns IntentInput.ServerNamespace, and is useful for accessing the field via an interface.
-func (v *IntentInput) GetServerNamespace() string { return v.ServerNamespace }
+func (v *IntentInput) GetServerNamespace() *string { return v.ServerNamespace }
 
 // GetBody returns IntentInput.Body, and is useful for accessing the field via an interface.
-func (v *IntentInput) GetBody() IntentBody { return v.Body }
+func (v *IntentInput) GetBody() *IntentBody { return v.Body }
 
 type IntentType string
 
@@ -80,15 +80,15 @@ const (
 )
 
 type KafkaConfigInput struct {
-	Name       string           `json:"name"`
-	Operations []KafkaOperation `json:"operations"`
+	Name       *string           `json:"name"`
+	Operations []*KafkaOperation `json:"operations"`
 }
 
 // GetName returns KafkaConfigInput.Name, and is useful for accessing the field via an interface.
-func (v *KafkaConfigInput) GetName() string { return v.Name }
+func (v *KafkaConfigInput) GetName() *string { return v.Name }
 
 // GetOperations returns KafkaConfigInput.Operations, and is useful for accessing the field via an interface.
-func (v *KafkaConfigInput) GetOperations() []KafkaOperation { return v.Operations }
+func (v *KafkaConfigInput) GetOperations() []*KafkaOperation { return v.Operations }
 
 type KafkaOperation string
 
@@ -107,26 +107,26 @@ const (
 
 // ReportDiscoveredIntentsResponse is returned by ReportDiscoveredIntents on success.
 type ReportDiscoveredIntentsResponse struct {
-	ReportDiscoveredIntents bool `json:"reportDiscoveredIntents"`
+	ReportDiscoveredIntents *bool `json:"reportDiscoveredIntents"`
 }
 
 // GetReportDiscoveredIntents returns ReportDiscoveredIntentsResponse.ReportDiscoveredIntents, and is useful for accessing the field via an interface.
-func (v *ReportDiscoveredIntentsResponse) GetReportDiscoveredIntents() bool {
+func (v *ReportDiscoveredIntentsResponse) GetReportDiscoveredIntents() *bool {
 	return v.ReportDiscoveredIntents
 }
 
 // __ReportDiscoveredIntentsInput is used internally by genqlient
 type __ReportDiscoveredIntentsInput struct {
-	Intents []IntentInput `json:"intents"`
+	Intents []*IntentInput `json:"intents"`
 }
 
 // GetIntents returns __ReportDiscoveredIntentsInput.Intents, and is useful for accessing the field via an interface.
-func (v *__ReportDiscoveredIntentsInput) GetIntents() []IntentInput { return v.Intents }
+func (v *__ReportDiscoveredIntentsInput) GetIntents() []*IntentInput { return v.Intents }
 
 func ReportDiscoveredIntents(
 	ctx context.Context,
 	client graphql.Client,
-	intents []IntentInput,
+	intents []*IntentInput,
 ) (*ReportDiscoveredIntentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ReportDiscoveredIntents",

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -1,3 +1,4 @@
+# @genqlient(pointer: true)
 mutation ReportDiscoveredIntents($intents: [IntentInput!]!) {
     reportDiscoveredIntents(intents: $intents)
 }

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
 	"github.com/otterize/network-mapper/src/mapper/pkg/resolvers"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
@@ -52,9 +53,10 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 	for service, serviceIntents := range c.intentsHolder.GetIntentsPerService(nil) {
 		for _, serviceIntent := range serviceIntents {
 			var intent cloudclient.IntentInput
-			intent.ClientName = service.Name
-			intent.Namespace = service.Namespace
-			intent.ServerName = serviceIntent.Name
+			intent.ClientName = lo.ToPtr(service.Name)
+			intent.Namespace = lo.ToPtr(service.Namespace)
+			intent.ServerName = lo.ToPtr(serviceIntent.Name)
+			intent.ServerNamespace = lo.ToPtr(serviceIntent.Namespace)
 
 			intents = append(intents, intent)
 		}

--- a/src/mapper/pkg/clouduploader/intents_input_matcher.go
+++ b/src/mapper/pkg/clouduploader/intents_input_matcher.go
@@ -1,0 +1,91 @@
+package clouduploader
+
+import (
+	"fmt"
+	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
+)
+
+// IntentsMatcher Implement gomock.Matcher interface for []cloudclient.IntentInput
+type IntentsMatcher struct {
+	expected []cloudclient.IntentInput
+}
+
+func NilCompare[T comparable](a *T, b *T) bool {
+	return (a == nil && b == nil) || (a != nil && b != nil && *a == *b)
+}
+
+func compareIntentInput(a cloudclient.IntentInput, b cloudclient.IntentInput) bool {
+	return NilCompare(a.ClientName, b.ClientName) &&
+		NilCompare(a.Namespace, b.Namespace) &&
+		NilCompare(a.ServerName, b.ServerName) &&
+		NilCompare(a.ServerNamespace, b.ServerNamespace)
+}
+
+func (m IntentsMatcher) Matches(x interface{}) bool {
+	if x == nil {
+		return false
+	}
+	actualIntents, ok := x.([]cloudclient.IntentInput)
+	if !ok {
+		return false
+	}
+	expectedIntents := m.expected
+	if len(actualIntents) != len(expectedIntents) {
+		return false
+	}
+
+	for _, expected := range expectedIntents {
+		found := false
+		for _, actual := range actualIntents {
+			if compareIntentInput(actual, expected) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func (m IntentsMatcher) String() string {
+	return prettyPrint(m)
+}
+
+func prettyPrint(m IntentsMatcher) string {
+	expected := m.expected
+	var result string
+	itemFormat := "IntentInput{ClientName: %s, ServerName: %s, Namespace: %s, ServerNamespace: %s},"
+	for _, intent := range expected {
+		var clientName, namespace, serverName, serverNamespace string
+		if intent.ClientName != nil {
+			clientName = *intent.ClientName
+		}
+		if intent.Namespace != nil {
+			namespace = *intent.Namespace
+		}
+		if intent.ServerName != nil {
+			serverName = *intent.ServerName
+		}
+		if intent.ServerNamespace != nil {
+			serverNamespace = *intent.ServerNamespace
+		}
+		result += fmt.Sprintf(itemFormat, clientName, serverName, namespace, serverNamespace)
+	}
+
+	return result
+}
+
+func (m IntentsMatcher) Got(got interface{}) string {
+	actual, ok := got.([]cloudclient.IntentInput)
+	if !ok {
+		return fmt.Sprintf("Not an []cloudclient.IntentInput, Got: %v", got)
+	}
+
+	return prettyPrint(IntentsMatcher{actual})
+}
+
+func GetMatcher(expected []cloudclient.IntentInput) IntentsMatcher {
+	return IntentsMatcher{expected}
+}

--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -91,17 +91,13 @@ func (i *IntentsHolder) Reset() {
 func (i *IntentsHolder) AddIntent(srcService model.OtterizeServiceIdentity, dstService model.OtterizeServiceIdentity) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	namespace := ""
-	if srcService.Namespace != dstService.Namespace {
-		// namespace is only needed if it's a connection between different namespaces.
-		namespace = dstService.Namespace
-	}
+
 	intents, ok := i.store[srcService]
 	if !ok {
 		intents = goset.NewSet[model.OtterizeServiceIdentity]()
 		i.store[srcService] = intents
 	}
-	intent := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: namespace}
+	intent := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: dstService.Namespace}
 	if !intents.Contains(intent) {
 		i.lastIntentsUpdate = time.Now()
 		intents.Add(intent)

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -67,7 +67,10 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 				Namespace: s.TestNamespace,
 			},
 			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
-				{Name: "service2"},
+				{
+					Name:      "service2",
+					Namespace: s.TestNamespace,
+				},
 			},
 		},
 		{
@@ -76,8 +79,14 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 				Namespace: s.TestNamespace,
 			},
 			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
-				{Name: "service1"},
-				{Name: "service2"},
+				{
+					Name:      "service1",
+					Namespace: s.TestNamespace,
+				},
+				{
+					Name:      "service2",
+					Namespace: s.TestNamespace,
+				},
 			},
 		},
 	})
@@ -112,7 +121,10 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 				Namespace: s.TestNamespace,
 			},
 			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
-				{Name: "service2"},
+				{
+					Name:      "service2",
+					Namespace: s.TestNamespace,
+				},
 			},
 		},
 		{
@@ -121,8 +133,14 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 				Namespace: s.TestNamespace,
 			},
 			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
-				{Name: "service1"},
-				{Name: "service2"},
+				{
+					Name:      "service1",
+					Namespace: s.TestNamespace,
+				},
+				{
+					Name:      "service2",
+					Namespace: s.TestNamespace,
+				},
 			},
 		},
 	})


### PR DESCRIPTION
### Description

Until this PR client namespace wasn't sent to cloud, even though we always detect it. 
In addition, empty body was sent to cloud instead of nil due to annoying behavior of genqlient, who explicitly expect each nullable object to be decaled as, well, nullable 🤦‍♂️

This PR fix both problems while upgrading our testing so we can catch it in the future.
### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
