### PR TITLE
Fix for issue #78 - Fix missing pod owner info

### DIFF
--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -86,15 +86,20 @@ type CertificateInformation {
 	ttl: Int
 }
 
+type Client {
+	id: ID!
+	secret: String!
+}
+
 type Cluster {
 	id: ID!
-	integration: Integration
-	defaultEnvironment: Environment
 	name: String!
-	components: IntegrationComponents!
 	configuration: ClusterConfiguration
 	namespaces: [Namespace!]!
 	serviceCount: Int!
+	integration: Integration
+	defaultEnvironment: Environment
+	components: IntegrationComponents!
 }
 
 type ClusterConfiguration {
@@ -170,11 +175,11 @@ enum EdgeAccessStatusVerdict {
 
 type Environment {
 	id: ID!
-	appliedIntentsCount: Int!
 	name: String!
 	labels: [Label!]
 	namespaces: [Namespace!]!
 	serviceCount: Int!
+	appliedIntentsCount: Int!
 }
 
 type HTTPConfig {
@@ -218,7 +223,6 @@ type Integration {
 }
 
 type IntegrationComponents {
-	clusterId: ID!
 	intentsOperator: IntentsOperatorComponent!
 	credentialsOperator: CredentialsOperatorComponent!
 	networkMapper: NetworkMapperComponent!
@@ -385,6 +389,26 @@ type MeMutation {
 type Mutation {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
+"""Create client"""
+	createClient: Client!
+"""Delete client"""
+	deleteClient(
+		id: ID!
+	): ID!
+"""Create user invite"""
+	createInvite(
+		email: String!
+	): Invite!
+"""Delete user invite"""
+	deleteInvite(
+		id: ID!
+	): ID!
+"""Accept user invite"""
+	acceptInvite(
+		id: ID!
+	): Invite!
+"""Operate on the current logged-in user"""
+	me: MeMutation!
 """Create a new organization"""
 	createOrganization: Organization!
 """Update organization"""
@@ -398,23 +422,57 @@ type Mutation {
 		id: ID!
 		userId: ID!
 	): ID!
-"""Operate on the current logged-in user"""
-	me: MeMutation!
-"""Create user invite"""
-	createInvite(
-		email: String!
-	): Invite!
-"""Delete user invite"""
-	deleteInvite(
+	initializeOrganizationCAs(
+		organizationId: ID!
+	): Boolean!
+"""Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
+	registerKubernetesPodOwnerCertificateRequest(
+		podOwner: NamespacedPodOwner!
+		certificateCustomization: CertificateCustomization
+	): Service!
+"""Report active pod owners to the cloud, as a result the cloud removes certificate requests of inactive pod owners """
+	reportActiveCertificateRequesters(
+		activePodOwners: [NamespacedPodOwner!]!
+	): Boolean!
+"""Create cluster"""
+	createCluster(
+		name: String!
+	): Cluster!
+"""Delete cluster"""
+	deleteCluster(
 		id: ID!
 	): ID!
-"""Accept user invite"""
-	acceptInvite(
+"""Update cluster"""
+	updateCluster(
 		id: ID!
-	): Invite!
-	reportIntentsOperatorConfiguration(
-		configuration: IntentsOperatorConfigurationInput!
-	): Boolean!
+		name: String
+		configuration: ClusterConfigurationInput
+	): Cluster!
+"""Create a new environment"""
+	createEnvironment(
+		name: String!
+		labels: [LabelInput!]
+	): Environment!
+"""Update environment"""
+	updateEnvironment(
+		id: ID!
+		name: String
+		labels: [LabelInput!]
+	): Environment!
+"""Delete environment"""
+	deleteEnvironment(
+		id: ID!
+	): ID!
+"""Add label to environment"""
+	addEnvironmentLabel(
+		id: ID!
+		label: LabelInput!
+	): Environment!
+"""Remove label from environment"""
+	deleteEnvironmentLabel(
+		id: ID!
+		key: String!
+	): Environment!
 """Create a new generic integration"""
 	createGenericIntegration(
 		name: String!
@@ -442,8 +500,8 @@ type Mutation {
 	reportIntegrationComponentStatus(
 		component: ComponentType!
 	): Boolean!
-	initializeOrganizationCAs(
-		organizationId: ID!
+	reportIntentsOperatorConfiguration(
+		configuration: IntentsOperatorConfigurationInput!
 	): Boolean!
 	reportDiscoveredIntents(
 		intents: [DiscoveredIntentInput!]!
@@ -456,58 +514,11 @@ type Mutation {
 		namespace: String!
 		serverConfigs: [KafkaServerConfigInput!]!
 	): Boolean!
-"""Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
-	registerKubernetesPodOwnerCertificateRequest(
-		podOwner: NamespacedPodOwner!
-		certificateCustomization: CertificateCustomization
-	): Service!
-"""Report active pod owners to the cloud, as a result the cloud removes certificate requests of inactive pod owners """
-	reportActiveCertificateRequesters(
-		activePodOwners: [NamespacedPodOwner!]!
-	): Boolean!
-"""Create a new environment"""
-	createEnvironment(
-		name: String!
-		labels: [LabelInput!]
-	): Environment!
-"""Update environment"""
-	updateEnvironment(
-		id: ID!
-		name: String
-		labels: [LabelInput!]
-	): Environment!
-"""Delete environment"""
-	deleteEnvironment(
-		id: ID!
-	): ID!
-"""Add label to environment"""
-	addEnvironmentLabel(
-		id: ID!
-		label: LabelInput!
-	): Environment!
-"""Remove label from environment"""
-	deleteEnvironmentLabel(
-		id: ID!
-		key: String!
-	): Environment!
 """Associate namespace to environment"""
 	associateNamespaceToEnv(
 		id: ID!
 		environmentId: ID
 	): Namespace!
-"""Create cluster"""
-	createCluster(
-		name: String!
-	): Cluster!
-"""Delete cluster"""
-	deleteCluster(
-		id: ID!
-	): ID!
-"""Update cluster"""
-	updateCluster(
-		id: ID!
-		configuration: ClusterConfigurationInput
-	): Cluster!
 }
 
 type Namespace {
@@ -538,20 +549,10 @@ type Organization {
 type Query {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
-"""List organizations"""
-	organizations: [Organization!]!
-"""Get organization"""
-	organization(
+"""Get client"""
+	client(
 		id: ID!
-	): Organization!
-"""List users"""
-	users: [User!]!
-"""Get user"""
-	user(
-		id: ID!
-	): User!
-"""Get information regarding the current logged-in user"""
-	me: Me!
+	): Client!
 """List user invites"""
 	invites(
 		email: String
@@ -566,6 +567,49 @@ type Query {
 		email: String
 		status: InviteStatus
 	): Invite!
+"""Get information regarding the current logged-in user"""
+	me: Me!
+"""List organizations"""
+	organizations: [Organization!]!
+"""Get organization"""
+	organization(
+		id: ID!
+	): Organization!
+"""List users"""
+	users: [User!]!
+"""Get user"""
+	user(
+		id: ID!
+	): User!
+"""Get access graph"""
+	accessGraph(
+		filter: InputAccessGraphFilter
+	): AccessGraph!
+"""Get cluster"""
+	cluster(
+		id: ID!
+	): Cluster!
+"""List clusters"""
+	clusters(
+		name: String
+	): [Cluster!]!
+"""Get cluster by filters"""
+	oneCluster(
+		name: String!
+	): Cluster
+"""Get environment"""
+	environment(
+		id: ID!
+	): Environment!
+"""List environments"""
+	environments(
+		name: String
+		labels: [LabelInput!]
+	): [Environment!]!
+"""Get environment by filters"""
+	oneEnvironment(
+		name: String!
+	): Environment!
 """List integrations"""
 	integrations(
 		name: String
@@ -594,39 +638,6 @@ type Query {
 		clientId: ID
 		serverId: ID
 	): [Intent!]!
-"""Get service"""
-	service(
-		id: ID!
-	): Service!
-"""List services"""
-	services(
-		environmentId: ID
-		namespaceId: ID
-		name: String
-	): [Service!]!
-"""Get service by filters"""
-	oneService(
-		environmentId: ID
-		namespaceId: ID
-		name: String
-	): Service
-"""Get access graph"""
-	accessGraph(
-		filter: InputAccessGraphFilter
-	): AccessGraph!
-"""Get environment"""
-	environment(
-		id: ID!
-	): Environment!
-"""List environments"""
-	environments(
-		name: String
-		labels: [LabelInput!]
-	): [Environment!]!
-"""Get environment by filters"""
-	oneEnvironment(
-		name: String!
-	): Environment!
 """Get namespace"""
 	namespace(
 		id: ID!
@@ -643,18 +654,22 @@ type Query {
 		clusterId: ID
 		name: String
 	): Namespace!
-"""Get cluster"""
-	cluster(
+"""Get service"""
+	service(
 		id: ID!
-	): Cluster!
-"""List clusters"""
-	clusters(
+	): Service!
+"""List services"""
+	services(
+		environmentId: ID
+		namespaceId: ID
 		name: String
-	): [Cluster!]!
-"""Get cluster by filters"""
-	oneCluster(
-		name: String!
-	): Cluster
+	): [Service!]!
+"""Get service by filters"""
+	oneService(
+		environmentId: ID
+		namespaceId: ID
+		name: String
+	): Service
 }
 
 type ServerBlockingStatus {
@@ -699,13 +714,13 @@ enum ServerProtectionStatusVerdict {
 
 type Service {
 	id: ID!
+	certificateInformation: CertificateInformation
 	tlsKeyPair: KeyPair!
 	name: String!
 	namespace: Namespace
 	environment: Environment!
 """If service is Kafka, its KafkaServerConfig."""
 	kafkaServerConfig: KafkaServerConfig
-	certificateInformation: CertificateInformation
 }
 
 type ServiceAccessGraph {

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -38,7 +38,8 @@ func (s *ResolverTestSuite) SetupTest() {
 func (s *ResolverTestSuite) TestReportCaptureResults() {
 	s.AddDeploymentWithService("service1", []string{"1.1.1.1"}, map[string]string{"app": "service1"})
 	s.AddDeploymentWithService("service2", []string{"1.1.1.2"}, map[string]string{"app": "service2"})
-	s.AddDeploymentWithService("service3", []string{"1.1.1.3"}, map[string]string{"app": "service3"})
+	s.AddDaemonSetWithService("service3", []string{"1.1.1.3"}, map[string]string{"app": "service3"})
+	s.AddPod("pod4", "1.1.1.4", nil, nil)
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	_, err := test_gql_client.ReportCaptureResults(context.Background(), s.client, test_gql_client.CaptureResults{
@@ -62,6 +63,14 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 					},
 				},
 			},
+			{
+				SrcIp: "1.1.1.4",
+				Destinations: []test_gql_client.Destination{
+					{
+						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),
+					},
+				},
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -92,7 +101,7 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 				Namespace: s.TestNamespace,
 				PodOwnerKind: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
 					Group:   "apps",
-					Kind:    "Deployment",
+					Kind:    "DaemonSet",
 					Version: "v1",
 				},
 			},
@@ -107,13 +116,31 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 				},
 			},
 		},
+		{
+			Client: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentity{
+				Name:      "pod4",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "",
+					Kind:    "Pod",
+					Version: "v1",
+				},
+			},
+			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
+				{
+					Name:      "service2",
+					Namespace: s.TestNamespace,
+				},
+			},
+		},
 	})
 }
 
 func (s *ResolverTestSuite) TestSocketScanResults() {
-	s.AddDeploymentWithService("service1", []string{"1.1.2.1"}, map[string]string{"app": "service1"})
+	s.AddDaemonSetWithService("service1", []string{"1.1.2.1"}, map[string]string{"app": "service1"})
 	s.AddDeploymentWithService("service2", []string{"1.1.2.2"}, map[string]string{"app": "service2"})
 	s.AddDeploymentWithService("service3", []string{"1.1.2.3"}, map[string]string{"app": "service3"})
+	s.AddPod("pod4", "1.1.2.4", nil, nil)
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	_, err := test_gql_client.ReportSocketScanResults(context.Background(), s.client, test_gql_client.SocketScanResults{
@@ -137,6 +164,14 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 					},
 				},
 			},
+			{
+				SrcIp: "1.1.2.4",
+				DestIps: []test_gql_client.Destination{
+					{
+						Destination: "1.1.2.2",
+					},
+				},
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -150,7 +185,7 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 				Namespace: s.TestNamespace,
 				PodOwnerKind: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
 					Group:   "apps",
-					Kind:    "Deployment",
+					Kind:    "DaemonSet",
 					Version: "v1",
 				},
 			},
@@ -176,6 +211,23 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 					Name:      "service1",
 					Namespace: s.TestNamespace,
 				},
+				{
+					Name:      "service2",
+					Namespace: s.TestNamespace,
+				},
+			},
+		},
+		{
+			Client: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentity{
+				Name:      "pod4",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "",
+					Kind:    "Pod",
+					Version: "v1",
+				},
+			},
+			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
 				{
 					Name:      "service2",
 					Namespace: s.TestNamespace,

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -73,6 +73,11 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 			Client: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentity{
 				Name:      "service1",
 				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
 			},
 			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
 				{
@@ -85,6 +90,11 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 			Client: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentity{
 				Name:      "service3",
 				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
 			},
 			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
 				{
@@ -138,6 +148,11 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 			Client: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentity{
 				Name:      "service1",
 				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
 			},
 			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
 				{
@@ -150,6 +165,11 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 			Client: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentity{
 				Name:      "service3",
 				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
 			},
 			Intents: []test_gql_client.ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity{
 				{

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -121,9 +121,20 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 				logrus.WithError(err).Debugf("Could not resolve pod %s to identity", destPod.Name)
 				continue
 			}
+
+			srcSvcIdentity := model.OtterizeServiceIdentity{Name: srcService.Name, Namespace: srcPod.Namespace, Labels: podLabelsToOtterizeLabels(srcPod)}
+			dstSvcIdentity := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: destPod.Namespace, Labels: podLabelsToOtterizeLabels(destPod)}
+			if srcService.OwnerObject != nil {
+				srcSvcIdentity.PodOwnerKind = model.GroupVersionKindFromKubeGVK(srcService.OwnerObject.GetObjectKind().GroupVersionKind())
+			}
+
+			if dstService.OwnerObject != nil {
+				dstSvcIdentity.PodOwnerKind = model.GroupVersionKindFromKubeGVK(dstService.OwnerObject.GetObjectKind().GroupVersionKind())
+			}
+
 			r.intentsHolder.AddIntent(
-				model.OtterizeServiceIdentity{Name: srcService.Name, Namespace: srcPod.Namespace, Labels: podLabelsToOtterizeLabels(srcPod)},
-				model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: destPod.Namespace, Labels: podLabelsToOtterizeLabels(destPod)},
+				srcSvcIdentity,
+				dstSvcIdentity,
 				destIp.LastSeen,
 			)
 		}

--- a/src/mapper/pkg/resolvers/test_gql_client/generated.go
+++ b/src/mapper/pkg/resolvers/test_gql_client/generated.go
@@ -58,6 +58,9 @@ func (v *ReportSocketScanResultsResponse) GetReportSocketScanResults() bool {
 
 // ServiceIntentsResponse is returned by ServiceIntents on success.
 type ServiceIntentsResponse struct {
+	// namespaces: Namespaces filter.
+	// includeLabels: Labels to include in the response. Ignored if includeAllLabels is specified.
+	// includeAllLabels: Return all labels for the pod in the response.
 	ServiceIntents []ServiceIntentsServiceIntents `json:"serviceIntents"`
 }
 
@@ -86,6 +89,8 @@ func (v *ServiceIntentsServiceIntents) GetIntents() []ServiceIntentsServiceInten
 type ServiceIntentsServiceIntentsClientOtterizeServiceIdentity struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
+	// If the service identity was resolved from a pod owner, the GroupVersionKind of the pod owner.
+	PodOwnerKind ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind `json:"podOwnerKind"`
 }
 
 // GetName returns ServiceIntentsServiceIntentsClientOtterizeServiceIdentity.Name, and is useful for accessing the field via an interface.
@@ -94,6 +99,33 @@ func (v *ServiceIntentsServiceIntentsClientOtterizeServiceIdentity) GetName() st
 // GetNamespace returns ServiceIntentsServiceIntentsClientOtterizeServiceIdentity.Namespace, and is useful for accessing the field via an interface.
 func (v *ServiceIntentsServiceIntentsClientOtterizeServiceIdentity) GetNamespace() string {
 	return v.Namespace
+}
+
+// GetPodOwnerKind returns ServiceIntentsServiceIntentsClientOtterizeServiceIdentity.PodOwnerKind, and is useful for accessing the field via an interface.
+func (v *ServiceIntentsServiceIntentsClientOtterizeServiceIdentity) GetPodOwnerKind() ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind {
+	return v.PodOwnerKind
+}
+
+// ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind includes the requested fields of the GraphQL type GroupVersionKind.
+type ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind struct {
+	Group   string `json:"group"`
+	Kind    string `json:"kind"`
+	Version string `json:"version"`
+}
+
+// GetGroup returns ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Group, and is useful for accessing the field via an interface.
+func (v *ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetGroup() string {
+	return v.Group
+}
+
+// GetKind returns ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Kind, and is useful for accessing the field via an interface.
+func (v *ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetKind() string {
+	return v.Kind
+}
+
+// GetVersion returns ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Version, and is useful for accessing the field via an interface.
+func (v *ServiceIntentsServiceIntentsClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetVersion() string {
+	return v.Version
 }
 
 // ServiceIntentsServiceIntentsIntentsOtterizeServiceIdentity includes the requested fields of the GraphQL type OtterizeServiceIdentity.
@@ -225,6 +257,11 @@ query ServiceIntents ($namespaces: [String!]) {
 		client {
 			name
 			namespace
+			podOwnerKind {
+				group
+				kind
+				version
+			}
 		}
 		intents {
 			name

--- a/src/mapper/pkg/resolvers/test_gql_client/genqlient.graphql
+++ b/src/mapper/pkg/resolvers/test_gql_client/genqlient.graphql
@@ -3,6 +3,11 @@ query ServiceIntents($namespaces: [String!]) {
         client {
             name
             namespace
+            podOwnerKind {
+                group
+                kind
+                version
+            }
         }
         intents {
             name


### PR DESCRIPTION
As reported in issue https://github.com/otterize/network-mapper/issues/78, a bug caused the PodOwnerKind to return empty. The bug happened on services&intents discovered by the socket scan mechanism, due to a missing check of the pod owner. 
This PR fixes this issue and adds more checks to the tests to ensure it doesn't happen again.

Closes #78 