### PR TITLE
Fix bug where socket scan hostname validation would erroneously discard socket scan data, and would treat non-ESTABLISHED connections as open

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.5
 	golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874
 	golang.org/x/sync v0.3.0
+	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
 	k8s.io/client-go v0.26.2

--- a/src/go.sum
+++ b/src/go.sum
@@ -305,6 +305,7 @@ github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.13.0 h1:BWSJ/M+f+3nmdz9bxB+bWX28kkALN2ok11D0rSo8EJU=
@@ -542,6 +543,7 @@ golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -709,6 +711,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/src/sniffer/pkg/collectors/socketscanner.go
+++ b/src/sniffer/pkg/collectors/socketscanner.go
@@ -38,8 +38,14 @@ func (s *SocketScanner) scanTcpFile(hostname string, path string) {
 			continue
 		}
 
+		if sock.State != procnet.Established {
+			// Skip sockets that are not in ESTABLISHED state, to avoid reporting stale connections (such as connections in TIME_WAIT).
+			continue
+		}
+
 		if _, ok := listenPorts[sock.LocalAddr.Port]; ok {
-			// FIXME: don't check hostname since we have the server's hostname and the client's IP here
+			// FIXME: don't check hostname since we have the server's hostname and the client's IP here. Consider reversing direction to reporting from the client's point-of-view,
+			// but this requires being able to resolve service IPs
 			// For example, Remote: 10.244.120.96 (loadgenerator) -> Local: 10.244.120.95 (frontend). The hostname we have is frontend (local), but the client we are attempting to report is loadgenerator.
 			s.addCapturedRequest(sock.RemoteAddr.IP.String(), "", sock.LocalAddr.IP.String(), time.Now())
 		}

--- a/src/sniffer/pkg/collectors/socketscanner.go
+++ b/src/sniffer/pkg/collectors/socketscanner.go
@@ -39,7 +39,9 @@ func (s *SocketScanner) scanTcpFile(hostname string, path string) {
 		}
 
 		if _, ok := listenPorts[sock.LocalAddr.Port]; ok {
-			s.addCapturedRequest(sock.RemoteAddr.IP.String(), hostname, sock.LocalAddr.IP.String(), time.Now())
+			// FIXME: don't check hostname since we have the server's hostname and the client's IP here
+			// For example, Remote: 10.244.120.96 (loadgenerator) -> Local: 10.244.120.95 (frontend). The hostname we have is frontend (local), but the client we are attempting to report is loadgenerator.
+			s.addCapturedRequest(sock.RemoteAddr.IP.String(), "", sock.LocalAddr.IP.String(), time.Now())
 		}
 	}
 }

