### PR TITLE
Send component status on start up

### DIFF
--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -91,6 +91,8 @@ func (c *CloudUploader) PeriodicIntentsUpload(ctx context.Context) {
 	cloudUploadTicker := time.NewTicker(time.Second * time.Duration(c.config.UploadInterval))
 
 	logrus.Info("Starting cloud ticker")
+	c.reportStatus(ctx)
+
 	for {
 		select {
 		case <-cloudUploadTicker.C:


### PR DESCRIPTION
Until this PR component status was sent only when interval time was done, this PR fix it to send connection status right when application is up.