### PR TITLE
Add discovery time to discovered intents

### DIFF
--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/Khan/genqlient/graphql"
-	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
@@ -12,7 +11,7 @@ import (
 type FactoryFunction func(ctx context.Context, apiAddress string, tokenSource oauth2.TokenSource) CloudClient
 
 type CloudClient interface {
-	ReportDiscoveredIntents(intents []IntentInput) bool
+	ReportDiscoveredIntents(intents []*DiscoveredIntentInput) bool
 	ReportComponentStatus(component ComponentType)
 }
 
@@ -31,14 +30,10 @@ func NewClient(ctx context.Context, apiAddress string, tokenSource oauth2.TokenS
 	}
 }
 
-func (c *CloudClientImpl) ReportDiscoveredIntents(intents []IntentInput) bool {
+func (c *CloudClientImpl) ReportDiscoveredIntents(intents []*DiscoveredIntentInput) bool {
 	logrus.Info("Uploading intents to cloud, count: ", len(intents))
 
-	intentsPtr := lo.Map(intents, func(intent IntentInput, _ int) *IntentInput {
-		return &intent
-	})
-
-	_, err := ReportDiscoveredIntents(c.ctx, c.client, intentsPtr)
+	_, err := ReportDiscoveredIntents(c.ctx, c.client, intents)
 	if err != nil {
 		logrus.Error("Failed to upload intents to cloud ", err)
 		return false

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -4,6 +4,7 @@ package cloudclient
 
 import (
 	"context"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 )
@@ -15,6 +16,17 @@ const (
 	ComponentTypeCredentialsOperator ComponentType = "CREDENTIALS_OPERATOR"
 	ComponentTypeNetworkMapper       ComponentType = "NETWORK_MAPPER"
 )
+
+type DiscoveredIntentInput struct {
+	DiscoveredAt *time.Time   `json:"discoveredAt"`
+	Intent       *IntentInput `json:"intent"`
+}
+
+// GetDiscoveredAt returns DiscoveredIntentInput.DiscoveredAt, and is useful for accessing the field via an interface.
+func (v *DiscoveredIntentInput) GetDiscoveredAt() *time.Time { return v.DiscoveredAt }
+
+// GetIntent returns DiscoveredIntentInput.Intent, and is useful for accessing the field via an interface.
+func (v *DiscoveredIntentInput) GetIntent() *IntentInput { return v.Intent }
 
 type HTTPConfigInput struct {
 	Path   *string     `json:"path"`
@@ -134,11 +146,11 @@ func (v *__ReportComponentStatusInput) GetComponent() ComponentType { return v.C
 
 // __ReportDiscoveredIntentsInput is used internally by genqlient
 type __ReportDiscoveredIntentsInput struct {
-	Intents []*IntentInput `json:"intents"`
+	Intents []*DiscoveredIntentInput `json:"intents"`
 }
 
 // GetIntents returns __ReportDiscoveredIntentsInput.Intents, and is useful for accessing the field via an interface.
-func (v *__ReportDiscoveredIntentsInput) GetIntents() []*IntentInput { return v.Intents }
+func (v *__ReportDiscoveredIntentsInput) GetIntents() []*DiscoveredIntentInput { return v.Intents }
 
 func ReportComponentStatus(
 	ctx context.Context,
@@ -173,12 +185,12 @@ mutation ReportComponentStatus ($component: ComponentType!) {
 func ReportDiscoveredIntents(
 	ctx context.Context,
 	client graphql.Client,
-	intents []*IntentInput,
+	intents []*DiscoveredIntentInput,
 ) (*ReportDiscoveredIntentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ReportDiscoveredIntents",
 		Query: `
-mutation ReportDiscoveredIntents ($intents: [IntentInput!]!) {
+mutation ReportDiscoveredIntents ($intents: [DiscoveredIntentInput!]!) {
 	reportDiscoveredIntents(intents: $intents)
 }
 `,

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -1,5 +1,5 @@
 # @genqlient(pointer: true)
-mutation ReportDiscoveredIntents($intents: [IntentInput!]!) {
+mutation ReportDiscoveredIntents($intents: [DiscoveredIntentInput!]!) {
     reportDiscoveredIntents(intents: $intents)
 }
 

--- a/src/mapper/pkg/cloudclient/genqlient.yaml
+++ b/src/mapper/pkg/cloudclient/genqlient.yaml
@@ -6,3 +6,6 @@ schema:
 operations:
   - genqlient.graphql
 generated: ./generated.go
+bindings:
+  Time:
+    type: time.Time

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -47,7 +47,7 @@ func (mr *MockCloudClientMockRecorder) ReportComponentStatus(component interface
 }
 
 // ReportDiscoveredIntents mocks base method.
-func (m *MockCloudClient) ReportDiscoveredIntents(intents []cloudclient.IntentInput) bool {
+func (m *MockCloudClient) ReportDiscoveredIntents(intents []*cloudclient.DiscoveredIntentInput) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReportDiscoveredIntents", intents)
 	ret0, _ := ret[0].(bool)

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -65,7 +65,17 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 		return
 	}
 
-	uploadSuccess := client.ReportDiscoveredIntents(intents)
+	var discoveredIntents []*cloudclient.DiscoveredIntentInput
+	for _, intent := range intents {
+		input := cloudclient.DiscoveredIntentInput{
+			Intent:       lo.ToPtr(intent),
+			DiscoveredAt: lo.ToPtr(time.Now()),
+		}
+
+		discoveredIntents = append(discoveredIntents, lo.ToPtr(input))
+	}
+
+	uploadSuccess := client.ReportDiscoveredIntents(discoveredIntents)
 	if uploadSuccess {
 		c.lastUploadTimestamp = lastUpdate
 	}

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -108,7 +108,7 @@ func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
 		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents)).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.addIntent("client", s.testNamespace, "server", s.testNamespace)
@@ -122,9 +122,9 @@ func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
 		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(false).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents)).Return(false).Times(1)
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents)).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
@@ -137,7 +137,7 @@ func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
 		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(intents).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents)).Return(true).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())

