### PR TITLE
Kafka watcher reads logs since last read, instead of following logs

### DIFF
--- a/src/exp/kafka-watcher/pkg/logwatcher/watcher.go
+++ b/src/exp/kafka-watcher/pkg/logwatcher/watcher.go
@@ -125,6 +125,9 @@ func (w *Watcher) WatchForever(ctx context.Context, kafkaServer types.Namespaced
 		log.Info("Watching logs")
 		err := w.WatchOnce(ctx, kafkaServer, readFromTime)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				continue
+			}
 			log.WithError(err).Error("Error watching logs")
 		}
 		readFromTime = time.Now()


### PR DESCRIPTION
Previously, the Kafka watcher would follow logs, and if the connection was interrupted, it would fail to detect it and just hang forever. It now reads a small amount of logs at a time and continues from where it left off each time, with a short timeout to detect dead connections.