### PR TITLE
Using shared cloud client from intents-operator

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.1
 	github.com/vektah/gqlparser/v2 v2.4.5
-	golang.org/x/oauth2 v0.4.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
@@ -86,6 +85,7 @@ require (
 	golang.org/x/exp v0.0.0-20221012211006-4de253d81b95 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
+	golang.org/x/oauth2 v0.4.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/term v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect

--- a/src/mapper/pkg/clouduploader/cloud_config.go
+++ b/src/mapper/pkg/clouduploader/cloud_config.go
@@ -6,21 +6,11 @@ import (
 )
 
 type Config struct {
-	ClientId       string
-	Secret         string
-	apiAddress     string
 	UploadInterval int
 }
 
 func ConfigFromViper() Config {
 	return Config{
-		Secret:         viper.GetString(config.ClientSecretKey),
-		ClientId:       viper.GetString(config.ClientIDKey),
-		apiAddress:     viper.GetString(config.CloudApiAddrKey),
 		UploadInterval: viper.GetInt(config.UploadIntervalSecondsKey),
 	}
-}
-
-func (c *Config) IsCloudUploadEnabled() bool {
-	return c.ClientId != "" && c.Secret != ""
 }

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -2,46 +2,30 @@ package clouduploader
 
 import (
 	"context"
-	"fmt"
 	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
 	"github.com/otterize/network-mapper/src/mapper/pkg/resolvers"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/clientcredentials"
 	"time"
 )
 
 type CloudUploader struct {
 	intentsHolder       *resolvers.IntentsHolder
 	config              Config
-	tokenSrc            oauth2.TokenSource
 	lastUploadTimestamp time.Time
-	cloudClientFactory  cloudclient.FactoryFunction
+	client              cloudclient.CloudClient
 }
 
-func NewCloudUploader(intentsHolder *resolvers.IntentsHolder, config Config, cloudClientFactory cloudclient.FactoryFunction) *CloudUploader {
-	cfg := clientcredentials.Config{
-		ClientID:     config.ClientId,
-		ClientSecret: config.Secret,
-		TokenURL:     fmt.Sprintf("%s/auth/tokens/token", config.apiAddress),
-		AuthStyle:    oauth2.AuthStyleInParams,
-	}
-
-	tokenSrc := cfg.TokenSource(context.Background())
-
+func NewCloudUploader(intentsHolder *resolvers.IntentsHolder, config Config, client cloudclient.CloudClient) *CloudUploader {
 	return &CloudUploader{
-		intentsHolder:      intentsHolder,
-		config:             config,
-		tokenSrc:           tokenSrc,
-		cloudClientFactory: cloudClientFactory,
+		intentsHolder: intentsHolder,
+		config:        config,
+		client:        client,
 	}
 }
 
 func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 	logrus.Info("Search for intents")
-
-	client := c.cloudClientFactory(ctx, c.config.apiAddress, c.tokenSrc)
 
 	lastUpdate := c.intentsHolder.LastIntentsUpdate()
 	if !c.lastUploadTimestamp.Before(lastUpdate) {
@@ -68,16 +52,14 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 		return
 	}
 
-	uploadSuccess := client.ReportDiscoveredIntents(discoveredIntents)
+	uploadSuccess := c.client.ReportDiscoveredIntents(discoveredIntents)
 	if uploadSuccess {
 		c.lastUploadTimestamp = lastUpdate
 	}
 }
 
 func (c *CloudUploader) reportStatus(ctx context.Context) {
-	client := c.cloudClientFactory(ctx, c.config.apiAddress, c.tokenSrc)
-
-	client.ReportComponentStatus(cloudclient.ComponentTypeNetworkMapper)
+	c.client.ReportComponentStatus(cloudclient.ComponentTypeNetworkMapper)
 }
 
 func (c *CloudUploader) PeriodicIntentsUpload(ctx context.Context) {

--- a/src/mapper/pkg/kubefinder/kubefinder.go
+++ b/src/mapper/pkg/kubefinder/kubefinder.go
@@ -23,7 +23,7 @@ type KubeFinder struct {
 	serviceIdResolver *serviceidresolver.Resolver
 }
 
-var FoundMoreThanOnePodError = fmt.Errorf("ip belongs to more than one pod")
+var ErrFoundMoreThanOnePod = fmt.Errorf("ip belongs to more than one pod")
 
 func NewKubeFinder(mgr manager.Manager) (*KubeFinder, error) {
 	indexer := &KubeFinder{client: mgr.GetClient(), mgr: mgr, serviceIdResolver: serviceidresolver.NewResolver(mgr.GetClient())}
@@ -58,7 +58,7 @@ func (k *KubeFinder) ResolveIpToPod(ctx context.Context, ip string) (*coreV1.Pod
 	if len(pods.Items) == 0 {
 		return nil, fmt.Errorf("pod with ip %s was not found", ip)
 	} else if len(pods.Items) > 1 {
-		return nil, FoundMoreThanOnePodError
+		return nil, ErrFoundMoreThanOnePod
 	}
 	return &pods.Items[0], nil
 }

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -27,7 +27,7 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 	for _, captureItem := range results.Results {
 		srcPod, err := r.kubeFinder.ResolveIpToPod(ctx, captureItem.SrcIP)
 		if err != nil {
-			if errors.Is(err, kubefinder.FoundMoreThanOnePodError) {
+			if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
 				logrus.WithError(err).Debugf("Ip %s belongs to more than one pod, ignoring", captureItem.SrcIP)
 			} else {
 				logrus.WithError(err).Debugf("Could not resolve %s to pod", captureItem.SrcIP)
@@ -56,7 +56,7 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 			}
 			destPod, err := r.kubeFinder.ResolveIpToPod(ctx, ips[0])
 			if err != nil {
-				if errors.Is(err, kubefinder.FoundMoreThanOnePodError) {
+				if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
 					logrus.WithError(err).Debugf("Ip %s belongs to more than one pod, ignoring", ips[0])
 				} else {
 					logrus.WithError(err).Debugf("Could not resolve %s to pod", ips[0])
@@ -86,7 +86,7 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 	for _, socketScanItem := range results.Results {
 		srcPod, err := r.kubeFinder.ResolveIpToPod(ctx, socketScanItem.SrcIP)
 		if err != nil {
-			if errors.Is(err, kubefinder.FoundMoreThanOnePodError) {
+			if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
 				logrus.WithError(err).Debugf("Ip %s belongs to more than one pod, ignoring", socketScanItem.SrcIP)
 			} else {
 				logrus.WithError(err).Debugf("Could not resolve %s to pod", socketScanItem.SrcIP)
@@ -101,7 +101,7 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 		for _, destIp := range socketScanItem.DestIps {
 			destPod, err := r.kubeFinder.ResolveIpToPod(ctx, destIp.Destination)
 			if err != nil {
-				if errors.Is(err, kubefinder.FoundMoreThanOnePodError) {
+				if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
 					logrus.WithError(err).Debugf("Ip %s belongs to more than one pod, ignoring", destIp)
 				} else {
 					logrus.WithError(err).Debugf("Could not resolve %s to pod", destIp)


### PR DESCRIPTION
This PR makes the network mapper use the shared cloud client from the intents-operator
Also fixes a small linter error

https://www.notion.so/otterize/Replace-mapper-cloud-client-with-shared-client-in-intents-operator-1ab83f28d41b40078506d041a4ef729e