--- a/src/mapper/pkg/clouduploader/intents_input_matcher.go
+++ b/src/mapper/pkg/clouduploader/intents_input_matcher.go
@@ -25,11 +25,13 @@ func (m IntentsMatcher) Matches(x interface{}) bool {
 	if x == nil {
 		return false
 	}
-	actualIntents, ok := x.([]cloudclient.IntentInput)
+	actualDiscoveredIntents, ok := x.([]*cloudclient.DiscoveredIntentInput)
 	if !ok {
 		return false
 	}
 	expectedIntents := m.expected
+	actualIntents := discoveredIntentsPtrToIntents(actualDiscoveredIntents)
+
 	if len(actualIntents) != len(expectedIntents) {
 		return false
 	}
@@ -47,6 +49,15 @@ func (m IntentsMatcher) Matches(x interface{}) bool {
 		}
 	}
 	return true
+}
+
+func discoveredIntentsPtrToIntents(actualDiscoveredIntents []*cloudclient.DiscoveredIntentInput) []cloudclient.IntentInput {
+	actualIntents := make([]cloudclient.IntentInput, 0)
+	for _, intent := range actualDiscoveredIntents {
+		intentObject := *intent.Intent
+		actualIntents = append(actualIntents, intentObject)
+	}
+	return actualIntents
 }
 
 func (m IntentsMatcher) String() string {
@@ -78,12 +89,12 @@ func prettyPrint(m IntentsMatcher) string {
 }
 
 func (m IntentsMatcher) Got(got interface{}) string {
-	actual, ok := got.([]cloudclient.IntentInput)
+	actual, ok := got.([]*cloudclient.DiscoveredIntentInput)
 	if !ok {
-		return fmt.Sprintf("Not an []cloudclient.IntentInput, Got: %v", got)
+		return fmt.Sprintf("Not an []*cloudclient.DiscoveredIntentInput, Got: %v", got)
 	}
 
-	return prettyPrint(IntentsMatcher{actual})
+	return prettyPrint(IntentsMatcher{discoveredIntentsPtrToIntents(actual)})
 }
 
 func GetMatcher(expected []cloudclient.IntentInput) IntentsMatcher {


### PR DESCRIPTION
This PR update the report discovered intents implementation to the new API with the discovery time, but without sending the actual discovery value, just to be aligned with the new API.