### PR TITLE
GraphQL conversion bug fix and aggregation changes

### DIFF
--- a/src/exp/istio-watcher/mapperclient/generated.go
+++ b/src/exp/istio-watcher/mapperclient/generated.go
@@ -9,13 +9,28 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+type HttpMethod string
+
+const (
+	HttpMethodGet     HttpMethod = "GET"
+	HttpMethodPost    HttpMethod = "POST"
+	HttpMethodPut     HttpMethod = "PUT"
+	HttpMethodDelete  HttpMethod = "DELETE"
+	HttpMethodOptions HttpMethod = "OPTIONS"
+	HttpMethodTrace   HttpMethod = "TRACE"
+	HttpMethodPatch   HttpMethod = "PATCH"
+	HttpMethodConnect HttpMethod = "CONNECT"
+	HttpMethodAll     HttpMethod = "ALL"
+)
+
 type IstioConnection struct {
-	SrcWorkload          string    `json:"srcWorkload"`
-	SrcWorkloadNamespace string    `json:"srcWorkloadNamespace"`
-	DstWorkload          string    `json:"dstWorkload"`
-	DstWorkloadNamespace string    `json:"dstWorkloadNamespace"`
-	RequestPaths         []string  `json:"requestPaths"`
-	LastSeen             time.Time `json:"lastSeen"`
+	SrcWorkload          string       `json:"srcWorkload"`
+	SrcWorkloadNamespace string       `json:"srcWorkloadNamespace"`
+	DstWorkload          string       `json:"dstWorkload"`
+	DstWorkloadNamespace string       `json:"dstWorkloadNamespace"`
+	Path                 string       `json:"path"`
+	Methods              []HttpMethod `json:"methods"`
+	LastSeen             time.Time    `json:"lastSeen"`
 }
 
 // GetSrcWorkload returns IstioConnection.SrcWorkload, and is useful for accessing the field via an interface.
@@ -30,8 +45,11 @@ func (v *IstioConnection) GetDstWorkload() string { return v.DstWorkload }
 // GetDstWorkloadNamespace returns IstioConnection.DstWorkloadNamespace, and is useful for accessing the field via an interface.
 func (v *IstioConnection) GetDstWorkloadNamespace() string { return v.DstWorkloadNamespace }
 
-// GetRequestPaths returns IstioConnection.RequestPaths, and is useful for accessing the field via an interface.
-func (v *IstioConnection) GetRequestPaths() []string { return v.RequestPaths }
+// GetPath returns IstioConnection.Path, and is useful for accessing the field via an interface.
+func (v *IstioConnection) GetPath() string { return v.Path }
+
+// GetMethods returns IstioConnection.Methods, and is useful for accessing the field via an interface.
+func (v *IstioConnection) GetMethods() []HttpMethod { return v.Methods }
 
 // GetLastSeen returns IstioConnection.LastSeen, and is useful for accessing the field via an interface.
 func (v *IstioConnection) GetLastSeen() time.Time { return v.LastSeen }

--- a/src/exp/istio-watcher/pkg/watcher/helpers.go
+++ b/src/exp/istio-watcher/pkg/watcher/helpers.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/otterize/network-mapper/src/exp/istio-watcher/mapperclient"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 	"time"
 )
 
@@ -19,17 +18,14 @@ func ToGraphQLIstioConnections(connections map[ConnectionWithPath]time.Time) []m
 				SrcWorkloadNamespace: connWithPath.SourceNamespace,
 				DstWorkload:          connWithPath.DestinationWorkload,
 				DstWorkloadNamespace: connWithPath.DestinationNamespace,
-				RequestPaths:         []string{connWithPath.RequestPath},
+				Path:                 connWithPath.RequestPath,
+				Methods:              []mapperclient.HttpMethod{mapperclient.HttpMethodAll},
 				LastSeen:             timestamp,
 			}
 			continue
 		}
 		if timestamp.After(istioConnection.LastSeen) {
 			istioConnection.LastSeen = timestamp
-		}
-		
-		if !slices.Contains(istioConnection.RequestPaths, connWithPath.RequestPath) {
-			istioConnection.RequestPaths = append(istioConnection.RequestPaths, connWithPath.RequestPath)
 		}
 
 		connectionPairToConn[connectionPair] = istioConnection

--- a/src/exp/istio-watcher/pkg/watcher/helpers.go
+++ b/src/exp/istio-watcher/pkg/watcher/helpers.go
@@ -24,15 +24,14 @@ func ToGraphQLIstioConnections(connections map[ConnectionWithPath]time.Time) []m
 			}
 			continue
 		}
