### PR TITLE
Only send new intents each time

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.10
 	github.com/Khan/genqlient v0.5.0
 	github.com/amit7itz/goset v1.2.1
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/golang/mock v1.6.0
 	github.com/google/gopacket v1.1.19
 	github.com/labstack/echo/v4 v4.9.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -72,6 +72,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -8,12 +8,11 @@ import (
 )
 
 type CloudClient interface {
-	ReportDiscoveredIntents(intents []*DiscoveredIntentInput) bool
-	ReportComponentStatus(component ComponentType)
+	ReportDiscoveredIntents(ctx context.Context, intents []*DiscoveredIntentInput) error
+	ReportComponentStatus(ctx context.Context, component ComponentType) error
 }
 
 type CloudClientImpl struct {
-	ctx    context.Context
 	client graphql.Client
 }
 
@@ -28,23 +27,23 @@ func NewClient(ctx context.Context) (CloudClient, bool, error) {
 	return &CloudClientImpl{client: client}, true, nil
 }
 
-func (c *CloudClientImpl) ReportDiscoveredIntents(intents []*DiscoveredIntentInput) bool {
+func (c *CloudClientImpl) ReportDiscoveredIntents(ctx context.Context, intents []*DiscoveredIntentInput) error {
 	logrus.Info("Uploading intents to cloud, count: ", len(intents))
 
-	_, err := ReportDiscoveredIntents(c.ctx, c.client, intents)
+	_, err := ReportDiscoveredIntents(ctx, c.client, intents)
 	if err != nil {
-		logrus.Error("Failed to upload intents to cloud ", err)
-		return false
+		return err
 	}
 
-	return true
+	return nil
 }
 
-func (c *CloudClientImpl) ReportComponentStatus(component ComponentType) {
-	logrus.Info("Uploading component to cloud")
+func (c *CloudClientImpl) ReportComponentStatus(ctx context.Context, component ComponentType) error {
+	logrus.Info("Uploading component status to cloud")
 
-	_, err := ReportComponentStatus(c.ctx, c.client, component)
+	_, err := ReportComponentStatus(ctx, c.client, component)
 	if err != nil {
-		logrus.Error("Failed to upload component to cloud ", err)
+		return err
 	}
+	return nil
 }

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -5,6 +5,7 @@
 package cloudclientmocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,27 +36,29 @@ func (m *MockCloudClient) EXPECT() *MockCloudClientMockRecorder {
 }
 
 // ReportComponentStatus mocks base method.
-func (m *MockCloudClient) ReportComponentStatus(component cloudclient.ComponentType) {
+func (m *MockCloudClient) ReportComponentStatus(ctx context.Context, component cloudclient.ComponentType) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReportComponentStatus", component)
+	ret := m.ctrl.Call(m, "ReportComponentStatus", ctx, component)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ReportComponentStatus indicates an expected call of ReportComponentStatus.
-func (mr *MockCloudClientMockRecorder) ReportComponentStatus(component interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ReportComponentStatus(ctx, component interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportComponentStatus", reflect.TypeOf((*MockCloudClient)(nil).ReportComponentStatus), component)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportComponentStatus", reflect.TypeOf((*MockCloudClient)(nil).ReportComponentStatus), ctx, component)
 }
 
 // ReportDiscoveredIntents mocks base method.
-func (m *MockCloudClient) ReportDiscoveredIntents(intents []*cloudclient.DiscoveredIntentInput) bool {
+func (m *MockCloudClient) ReportDiscoveredIntents(ctx context.Context, intents []*cloudclient.DiscoveredIntentInput) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportDiscoveredIntents", intents)
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "ReportDiscoveredIntents", ctx, intents)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReportDiscoveredIntents indicates an expected call of ReportDiscoveredIntents.
-func (mr *MockCloudClientMockRecorder) ReportDiscoveredIntents(intents interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ReportDiscoveredIntents(ctx, intents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredIntents), intents)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredIntents), ctx, intents)
 }

--- a/src/mapper/pkg/clouduploader/cloud_config.go
+++ b/src/mapper/pkg/clouduploader/cloud_config.go
@@ -3,14 +3,15 @@ package clouduploader
 import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/config"
 	"github.com/spf13/viper"
+	"time"
 )
 
 type Config struct {
-	UploadInterval int
+	UploadInterval time.Duration
 }
 
 func ConfigFromViper() Config {
 	return Config{
-		UploadInterval: viper.GetInt(config.UploadIntervalSecondsKey),
+		UploadInterval: time.Duration(viper.GetInt(config.UploadIntervalSecondsKey)) * time.Second,
 	}
 }

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -55,7 +55,7 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 			logrus.WithError(err).Error("Failed to report discovered intents to cloud, retrying")
 		}
 		return err