--- a/src/sniffer/pkg/collectors/socketscanner_test.go
+++ b/src/sniffer/pkg/collectors/socketscanner_test.go
@@ -2,12 +2,15 @@ package collectors
 
 import (
 	"fmt"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/config"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/mapperclient"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
+	"gotest.tools/v3/assert"
 	"os"
 	"testing"
+	"time"
 )
 
 type SocketScannerTestSuite struct {
@@ -96,10 +99,11 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 
 	// We should only see sockets that this pod serves to other clients.
 	// all other sockets should be ignored (because parsing the server sides on all pods is enough)
-	expectedResult := GetMatcher([]mapperclient.RecordedDestinationsForSrc{
+	results := scanner.CollectResults()
+	expectedResults := []mapperclient.RecordedDestinationsForSrc{
 		{
 			SrcIp:       "192.168.35.14",
-			SrcHostname: "",
+			SrcHostname: "", // Intentional - socket scan does not currently report hostnames
 			Destinations: []mapperclient.Destination{
 				{
 					Destination: "192.168.38.211",
@@ -108,16 +112,15 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 		},
 		{
 			SrcIp:       "176.168.35.14",
-			SrcHostname: "",
+			SrcHostname: "", // Intentional - socket scan does not currently report hostnames
 			Destinations: []mapperclient.Destination{
 				{
 					Destination: "192.168.38.211",
 				},
 			},
 		},
-	})
-	results := scanner.CollectResults()
-	s.Require().True(expectedResult.Matches(results))
+	}
+	assert.DeepEqual(s.T(), expectedResults, results, cmpopts.IgnoreTypes(time.Time{}))
 }
 
 func TestSocketScannerSuite(t *testing.T) {
@@ -128,8 +131,15 @@ const mockTcpFileContent = `  sl  local_address rem_address   st tx_queue rx_que
    0: D326A8C0:EC8E 7EB3640A:1B9E 01 00000000:00000000 02:0000058E 00000000     0        0 2688924237 2 0000000000000000 20 4 24 10 -1
    1: D326A8C0:89F6 0EB8640A:C383 01 00000000:00000000 02:000002DB 00000000     0        0 2448859443 2 0000000000000000 20 4 1 4 -1
    2: D326A8C0:ADEE 20CB640A:2553 01 00000000:00000000 02:000003A7 00000000     0        0 2448899655 2 0000000000000000 20 4 1 10 -1`
+
+// 192.168.35.14 -> 192.168.38.211 ESTABLISHED
+// 176.168.35.14 -> 192.168.38.211 ESTABLISHED
+// 192.168.35.14 -> 193.168.38.211 TIME_WAIT
+// 176.168.35.14 -> 193.168.38.211 TIME_WAIT
 const mockTcp6FileContent = `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
    0: 00000000000000000000000000000000:1F90 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 2448849674 1 0000000000000000 100 0 0 10 0
-   1: 0000000000000000FFFF0000D326A8C0:1F90 0000000000000000FFFF00000E23A8C0:CA08 06 00000000:00000000 03:00000A41 00000000     0        0 0 3 0000000000000000
-   2: 0000000000000000FFFF0000D326A8C0:1F90 0000000000000000FFFF00000E23A8B0:CA08 06 00000000:00000000 03:00000A41 00000000     0        0 0 3 0000000000000000`
+   1: 0000000000000000FFFF0000D326A8C1:1F90 0000000000000000FFFF00000E23A8C0:CA08 06 00000000:00000000 03:00000A41 00000000     0        0 0 3 0000000000000000
+   2: 0000000000000000FFFF0000D326A8C1:1F90 0000000000000000FFFF00000E23A8B0:CA08 06 00000000:00000000 03:00000A41 00000000     0        0 0 3 0000000000000000
+   3: 0000000000000000FFFF0000D326A8C0:1F90 0000000000000000FFFF00000E23A8C0:CA08 01 00000000:00000000 03:00000A41 00000000     0        0 0 3 0000000000000000
+   4: 0000000000000000FFFF0000D326A8C0:1F90 0000000000000000FFFF00000E23A8B0:CA08 01 00000000:00000000 03:00000A41 00000000     0        0 0 3 0000000000000000`
 const mockEnvironFileContent = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\x00HOSTNAME=thisverypod\x00TERM=xterm\x00HOME=/root\x00"

--- a/src/sniffer/pkg/collectors/socketscanner_test.go
+++ b/src/sniffer/pkg/collectors/socketscanner_test.go
@@ -96,28 +96,7 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 
 	// We should only see sockets that this pod serves to other clients.
 	// all other sockets should be ignored (because parsing the server sides on all pods is enough)
-	//expectedResult := GetMatcher([]mapperclient.RecordedDestinationsForSrc{
-	//	{
-	//		SrcIp:       "192.168.35.14",
-	//		SrcHostname: "thisverypod",
-	//		Destinations: []mapperclient.Destination{
-	//			{
-	//				Destination: "192.168.38.211",
-	//			},
-	//		},
-	//	},
-	//	{
-	//		SrcIp:       "176.168.35.14",
-	//		SrcHostname: "thisverypod",
-	//		Destinations: []mapperclient.Destination{
-	//			{
-	//				Destination: "192.168.38.211",
-	//			},
-	//		},
-	//	},
-	//})
-	results := scanner.CollectResults()
-	s.Require().ElementsMatch([]mapperclient.RecordedDestinationsForSrc{
+	expectedResult := GetMatcher([]mapperclient.RecordedDestinationsForSrc{
 		{
 			SrcIp:       "192.168.35.14",
 			SrcHostname: "",
@@ -136,7 +115,9 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 				},
 			},
 		},
-	}, results)
+	})
+	results := scanner.CollectResults()
+	s.Require().True(expectedResult.Matches(results))
 }
 
 func TestSocketScannerSuite(t *testing.T) {

--- a/src/sniffer/pkg/collectors/socketscanner_test.go
+++ b/src/sniffer/pkg/collectors/socketscanner_test.go
@@ -96,10 +96,31 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 
 	// We should only see sockets that this pod serves to other clients.
 	// all other sockets should be ignored (because parsing the server sides on all pods is enough)
-	expectedResult := GetMatcher([]mapperclient.RecordedDestinationsForSrc{
+	//expectedResult := GetMatcher([]mapperclient.RecordedDestinationsForSrc{
+	//	{
+	//		SrcIp:       "192.168.35.14",
+	//		SrcHostname: "thisverypod",
+	//		Destinations: []mapperclient.Destination{
+	//			{
+	//				Destination: "192.168.38.211",
+	//			},
+	//		},
+	//	},
+	//	{
+	//		SrcIp:       "176.168.35.14",
+	//		SrcHostname: "thisverypod",
+	//		Destinations: []mapperclient.Destination{
+	//			{
+	//				Destination: "192.168.38.211",
+	//			},
+	//		},
+	//	},
+	//})
+	results := scanner.CollectResults()
+	s.Require().ElementsMatch([]mapperclient.RecordedDestinationsForSrc{
 		{
 			SrcIp:       "192.168.35.14",
-			SrcHostname: "thisverypod",
+			SrcHostname: "",
 			Destinations: []mapperclient.Destination{
 				{
 					Destination: "192.168.38.211",
@@ -108,16 +129,14 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 		},
 		{
 			SrcIp:       "176.168.35.14",
-			SrcHostname: "thisverypod",
+			SrcHostname: "",
 			Destinations: []mapperclient.Destination{
 				{
 					Destination: "192.168.38.211",
 				},
 			},
 		},
-	})
-	results := scanner.CollectResults()
-	s.Require().True(expectedResult.Matches(results))
+	}, results)
 }
 
 func TestSocketScannerSuite(t *testing.T) {


### PR DESCRIPTION
Disables hostname validation check for socket scans. Also only regards sockets in state ESTABLISHED as open, to prevent misreporting connections. For example, connections can stay in TIME_WAIT for a relatively long time (30-60 sec) after being closed, resulting in reporting stale connections.