### PR TITLE
Ignore unknown value in request path

### DIFF
--- a/src/exp/istio-watcher/pkg/watcher/watcher.go
+++ b/src/exp/istio-watcher/pkg/watcher/watcher.go
@@ -80,7 +80,7 @@ func (p *ConnectionWithPath) hasMissingInfo() bool {
 		}
 	}
 
-	return p.RequestPath == ""
+	return p.RequestPath == "" || p.RequestPath == "unknown"
 }
 
 type EnvoyMetrics struct {


### PR DESCRIPTION
Envoy may set a request path to `unknown`. Those requests should be ignored. 
Note that we don't check if the path contains the work, since that would be a legitimate path, only if that's the actual value.