### PR TITLE
Run go generate with latest schema to fix null body error in intents reporting

### DIFF
--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -40,27 +40,14 @@ const (
 	HTTPMethodConnect HTTPMethod = "CONNECT"
 )
 
-type IntentBody struct {
-	Type      *IntentType         `json:"type"`
-	Topics    []*KafkaConfigInput `json:"topics"`
-	Resources []*HTTPConfigInput  `json:"resources"`
-}
-
-// GetType returns IntentBody.Type, and is useful for accessing the field via an interface.
-func (v *IntentBody) GetType() *IntentType { return v.Type }
-
-// GetTopics returns IntentBody.Topics, and is useful for accessing the field via an interface.
-func (v *IntentBody) GetTopics() []*KafkaConfigInput { return v.Topics }
-
-// GetResources returns IntentBody.Resources, and is useful for accessing the field via an interface.
-func (v *IntentBody) GetResources() []*HTTPConfigInput { return v.Resources }
-
 type IntentInput struct {
-	Namespace       *string     `json:"namespace"`
-	ClientName      *string     `json:"clientName"`
-	ServerName      *string     `json:"serverName"`
-	ServerNamespace *string     `json:"serverNamespace"`
-	Body            *IntentBody `json:"body"`
+	Namespace       *string             `json:"namespace"`
+	ClientName      *string             `json:"clientName"`
+	ServerName      *string             `json:"serverName"`
+	ServerNamespace *string             `json:"serverNamespace"`
+	Type            *IntentType         `json:"type"`
+	Topics          []*KafkaConfigInput `json:"topics"`
+	Resources       []*HTTPConfigInput  `json:"resources"`
 }
 
 // GetNamespace returns IntentInput.Namespace, and is useful for accessing the field via an interface.
@@ -75,16 +62,20 @@ func (v *IntentInput) GetServerName() *string { return v.ServerName }
 // GetServerNamespace returns IntentInput.ServerNamespace, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetServerNamespace() *string { return v.ServerNamespace }
 
-// GetBody returns IntentInput.Body, and is useful for accessing the field via an interface.
-func (v *IntentInput) GetBody() *IntentBody { return v.Body }
+// GetType returns IntentInput.Type, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetType() *IntentType { return v.Type }
+
+// GetTopics returns IntentInput.Topics, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetTopics() []*KafkaConfigInput { return v.Topics }
+
+// GetResources returns IntentInput.Resources, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetResources() []*HTTPConfigInput { return v.Resources }
 
 type IntentType string
 
 const (
 	IntentTypeHttp  IntentType = "HTTP"
 	IntentTypeKafka IntentType = "KAFKA"
-	IntentTypeGrpc  IntentType = "GRPC"
-	IntentTypeRedis IntentType = "REDIS"
 )
 
 type KafkaConfigInput struct {

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -53,7 +53,7 @@ func (s *CloudUploaderTestSuite) addIntent(source string, srcNamespace string, d
 	)
 }
 
-func intentInput(clientName string, namespace string, serverName string, serverNamespace string, bodyPtr *cloudclient.IntentBody) cloudclient.IntentInput {
+func intentInput(clientName string, namespace string, serverName string, serverNamespace string) cloudclient.IntentInput {
 	nilIfEmpty := func(s string) *string {
 		if s == "" {
 			return nil
@@ -66,7 +66,6 @@ func intentInput(clientName string, namespace string, serverName string, serverN
 		ServerName:      nilIfEmpty(serverName),
 		Namespace:       nilIfEmpty(namespace),
 		ServerNamespace: nilIfEmpty(serverNamespace),
-		Body:            bodyPtr,
 	}
 }
 
@@ -75,8 +74,8 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 	s.addIntent("client1", s.testNamespace, "server2", "external-namespace")
 
 	intents1 := []cloudclient.IntentInput{
-		intentInput("client1", s.testNamespace, "server1", s.testNamespace, nil),
-		intentInput("client1", s.testNamespace, "server2", "external-namespace", nil),
+		intentInput("client1", s.testNamespace, "server1", s.testNamespace),
+		intentInput("client1", s.testNamespace, "server2", "external-namespace"),
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents1)).Return(true).Times(1)
@@ -86,9 +85,9 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 	s.addIntent("client2", s.testNamespace, "server1", s.testNamespace)
 
 	intents2 := []cloudclient.IntentInput{
-		intentInput("client2", s.testNamespace, "server1", s.testNamespace, nil),
-		intentInput("client1", s.testNamespace, "server1", s.testNamespace, nil),
-		intentInput("client1", s.testNamespace, "server2", "external-namespace", nil),
+		intentInput("client2", s.testNamespace, "server1", s.testNamespace),
+		intentInput("client1", s.testNamespace, "server1", s.testNamespace),
+		intentInput("client1", s.testNamespace, "server2", "external-namespace"),
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents2)).Return(true).Times(1)
@@ -106,7 +105,7 @@ func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
 	s.addIntent("client", s.testNamespace, "server", s.testNamespace)
 
 	intents := []cloudclient.IntentInput{
-		intentInput("client", s.testNamespace, "server", s.testNamespace, nil),
+		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)
@@ -120,7 +119,7 @@ func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
 	s.addIntent("client", s.testNamespace, "server", s.testNamespace)
 
 	intents := []cloudclient.IntentInput{
-		intentInput("client", s.testNamespace, "server", s.testNamespace, nil),
+		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(false).Times(1)
@@ -135,7 +134,7 @@ func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
 	s.addIntent("client", s.testNamespace, "server", s.testNamespace)
 
 	intents := []cloudclient.IntentInput{
-		intentInput("client", s.testNamespace, "server", s.testNamespace, nil),
+		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)

--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -223,9 +223,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	{Name: "../mappergraphql/schema.graphql", Input: `
-
-input CaptureResultForSrcIp {
+	{Name: "../mappergraphql/schema.graphql", Input: `input CaptureResultForSrcIp {
     srcIp: String!
     destinations: [String!]!
 }


### PR DESCRIPTION
### Description
Ran go generate to use new intents graphql schema without body & fixed tests.