-		if slices.Contains(istioConnection.RequestPaths, connWithPath.RequestPath) {
-			continue
-		}
-		// Reassign connection to map with newly appended request path
-		istioConnection.RequestPaths = append(istioConnection.RequestPaths, connWithPath.RequestPath)
-
 		if timestamp.After(istioConnection.LastSeen) {
 			istioConnection.LastSeen = timestamp
 		}
+		
+		if !slices.Contains(istioConnection.RequestPaths, connWithPath.RequestPath) {
+			istioConnection.RequestPaths = append(istioConnection.RequestPaths, connWithPath.RequestPath)
+		}
+
 		connectionPairToConn[connectionPair] = istioConnection
 	}
 

--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -527,14 +527,14 @@ input IstioConnection {
     srcWorkloadNamespace: String!
     dstWorkload: String!
     dstWorkloadNamespace: String!
-    requestPaths: [String!]!
+    path: String!
+    methods: [HttpMethod!]!
     lastSeen: Time!
 }
 
 input IstioConnectionResults {
     results: [IstioConnection!]!
 }
-
 
 type Query {
     """
@@ -3094,11 +3094,19 @@ func (ec *executionContext) unmarshalInputIstioConnection(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
-		case "requestPaths":
+		case "path":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestPaths"))
-			it.RequestPaths, err = ec.unmarshalNString2ᚕstringᚄ(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+			it.Path, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "methods":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("methods"))
+			it.Methods, err = ec.unmarshalNHttpMethod2ᚕgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐHTTPMethodᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -4277,6 +4285,67 @@ func (ec *executionContext) marshalNHttpMethod2githubᚗcomᚋotterizeᚋnetwork
 	return v
 }
 
+func (ec *executionContext) unmarshalNHttpMethod2ᚕgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐHTTPMethodᚄ(ctx context.Context, v interface{}) ([]model.HTTPMethod, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]model.HTTPMethod, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNHttpMethod2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐHTTPMethod(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNHttpMethod2ᚕgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐHTTPMethodᚄ(ctx context.Context, sel ast.SelectionSet, v []model.HTTPMethod) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNHttpMethod2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐHTTPMethod(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNHttpResource2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐHTTPResource(ctx context.Context, sel ast.SelectionSet, v model.HTTPResource) graphql.Marshaler {
 	return ec._HttpResource(ctx, sel, &v)
 }
@@ -4547,38 +4616,6 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
-}
-
-func (ec *executionContext) unmarshalNString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]string, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) marshalNString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	for i := range v {
-		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
-	}
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -43,12 +43,13 @@ type Intent struct {
 }
 
 type IstioConnection struct {
-	SrcWorkload          string    `json:"srcWorkload"`
-	SrcWorkloadNamespace string    `json:"srcWorkloadNamespace"`
-	DstWorkload          string    `json:"dstWorkload"`
-	DstWorkloadNamespace string    `json:"dstWorkloadNamespace"`
-	RequestPaths         []string  `json:"requestPaths"`
-	LastSeen             time.Time `json:"lastSeen"`
+	SrcWorkload          string       `json:"srcWorkload"`
+	SrcWorkloadNamespace string       `json:"srcWorkloadNamespace"`
+	DstWorkload          string       `json:"dstWorkload"`
+	DstWorkloadNamespace string       `json:"dstWorkloadNamespace"`
+	Path                 string       `json:"path"`
+	Methods              []HTTPMethod `json:"methods"`
+	LastSeen             time.Time    `json:"lastSeen"`
 }
 
 type IstioConnectionResults struct {

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -220,12 +220,11 @@ func (r *mutationResolver) ReportIstioConnectionResults(ctx context.Context, res
 				Name:      result.DstWorkload,
 				Namespace: result.DstWorkloadNamespace,
 			},
-			Type: lo.ToPtr(model.IntentTypeHTTP),
-			HTTPResources: lo.Map(result.RequestPaths, func(path string, i int) model.HTTPResource {
-				return model.HTTPResource{Path: path}
-			}),
+			Type:          lo.ToPtr(model.IntentTypeHTTP),
+			HTTPResources: []model.HTTPResource{{Path: result.Path, Methods: result.Methods}},
 		})
 	}
+
 	return true, nil
 }
 

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -116,14 +116,14 @@ input IstioConnection {
     srcWorkloadNamespace: String!
     dstWorkload: String!
     dstWorkloadNamespace: String!
-    requestPaths: [String!]!
+    path: String!
+    methods: [HttpMethod!]!
     lastSeen: Time!
 }
 
 input IstioConnectionResults {
     results: [IstioConnection!]!
 }
-
 
 type Query {
     """


### PR DESCRIPTION
### Description
GraphQL conversion bug fix.
Changed HTTP Resource schema to be a string for path (instead of array). Will now relay on mapper intent aggregation to join same src/dst connections.
