### PR TITLE
Create config file for networkmapper grqphql

### DIFF
--- a/src/mapper/gqlgen.yml
+++ b/src/mapper/gqlgen.yml
@@ -1,6 +1,6 @@
 # Where are all the schema files located? globs are supported eg  src/**/*.graphqls
 schema:
-  - '../mappergraphql/*'
+  - '../mappergraphql/*.graphql'
 
 # Where should the generated server code go?
 exec:

--- a/src/mappergraphql/.graphqlconfig.yaml
+++ b/src/mappergraphql/.graphqlconfig.yaml
@@ -1,0 +1,4 @@
+schema:
+  - ./*.graphql
+
+

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -1,5 +1,3 @@
-
-
 input CaptureResultForSrcIp {
     srcIp: String!
     destinations: [String!]!


### PR DESCRIPTION
Config file for each GraphQL project help IDE and other tools to differentiate between stand-along projects.