-	}, backoff.WithMaxRetries(exponentialBackoff, 10))
+	}, exponentialBackoff)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to report discovered intents to cloud, giving up after 10 retries")
 	}

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -2,6 +2,7 @@ package clouduploader
 
 import (
 	"context"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
 	"github.com/otterize/network-mapper/src/mapper/pkg/resolvers"
 	"github.com/samber/lo"
@@ -10,10 +11,9 @@ import (
 )
 
 type CloudUploader struct {
-	intentsHolder       *resolvers.IntentsHolder
-	config              Config
-	lastUploadTimestamp time.Time
-	client              cloudclient.CloudClient
+	intentsHolder *resolvers.IntentsHolder
+	config        Config
+	client        cloudclient.CloudClient
 }
 
 func NewCloudUploader(intentsHolder *resolvers.IntentsHolder, config Config, client cloudclient.CloudClient) *CloudUploader {
@@ -27,13 +27,8 @@ func NewCloudUploader(intentsHolder *resolvers.IntentsHolder, config Config, cli
 func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 	logrus.Info("Search for intents")
 
-	lastUpdate := c.intentsHolder.LastIntentsUpdate()
-	if !c.lastUploadTimestamp.Before(lastUpdate) {
-		return
-	}
-
 	var discoveredIntents []*cloudclient.DiscoveredIntentInput
-	for _, intent := range c.intentsHolder.GetIntents(nil) {
+	for _, intent := range c.intentsHolder.GetNewIntentsSinceLastGet() {
 		var discoveredIntent cloudclient.IntentInput
 		discoveredIntent.ClientName = lo.ToPtr(intent.Source.Name)
 		discoveredIntent.Namespace = lo.ToPtr(intent.Source.Namespace)
@@ -52,30 +47,51 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 		return
 	}
 
-	uploadSuccess := c.client.ReportDiscoveredIntents(discoveredIntents)
-	if uploadSuccess {
-		c.lastUploadTimestamp = lastUpdate
+	exponentialBackoff := backoff.NewExponentialBackOff()
+
+	err := backoff.Retry(func() error {
+		err := c.client.ReportDiscoveredIntents(ctx, discoveredIntents)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to report discovered intents to cloud, retrying")
+		}
+		return err
+	}, backoff.WithMaxRetries(exponentialBackoff, 10))
+	if err != nil {
+		logrus.WithError(err).Error("Failed to report discovered intents to cloud, giving up after 10 retries")
 	}
 }
 
 func (c *CloudUploader) reportStatus(ctx context.Context) {
-	c.client.ReportComponentStatus(cloudclient.ComponentTypeNetworkMapper)
+	err := c.client.ReportComponentStatus(ctx, cloudclient.ComponentTypeNetworkMapper)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to report component status to cloud")
+	}
 }
 
 func (c *CloudUploader) PeriodicIntentsUpload(ctx context.Context) {
-	cloudUploadTicker := time.NewTicker(time.Second * time.Duration(c.config.UploadInterval))
+	logrus.Info("Starting periodic intents upload")
 
-	logrus.Info("Starting cloud ticker")
+	for {
+		select {
+		case <-time.After(c.config.UploadInterval):
+			c.uploadDiscoveredIntents(ctx)
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *CloudUploader) PeriodicStatusReport(ctx context.Context) {
+	logrus.Info("Starting status reporting")
 	c.reportStatus(ctx)
 
 	for {
 		select {
-		case <-cloudUploadTicker.C:
-			c.uploadDiscoveredIntents(ctx)
+		case <-time.After(c.config.UploadInterval):
 			c.reportStatus(ctx)
 
 		case <-ctx.Done():
-			logrus.Info("Periodic upload exit")
 			return
 		}
 	}

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -2,6 +2,7 @@ package clouduploader
 
 import (
 	"context"
+	"errors"
 	"github.com/golang/mock/gomock"
 	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
 	cloudclientmocks "github.com/otterize/network-mapper/src/mapper/pkg/cloudclient/mocks"
@@ -70,7 +71,7 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 		intentInput("client1", s.testNamespace, "server2", "external-namespace"),
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents1)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents1)).Return(nil).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 
@@ -78,17 +79,15 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 
 	intents2 := []cloudclient.IntentInput{
 		intentInput("client2", s.testNamespace, "server1", s.testNamespace),
-		intentInput("client1", s.testNamespace, "server1", s.testNamespace),
-		intentInput("client1", s.testNamespace, "server2", "external-namespace"),
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents2)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents2)).Return(nil).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
 
 func (s *CloudUploaderTestSuite) TestDontUploadWithoutIntents() {
-	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any()).Times(0)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), gomock.Any()).Times(0)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
@@ -100,7 +99,7 @@ func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
 		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents)).Return(nil).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.addIntent("client", s.testNamespace, "server", s.testNamespace)
