### PR TITLE
Update envoy query to clients metrics only

### DIFF
--- a/src/exp/istio-watcher/pkg/watcher/watcher.go
+++ b/src/exp/istio-watcher/pkg/watcher/watcher.go
@@ -39,7 +39,7 @@ Envoy metric sample
 	}
 */
 const (
-	IstioProxyTotalRequestsCMD = "pilot-agent request GET stats?format=json&filter=istio_requests_total"
+	IstioProxyTotalRequestsCMD = "pilot-agent request GET stats?format=json&filter=istio_requests_total\\.*reporter\\.source"
 	IstioSidecarContainerName  = "istio-proxy"
 	IstioPodsLabelSelector     = "security.istio.io/tlsMode"
 	MetricsBufferedChannelSize = 100


### PR DESCRIPTION
There are two issues with reading metrics from the servers envoy:
* clients may change their call to the server, the server sidecar will still contain the old logs
* there are some metrics where the client field is wrong, maybe due to a bug in Envoy workload resolution

This PR filter out only metrics where the sidecar is the source of the communication.