### PR TITLE
Validate that packet belongs to resolved pod by verifying timestamp

### DIFF
--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -38,12 +38,23 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 			}
 			continue
 		}
+
+		if srcPod.DeletionTimestamp != nil {
+			logrus.Debugf("Pod %s is being deleted, ignoring", srcPod.Name)
+			continue
+		}
+
 		srcService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, srcPod)
 		if err != nil {
 			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", srcPod.Name)
 			continue
 		}
 		for _, dest := range captureItem.Destinations {
+			if srcPod.CreationTimestamp.After(dest.LastSeen) {
+				logrus.Debugf("Pod %s was created after capture time %s, ignoring", srcPod.Name, dest.LastSeen)
+				continue
+			}
+
 			destAddress := dest.Destination
 			if !strings.HasSuffix(destAddress, viper.GetString(config.ClusterDomainKey)) {
 				// not a k8s service, ignore
@@ -67,6 +78,17 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 				}
 				continue
 			}
+
+			if destPod.CreationTimestamp.After(dest.LastSeen) {
+				logrus.Debugf("Pod %s was created after capture time %s, ignoring", destPod.Name, dest.LastSeen)
+				continue
+			}
+
+			if destPod.DeletionTimestamp != nil {
+				logrus.Debugf("Pod %s is being deleted, ignoring", destPod.Name)
+				continue
+			}
+
 			dstService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, destPod)
 			if err != nil {
 				logrus.WithError(err).Debugf("Could not resolve pod %s to identity", destPod.Name)
@@ -109,12 +131,23 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 			}
 			continue
 		}
+
+		if srcPod.DeletionTimestamp != nil {
+			logrus.Debugf("Pod %s is being deleted, ignoring", srcPod.Name)
+			continue
+		}
+
 		srcService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, srcPod)
 		if err != nil {
 			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", srcPod.Name)
 			continue
 		}
 		for _, destIp := range socketScanItem.DestIps {
+			if srcPod.CreationTimestamp.After(destIp.LastSeen) {
+				logrus.Debugf("Pod %s was created after scan time %s, ignoring", srcPod.Name, destIp.LastSeen)
+				continue
+			}
+
 			destPod, err := r.kubeFinder.ResolveIpToPod(ctx, destIp.Destination)
 			if err != nil {
 				if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
@@ -124,6 +157,17 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 				}
 				continue
 			}
+
+			if destPod.DeletionTimestamp != nil {
+				logrus.Debugf("Pod %s is being deleted, ignoring", destPod.Name)
+				continue
+			}
+
+			if destPod.CreationTimestamp.After(destIp.LastSeen) {
+				logrus.Debugf("Pod %s was created after scan time %s, ignoring", destPod.Name, destIp.LastSeen)
+				continue
+			}
+
 			dstService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, destPod)
 			if err != nil {
 				logrus.WithError(err).Debugf("Could not resolve pod %s to identity", destPod.Name)
@@ -166,6 +210,17 @@ func (r *mutationResolver) ReportKafkaMapperResults(ctx context.Context, results
 			}
 			continue
 		}
+
+		if srcPod.DeletionTimestamp != nil {
+			logrus.Debugf("Pod %s is being deleted, ignoring", srcPod.Name)
+			continue
+		}
+
+		if srcPod.CreationTimestamp.After(result.LastSeen) {
+			logrus.Debugf("Pod %s was created after scan time %s, ignoring", srcPod.Name, result.LastSeen)
+			continue
+		}
+
 		srcService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, srcPod)
 		if err != nil {
 			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", srcPod.Name)

--- a/src/sniffer/pkg/config/config.go
+++ b/src/sniffer/pkg/config/config.go
@@ -10,7 +10,7 @@ const (
 	HostProcDirKey               = "host-proc-dir"
 	HostProcDirDefault           = "/hostproc"
 	CallsTimeoutKey              = "calls-timeout"
-	CallsTimeoutDefault          = 5 * time.Second
+	CallsTimeoutDefault          = 60 * time.Second
 	SnifferReportIntervalKey     = "sniffer-report-interval"
 	SnifferReportIntervalDefault = 10 * time.Second
 )


### PR DESCRIPTION
This PR makes the mapper ignores results from deleted pods or pods that have been terminated. This is to mitigate a rare risk of inaccurate data being discovered in AWS. EKS may reuse IP addresses and when configuring the node group with more pods per node than recommended and rapidly deleting\creating pods the chances for reuse increase. 

We also ignore the result if the resolved Pod is terminated since controller-run time cache updates can be received in meaningful delay when cluster resources are exhausted. This means that a new communication seen only when the pod is terminated will be ignored, but it's important mitigation to avoid resolving inaccurate data.

This PR also increases the default timeout of sniffer reporting to make sure the mapper will receive the data even in high-latency communication.