@@ -114,11 +113,10 @@ func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
 		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents)).Return(false).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents)).Return(errors.New("fail")).Times(1)
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents)).Return(nil).Times(1)
 
-	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
 
@@ -129,14 +127,14 @@ func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
 		intentInput("client", s.testNamespace, "server", s.testNamespace),
 	}
 
-	s.clientMock.EXPECT().ReportDiscoveredIntents(GetMatcher(intents)).Return(true).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents)).Return(nil).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
 }
 
 func (s *CloudUploaderTestSuite) TestReportMapperComponent() {
-	s.clientMock.EXPECT().ReportComponentStatus(cloudclient.ComponentTypeNetworkMapper).Times(1)
+	s.clientMock.EXPECT().ReportComponentStatus(gomock.Any(), cloudclient.ComponentTypeNetworkMapper).Times(1)
 
 	s.cloudUploader.reportStatus(context.Background())
 }

--- a/src/mapper/pkg/resolvers/resolver.go
+++ b/src/mapper/pkg/resolvers/resolver.go
@@ -1,13 +1,11 @@
 package resolvers
 
 import (
-	"context"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/generated"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
-	"github.com/sirupsen/logrus"
 )
 
 // This file will not be regenerated automatically.
@@ -35,14 +33,4 @@ func (r *Resolver) Register(e *echo.Echo) {
 		srv.ServeHTTP(c.Response(), c.Request())
 		return nil
 	})
-}
-
-func (r *Resolver) LoadStore(ctx context.Context) error {
-	err := r.intentsHolder.LoadStore(ctx)
-	if err != nil {
-		logrus.WithError(err).Warning("Failed to load state from previous runs")
-		return err
-	}
-
-	return nil
 }

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -166,56 +166,6 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 	})
 }
 
-func (s *ResolverTestSuite) TestLoadStore() {
-	res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
-	s.Require().NoError(err)
-	s.Require().Len(res.ServiceIntents, 0)
-
-	s.AddDeploymentWithService("service1", []string{"1.1.3.1"}, map[string]string{"app": "service1"})
-	s.AddDeploymentWithService("service2", []string{"1.1.3.2"}, map[string]string{"app": "service2"})
-	s.AddDeploymentWithService("service3", []string{"1.1.3.3"}, map[string]string{"app": "service3"})
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
-	_, err = test_gql_client.ReportSocketScanResults(context.Background(), s.client, test_gql_client.SocketScanResults{
-		Results: []test_gql_client.SocketScanResultForSrcIp{
-			{
-				SrcIp: "1.1.3.1",
-				DestIps: []test_gql_client.Destination{
-					{
-						Destination: "1.1.3.2",
-					},
-				},
-			},
-			{
-				SrcIp: "1.1.3.3",
-				DestIps: []test_gql_client.Destination{
-					{
-						Destination: "1.1.3.2",
-					},
-					{
-						Destination: "1.1.3.2",
-					},
-				},
-			},
-		},
-	})
-	s.Require().NoError(err)
-	res, err = test_gql_client.ServiceIntents(context.Background(), s.client, nil)
-	s.Require().NoError(err)
-	s.Require().Len(res.ServiceIntents, 2)
-
-	// create a new resolver and see LoadStore works
-	resolver := NewResolver(s.kubeFinder, serviceidresolver.NewResolver(s.Mgr.GetClient()), NewIntentsHolder(s.Mgr.GetClient(), IntentsHolderConfig{StoreConfigMap: config.StoreConfigMapDefault, Namespace: s.TestNamespace}))
-	intents, err := resolver.Query().ServiceIntents(context.Background(), nil)
-	s.Require().NoError(err)
-	s.Require().Len(intents, 0)
-
-	err = resolver.LoadStore(context.Background())
-	s.Require().NoError(err)
-	intents, err = resolver.Query().ServiceIntents(context.Background(), nil)
-	s.Require().NoError(err)
-	s.Require().Len(intents, 2)
-}
-
 func TestRunSuite(t *testing.T) {
 	suite.Run(t, new(ResolverTestSuite))
 }

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -75,10 +75,6 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 			)
 		}
 	}
-	err := r.intentsHolder.WriteStore(ctx)
-	if err != nil {
-		logrus.WithError(err).Warning("Failed to save state into the store file")
-	}
 	return true, nil
 }
 
@@ -119,10 +115,6 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 				destIp.LastSeen,
 			)
 		}
-	}
-	err := r.intentsHolder.WriteStore(ctx)
-	if err != nil {
-		logrus.WithError(err).Warning("Failed to save state into the store file")
 	}
 	return true, nil
 }


### PR DESCRIPTION
Previously, the network mapper would send to cloud the intents every time a new or existing intent was seen.
Now, it will only send the updated intents.

Also removed the persistency feature, at least temporarily, to simplify this change. The primary motivation behind the persistency feature was to simplify sending intents to the cloud.