### PR TITLE
Fix filter intents by server

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/amit7itz/goset v1.2.1
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/golang/mock v1.6.0
+	github.com/google/go-cmp v0.5.9
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.3.0
 	github.com/labstack/echo/v4 v4.9.1
@@ -51,7 +52,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -17,6 +17,27 @@ const (
 	ComponentTypeNetworkMapper       ComponentType = "NETWORK_MAPPER"
 )
 
+type DatabaseConfigInput struct {
+	Table      *string              `json:"table"`
+	Operations []*DatabaseOperation `json:"operations"`
+}
+
+// GetTable returns DatabaseConfigInput.Table, and is useful for accessing the field via an interface.
+func (v *DatabaseConfigInput) GetTable() *string { return v.Table }
+
+// GetOperations returns DatabaseConfigInput.Operations, and is useful for accessing the field via an interface.
+func (v *DatabaseConfigInput) GetOperations() []*DatabaseOperation { return v.Operations }
+
+type DatabaseOperation string
+
+const (
+	DatabaseOperationAll    DatabaseOperation = "ALL"
+	DatabaseOperationSelect DatabaseOperation = "SELECT"
+	DatabaseOperationInsert DatabaseOperation = "INSERT"
+	DatabaseOperationUpdate DatabaseOperation = "UPDATE"
+	DatabaseOperationDelete DatabaseOperation = "DELETE"
+)
+
 type DiscoveredIntentInput struct {
 	DiscoveredAt *time.Time   `json:"discoveredAt"`
 	Intent       *IntentInput `json:"intent"`
@@ -54,14 +75,15 @@ const (
 )
 
 type IntentInput struct {
-	Namespace       *string             `json:"namespace"`
-	ClientName      *string             `json:"clientName"`
-	ServerName      *string             `json:"serverName"`
-	ServerNamespace *string             `json:"serverNamespace"`
-	Type            *IntentType         `json:"type"`
-	Topics          []*KafkaConfigInput `json:"topics"`
-	Resources       []*HTTPConfigInput  `json:"resources"`
-	Status          *IntentStatusInput  `json:"status"`
+	Namespace         *string                `json:"namespace"`
+	ClientName        *string                `json:"clientName"`
+	ServerName        *string                `json:"serverName"`
+	ServerNamespace   *string                `json:"serverNamespace"`
+	Type              *IntentType            `json:"type"`
+	Topics            []*KafkaConfigInput    `json:"topics"`
+	Resources         []*HTTPConfigInput     `json:"resources"`
+	DatabaseResources []*DatabaseConfigInput `json:"databaseResources"`
+	Status            *IntentStatusInput     `json:"status"`
 }
 
 // GetNamespace returns IntentInput.Namespace, and is useful for accessing the field via an interface.
@@ -85,6 +107,9 @@ func (v *IntentInput) GetTopics() []*KafkaConfigInput { return v.Topics }
 // GetResources returns IntentInput.Resources, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetResources() []*HTTPConfigInput { return v.Resources }
 
+// GetDatabaseResources returns IntentInput.DatabaseResources, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetDatabaseResources() []*DatabaseConfigInput { return v.DatabaseResources }
+
 // GetStatus returns IntentInput.Status, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetStatus() *IntentStatusInput { return v.Status }
 
@@ -98,8 +123,9 @@ func (v *IntentStatusInput) GetIstioStatus() *IstioStatusInput { return v.IstioS
 type IntentType string
 
 const (
-	IntentTypeHttp  IntentType = "HTTP"
-	IntentTypeKafka IntentType = "KAFKA"
+	IntentTypeHttp     IntentType = "HTTP"
+	IntentTypeKafka    IntentType = "KAFKA"
+	IntentTypeDatabase IntentType = "DATABASE"
 )
 
 type IstioStatusInput struct {

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -150,6 +150,57 @@ enum CustomConstraint {
 	ID
 }
 
+type DatabaseConfig {
+	table: String!
+	operations: [DatabaseOperation!]
+}
+
+input DatabaseConfigInput {
+	table: String!
+	operations: [DatabaseOperation!]!
+}
+
+type DatabaseCredentials {
+	username: String!
+	password: String!
+}
+
+input DatabaseCredentialsInput {
+	username: String!
+	password: String!
+}
+
+type DatabaseInfo {
+	name: String!
+	address: String!
+	databaseType: DatabaseType
+	credentials: DatabaseCredentials!
+}
+
+input DatabaseInfoInput {
+	name: String!
+	address: String!
+	databaseType: DatabaseType!
+	credentials: DatabaseCredentialsInput!
+}
+
+enum DatabaseOperation {
+	ALL
+	SELECT
+	INSERT
+	UPDATE
+	DELETE
+}
+
+enum DatabaseType {
+	POSTGRESQL
+}
+
+enum DBPermissionChange {
+	APPLY
+	DELETE
+}
+
 input DiscoveredIntentInput {
 	discoveredAt: Time!
 	intent: IntentInput!
@@ -169,6 +220,7 @@ enum EdgeAccessStatusReason {
 	ALLOWED_BY_APPLIED_INTENTS_OVERLY_PERMISSIVE
 	ALLOWED_BY_APPLIED_INTENTS_HTTP_OVERLY_PERMISSIVE
 	ALLOWED_BY_APPLIED_INTENTS_KAFKA_OVERLY_PERMISSIVE
+	ALLOWED_BY_EXTERNAL_TRAFFIC_NETWORK_POLICY
 	BLOCKED_BY_APPLIED_INTENTS_UNDER_PERMISSIVE
 	BLOCKED_BY_APPLIED_INTENTS_RESOURCE_MISMATCH
 	BLOCKED_BY_APPLIED_INTENTS_HTTP_UNDER_PERMISSIVE
@@ -184,6 +236,7 @@ enum EdgeAccessStatusReason {
 	INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT
 	INTENTS_OPERATOR_NOT_ENFORCING_KAFKA_INTENTS_NOT_REQUIRED_FOR_TOPIC
 	MISSING_APPLIED_INTENT
+	NOT_IN_PROTECTED_SERVICES
 	INTENTS_OPERATOR_NEVER_CONNECTED
 	NETWORK_MAPPER_NEVER_CONNECTED
 	NO_INTENTS_FOUND_OF_RELEVANT_TYPE
@@ -246,6 +299,7 @@ type Integration {
 	components: IntegrationComponents
 	defaultEnvironment: Environment
 	cluster: Cluster
+	databaseInfo: DatabaseInfo
 }
 
 type IntegrationComponents {
@@ -262,6 +316,7 @@ type IntegrationCredentials {
 enum IntegrationType {
 	GENERIC
 	KUBERNETES
+	DATABASE
 }
 
 type Intent {
@@ -271,6 +326,7 @@ type Intent {
 	type: IntentType
 	kafkaTopics: [KafkaConfig!]
 	httpResources: [HTTPConfig!]
+	databaseResources: [DatabaseConfig!]
 	status: IntentStatus
 }
 
@@ -282,6 +338,7 @@ input IntentInput {
 	type: IntentType
 	topics: [KafkaConfigInput!]
 	resources: [HTTPConfigInput!]
+	databaseResources: [DatabaseConfigInput!]
 	status: IntentStatusInput
 }
 
@@ -296,13 +353,16 @@ type IntentsOperatorConfiguration {
 	networkPolicyEnforcementEnabled: Boolean!
 	kafkaACLEnforcementEnabled: Boolean!
 	istioPolicyEnforcementEnabled: Boolean!
+	protectedServicesEnabled: Boolean!
+	protectedServices: [Service!]!
 }
 
 input IntentsOperatorConfigurationInput {
 	globalEnforcementEnabled: Boolean!
-	networkPolicyEnforcementEnabled: Boolean!
-	kafkaACLEnforcementEnabled: Boolean!
-	istioPolicyEnforcementEnabled: Boolean!
+	networkPolicyEnforcementEnabled: Boolean
+	kafkaACLEnforcementEnabled: Boolean
+	istioPolicyEnforcementEnabled: Boolean
+	protectedServicesEnabled: Boolean
 }
 
 type IntentStatus {
@@ -319,6 +379,7 @@ input IntentStatusInput {
 enum IntentType {
 	HTTP
 	KAFKA
+	DATABASE
 }
 
 type Invite {
@@ -525,6 +586,10 @@ type Mutation {
 	createGenericIntegration(
 		name: String!
 	): Integration
+	createDatabaseIntegration(
+		name: String!
+		databaseInfo: DatabaseInfoInput!
+	): Integration
 """Create a new Kubernetes integration"""
 	createKubernetesIntegration(
 		environmentId: ID
@@ -558,6 +623,10 @@ type Mutation {
 		namespace: String!
 		intents: [IntentInput!]!
 	): Boolean!
+	handleDatabaseIntents(
+		intents: [IntentInput!]!
+		action: DBPermissionChange!
+	): Boolean!
 	reportNetworkPolicies(
 		namespace: String!
 		policies: [NetworkPolicyInput!]!
@@ -571,6 +640,10 @@ type Mutation {
 		id: ID!
 		environmentId: ID
 	): Namespace!
+	reportProtectedServicesSnapshot(
+		namespace: String!
+		services: [ProtectedServiceInput!]!
+	): Boolean!
 }
 
 type Namespace {
@@ -594,14 +667,19 @@ type NetworkMapperComponent {
 
 input NetworkPolicyInput {
 	namespace: String!
+	name: String!
 	serverName: String!
-	externalTrafficPolicy: Boolean!
+	externalNetworkTrafficPolicy: Boolean!
 }
 
 type Organization {
 	id: ID!
 	name: String
 	imageURL: String
+}
+
+input ProtectedServiceInput {
+	name: String!
 }
 
 type Query {

--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -89,7 +89,7 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Intents        func(childComplexity int, namespaces []string, includeLabels []string, excludeServiceWithLabels []string, includeAllLabels *bool, serverName *string) int
+		Intents        func(childComplexity int, namespaces []string, includeLabels []string, excludeServiceWithLabels []string, includeAllLabels *bool, server *model.ServerFilter) int
 		ServiceIntents func(childComplexity int, namespaces []string, includeLabels []string, includeAllLabels *bool) int
 	}
 
@@ -108,7 +108,7 @@ type MutationResolver interface {
 }
 type QueryResolver interface {
 	ServiceIntents(ctx context.Context, namespaces []string, includeLabels []string, includeAllLabels *bool) ([]model.ServiceIntents, error)
-	Intents(ctx context.Context, namespaces []string, includeLabels []string, excludeServiceWithLabels []string, includeAllLabels *bool, serverName *string) ([]model.Intent, error)
+	Intents(ctx context.Context, namespaces []string, includeLabels []string, excludeServiceWithLabels []string, includeAllLabels *bool, server *model.ServerFilter) ([]model.Intent, error)
 }
 
 type executableSchema struct {
@@ -317,7 +317,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Intents(childComplexity, args["namespaces"].([]string), args["includeLabels"].([]string), args["excludeServiceWithLabels"].([]string), args["includeAllLabels"].(*bool), args["serverName"].(*string)), true
+		return e.complexity.Query.Intents(childComplexity, args["namespaces"].([]string), args["includeLabels"].([]string), args["excludeServiceWithLabels"].([]string), args["includeAllLabels"].(*bool), args["server"].(*model.ServerFilter)), true
 
 	case "Query.serviceIntents":
 		if e.complexity.Query.ServiceIntents == nil {
@@ -533,6 +533,11 @@ input IstioConnectionResults {
     results: [IstioConnection!]!
 }
 
+input ServerFilter {
+    name: String!
+    namespace: String!
+}
+
 type Query {
     """
     Kept for backwards compatibility with CLI -
@@ -555,7 +560,7 @@ type Query {
         includeLabels: [String!],
         excludeServiceWithLabels: [String!],
         includeAllLabels: Boolean,
-        serverName: String,
+        server: ServerFilter,
     ): [Intent!]!
 }
 
@@ -687,15 +692,15 @@ func (ec *executionContext) field_Query_intents_args(ctx context.Context, rawArg
 		}
 	}
 	args["includeAllLabels"] = arg3
-	var arg4 *string
-	if tmp, ok := rawArgs["serverName"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serverName"))
-		arg4, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+	var arg4 *model.ServerFilter
+	if tmp, ok := rawArgs["server"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("server"))
+		arg4, err = ec.unmarshalOServerFilter2ᚖgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐServerFilter(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["serverName"] = arg4
+	args["server"] = arg4
 	return args, nil
 }
 
@@ -1646,7 +1651,7 @@ func (ec *executionContext) _Query_intents(ctx context.Context, field graphql.Co
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Intents(rctx, args["namespaces"].([]string), args["includeLabels"].([]string), args["excludeServiceWithLabels"].([]string), args["includeAllLabels"].(*bool), args["serverName"].(*string))
+		return ec.resolvers.Query().Intents(rctx, args["namespaces"].([]string), args["includeLabels"].([]string), args["excludeServiceWithLabels"].([]string), args["includeAllLabels"].(*bool), args["server"].(*model.ServerFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -3254,6 +3259,37 @@ func (ec *executionContext) unmarshalInputRecordedDestinationsForSrc(ctx context
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("destinations"))
 			it.Destinations, err = ec.unmarshalNDestination2ᚕgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐDestinationᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputServerFilter(ctx context.Context, obj interface{}) (model.ServerFilter, error) {
+	var it model.ServerFilter
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "name":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			it.Name, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "namespace":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("namespace"))
+			it.Namespace, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5185,6 +5221,14 @@ func (ec *executionContext) marshalOPodLabel2ᚕgithubᚗcomᚋotterizeᚋnetwor
 	}
 
 	return ret
+}
+
+func (ec *executionContext) unmarshalOServerFilter2ᚖgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐServerFilter(ctx context.Context, v interface{}) (*model.ServerFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputServerFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -88,6 +88,11 @@ type RecordedDestinationsForSrc struct {
 	Destinations []Destination `json:"destinations"`
 }
 
+type ServerFilter struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
 type ServiceIntents struct {
 	Client  *OtterizeServiceIdentity  `json:"client"`
 	Intents []OtterizeServiceIdentity `json:"intents"`

--- a/src/mapper/pkg/intentsstore/holder.go
+++ b/src/mapper/pkg/intentsstore/holder.go
@@ -211,9 +211,6 @@ func (i *IntentsHolder) getIntentsFromStore(
 	includeAllLabels bool,
 	filterByServer string,
 ) ([]TimestampedIntent, error) {
-	var targetedServerClients []types.NamespacedName
-	var err error
-
 	namespacesSet := goset.FromSlice(namespaces)
 	includeLabelsSet := goset.FromSlice(includeLabels)
 	result := make([]TimestampedIntent, 0)
@@ -225,6 +222,8 @@ func (i *IntentsHolder) getIntentsFromStore(
 		return labelSlice[0], labelSlice[1]
 	})
 
+	var targetedServerClients []types.NamespacedName
+	var err error
 	shouldFilterByServer := len(filterByServer) != 0
 	if shouldFilterByServer {
 		targetedServerClients, err = getAllClientsCallingServer(filterByServer, store)

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -290,7 +290,7 @@ func (s *ResolverTestSuite) TestIntents() {
 	_, err := test_gql_client.ReportCaptureResults(context.Background(), s.client, test_gql_client.CaptureResults{
 		Results: []test_gql_client.RecordedDestinationsForSrc{
 			{
-				SrcIp: "1.1.1.1",
+				SrcIp: "1.1.21.1",
 				Destinations: []test_gql_client.Destination{
 					{
 						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),
@@ -299,7 +299,7 @@ func (s *ResolverTestSuite) TestIntents() {
 				},
 			},
 			{
-				SrcIp: "1.1.1.3",
+				SrcIp: "1.1.21.3",
 				Destinations: []test_gql_client.Destination{
 					{
 						Destination: fmt.Sprintf("service1.%s.svc.cluster.local", s.TestNamespace),
@@ -312,7 +312,7 @@ func (s *ResolverTestSuite) TestIntents() {
 				},
 			},
 			{
-				SrcIp: "1.1.1.4",
+				SrcIp: "1.1.21.4",
 				Destinations: []test_gql_client.Destination{
 					{
 						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/resolvers/test_gql_client"
 	"github.com/otterize/network-mapper/src/shared/testbase"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 	"net/http/httptest"
 	"testing"
@@ -276,6 +277,245 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 			},
 		},
 	})
+}
+
+func (s *ResolverTestSuite) TestIntents() {
+	s.AddDeploymentWithService("service1", []string{"1.1.21.1"}, map[string]string{"app": "service1"})
+	s.AddDeploymentWithService("service2", []string{"1.1.21.2"}, map[string]string{"app": "service2"})
+	s.AddDaemonSetWithService("service3", []string{"1.1.21.3"}, map[string]string{"app": "service3"})
+	s.AddPod("pod4", "1.1.21.4", nil, nil)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	packetTime := time.Now().Add(time.Minute)
+	_, err := test_gql_client.ReportCaptureResults(context.Background(), s.client, test_gql_client.CaptureResults{
+		Results: []test_gql_client.RecordedDestinationsForSrc{
+			{
+				SrcIp: "1.1.1.1",
+				Destinations: []test_gql_client.Destination{
+					{
+						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),
+						LastSeen:    packetTime,
+					},
+				},
+			},
+			{
+				SrcIp: "1.1.1.3",
+				Destinations: []test_gql_client.Destination{
+					{
+						Destination: fmt.Sprintf("service1.%s.svc.cluster.local", s.TestNamespace),
+						LastSeen:    packetTime,
+					},
+					{
+						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),
+						LastSeen:    packetTime,
+					},
+				},
+			},
+			{
+				SrcIp: "1.1.1.4",
+				Destinations: []test_gql_client.Destination{
+					{
+						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),
+						LastSeen:    packetTime,
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	logrus.Info("Testing Intents query")
+	res, err := test_gql_client.Intents(context.Background(), s.client, nil, nil, nil, true, "")
+	s.Require().NoError(err)
+	logrus.Info("Testing Intents query done")
+	logrus.Infof("Intents: %v", res.Intents)
+
+	expectedIntents := []test_gql_client.IntentsIntentsIntent{
+		{
+			Client: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentity{
+				Name:      "service1",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
+			},
+			Server: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentity{
+				Name:      "service2",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
+			},
+		},
+		{
+			Client: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentity{
+				Name:      "service3",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "DaemonSet",
+					Version: "v1",
+				},
+			},
+			Server: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentity{
+				Name:      "service1",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
+			},
+		}, {
+			Client: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentity{
+				Name:      "service3",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "DaemonSet",
+					Version: "v1",
+				},
+			},
+			Server: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentity{
+				Name:      "service2",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
+			},
+		},
+		{
+			Client: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentity{
+				Name:      "pod4",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "",
+					Kind:    "Pod",
+					Version: "v1",
+				},
+			},
+			Server: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentity{
+				Name:      "service2",
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
+			},
+		},
+	}
+	s.Require().ElementsMatch(res.Intents, expectedIntents)
+}
+
+func (s *ResolverTestSuite) TestIntentsFilterByServer() {
+	service1Name := "service1"
+	service1IP := "1.1.18.1"
+	s.AddDeploymentWithService(service1Name, []string{service1IP}, map[string]string{"app": service1Name})
+	service2Name := "service2"
+	service2IP := "1.1.18.2"
+	s.AddDeploymentWithService(service2Name, []string{service2IP}, map[string]string{"app": service2Name})
+	service3Name := "service3"
+	service3IP := "1.1.18.3"
+	s.AddDaemonSetWithService(service3Name, []string{service3IP}, map[string]string{"app": service3Name})
+	podServiceName := "pod4"
+	podIP := "1.1.18.4"
+	s.AddPod(podServiceName, podIP, nil, nil)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	packetTime := time.Now().Add(time.Minute)
+	_, err := test_gql_client.ReportCaptureResults(context.Background(), s.client, test_gql_client.CaptureResults{
+		Results: []test_gql_client.RecordedDestinationsForSrc{
+			{
+				SrcIp: service1IP,
+				Destinations: []test_gql_client.Destination{
+					{
+						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),
+						LastSeen:    packetTime,
+					},
+				},
+			},
+			{
+				SrcIp: service3IP,
+				Destinations: []test_gql_client.Destination{
+					{
+						Destination: fmt.Sprintf("service1.%s.svc.cluster.local", s.TestNamespace),
+						LastSeen:    packetTime,
+					},
+					{
+						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),
+						LastSeen:    packetTime,
+					},
+				},
+			},
+			{
+				SrcIp: podIP,
+				Destinations: []test_gql_client.Destination{
+					{
+						Destination: fmt.Sprintf("service2.%s.svc.cluster.local", s.TestNamespace),
+						LastSeen:    packetTime,
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	logrus.Info("Waiting for report to be processed")
+	serverFilter := fmt.Sprintf("%s.%s", service1Name, s.TestNamespace)
+	res, err := test_gql_client.Intents(context.Background(), s.client, []string{s.TestNamespace}, nil, nil, true, serverFilter)
+	s.Require().NoError(err)
+	logrus.Info("Report processed")
+	logrus.Infof("Intents: %v", res.Intents)
+
+	expectedIntents := []test_gql_client.IntentsIntentsIntent{
+		{
+			Client: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentity{
+				Name:      service3Name,
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "DaemonSet",
+					Version: "v1",
+				},
+			},
+			Server: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentity{
+				Name:      service1Name,
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
+			},
+		}, {
+			Client: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentity{
+				Name:      service3Name,
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "DaemonSet",
+					Version: "v1",
+				},
+			},
+			Server: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentity{
+				Name:      service2Name,
+				Namespace: s.TestNamespace,
+				PodOwnerKind: test_gql_client.IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				},
+			},
+		},
+	}
+	s.Require().ElementsMatch(res.Intents, expectedIntents)
 }
 
 func TestRunSuite(t *testing.T) {

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -325,7 +325,7 @@ func (s *ResolverTestSuite) TestIntents() {
 	s.Require().NoError(err)
 
 	logrus.Info("Testing Intents query")
-	res, err := test_gql_client.Intents(context.Background(), s.client, nil, nil, nil, true, "")
+	res, err := test_gql_client.Intents(context.Background(), s.client, nil, nil, nil, true, nil)
 	s.Require().NoError(err)
 	logrus.Info("Testing Intents query done")
 	logrus.Infof("Intents: %v", res.Intents)
@@ -468,7 +468,10 @@ func (s *ResolverTestSuite) TestIntentsFilterByServer() {
 	s.Require().NoError(err)
 
 	logrus.Info("Waiting for report to be processed")
-	serverFilter := fmt.Sprintf("%s.%s", service1Name, s.TestNamespace)
+	serverFilter := &test_gql_client.ServerFilter{
+		Name:      service1Name,
+		Namespace: s.TestNamespace,
+	}
 	res, err := test_gql_client.Intents(context.Background(), s.client, []string{s.TestNamespace}, nil, nil, true, serverFilter)
 	s.Require().NoError(err)
 	logrus.Info("Report processed")

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -266,7 +266,7 @@ func (r *queryResolver) ServiceIntents(ctx context.Context, namespaces []string,
 	if includeAllLabels != nil && *includeAllLabels {
 		shouldIncludeAllLabels = true
 	}
-	discoveredIntents, err := r.intentsHolder.GetIntents(namespaces, includeLabels, []string{}, shouldIncludeAllLabels, "")
+	discoveredIntents, err := r.intentsHolder.GetIntents(namespaces, includeLabels, []string{}, shouldIncludeAllLabels, nil)
 	if err != nil {
 		return []model.ServiceIntents{}, err
 	}
@@ -286,17 +286,10 @@ func (r *queryResolver) ServiceIntents(ctx context.Context, namespaces []string,
 	return intentsBySource, nil
 }
 
-func (r *queryResolver) Intents(ctx context.Context, namespaces []string, includeLabels []string, excludeServiceWithLabels []string, includeAllLabels *bool, serverName *string) ([]model.Intent, error) {
+func (r *queryResolver) Intents(ctx context.Context, namespaces []string, includeLabels []string, excludeServiceWithLabels []string, includeAllLabels *bool, server *model.ServerFilter) ([]model.Intent, error) {
 	shouldIncludeAllLabels := false
 	if includeAllLabels != nil && *includeAllLabels {
 		shouldIncludeAllLabels = true
-	}
-
-	var server string
-	if serverName == nil {
-		server = ""
-	} else {
-		server = *serverName
 	}
 
 	timestampedIntents, err := r.intentsHolder.GetIntents(

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -286,14 +286,7 @@ func (r *queryResolver) ServiceIntents(ctx context.Context, namespaces []string,
 	return intentsBySource, nil
 }
 
-func (r *queryResolver) Intents(
-	ctx context.Context,
-	namespaces []string,
-	includeLabels []string,
-	excludeServiceWithLabels []string,
-	includeAllLabels *bool,
-	serverName *string,
-) ([]model.Intent, error) {
+func (r *queryResolver) Intents(ctx context.Context, namespaces []string, includeLabels []string, excludeServiceWithLabels []string, includeAllLabels *bool, serverName *string) ([]model.Intent, error) {
 	shouldIncludeAllLabels := false
 	if includeAllLabels != nil && *includeAllLabels {
 		shouldIncludeAllLabels = true

--- a/src/mapper/pkg/resolvers/test_gql_client/generated.go
+++ b/src/mapper/pkg/resolvers/test_gql_client/generated.go
@@ -171,6 +171,17 @@ func (v *ReportSocketScanResultsResponse) GetReportSocketScanResults() bool {
 	return v.ReportSocketScanResults
 }
 
+type ServerFilter struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// GetName returns ServerFilter.Name, and is useful for accessing the field via an interface.
+func (v *ServerFilter) GetName() string { return v.Name }
+
+// GetNamespace returns ServerFilter.Namespace, and is useful for accessing the field via an interface.
+func (v *ServerFilter) GetNamespace() string { return v.Namespace }
+
 // ServiceIntentsResponse is returned by ServiceIntents on success.
 type ServiceIntentsResponse struct {
 	// Kept for backwards compatibility with CLI -
@@ -268,11 +279,11 @@ func (v *SocketScanResults) GetResults() []RecordedDestinationsForSrc { return v
 
 // __IntentsInput is used internally by genqlient
 type __IntentsInput struct {
-	Namespaces               []string `json:"namespaces"`
-	IncludeLabels            []string `json:"includeLabels"`
-	ExcludeServiceWithLabels []string `json:"excludeServiceWithLabels"`
-	IncludeAllLabels         bool     `json:"includeAllLabels"`
-	ServerName               string   `json:"serverName"`
+	Namespaces               []string      `json:"namespaces"`
+	IncludeLabels            []string      `json:"includeLabels"`
+	ExcludeServiceWithLabels []string      `json:"excludeServiceWithLabels"`
+	IncludeAllLabels         bool          `json:"includeAllLabels"`
+	Server                   *ServerFilter `json:"server"`
 }
 
 // GetNamespaces returns __IntentsInput.Namespaces, and is useful for accessing the field via an interface.
@@ -287,8 +298,8 @@ func (v *__IntentsInput) GetExcludeServiceWithLabels() []string { return v.Exclu
 // GetIncludeAllLabels returns __IntentsInput.IncludeAllLabels, and is useful for accessing the field via an interface.
 func (v *__IntentsInput) GetIncludeAllLabels() bool { return v.IncludeAllLabels }
 
-// GetServerName returns __IntentsInput.ServerName, and is useful for accessing the field via an interface.
-func (v *__IntentsInput) GetServerName() string { return v.ServerName }
+// GetServer returns __IntentsInput.Server, and is useful for accessing the field via an interface.
+func (v *__IntentsInput) GetServer() *ServerFilter { return v.Server }
 
 // __ReportCaptureResultsInput is used internally by genqlient
 type __ReportCaptureResultsInput struct {
@@ -316,8 +327,9 @@ func (v *__ServiceIntentsInput) GetNamespaces() []string { return v.Namespaces }
 
 // The query or mutation executed by Intents.
 const Intents_Operation = `
-query Intents ($namespaces: [String!], $includeLabels: [String!], $excludeServiceWithLabels: [String!], $includeAllLabels: Boolean, $serverName: String) {
-	intents(namespaces: $namespaces, includeLabels: $includeLabels, excludeServiceWithLabels: $excludeServiceWithLabels, includeAllLabels: $includeAllLabels, serverName: $serverName) {
+query Intents ($namespaces: [String!], $includeLabels: [String!], $excludeServiceWithLabels: [String!], $includeAllLabels: Boolean, # @genqlient(pointer: true)
+$server: ServerFilter) {
+	intents(namespaces: $namespaces, includeLabels: $includeLabels, excludeServiceWithLabels: $excludeServiceWithLabels, includeAllLabels: $includeAllLabels, server: $server) {
 		client {
 			name
 			namespace
@@ -347,7 +359,7 @@ func Intents(
 	includeLabels []string,
 	excludeServiceWithLabels []string,
 	includeAllLabels bool,
-	serverName string,
+	server *ServerFilter,
 ) (*IntentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "Intents",
@@ -357,7 +369,7 @@ func Intents(
 			IncludeLabels:            includeLabels,
 			ExcludeServiceWithLabels: excludeServiceWithLabels,
 			IncludeAllLabels:         includeAllLabels,
-			ServerName:               serverName,
+			Server:                   server,
 		},
 	}
 	var err error

--- a/src/mapper/pkg/resolvers/test_gql_client/generated.go
+++ b/src/mapper/pkg/resolvers/test_gql_client/generated.go
@@ -27,6 +27,117 @@ func (v *Destination) GetDestination() string { return v.Destination }
 // GetLastSeen returns Destination.LastSeen, and is useful for accessing the field via an interface.
 func (v *Destination) GetLastSeen() time.Time { return v.LastSeen }
 
+// IntentsIntentsIntent includes the requested fields of the GraphQL type Intent.
+type IntentsIntentsIntent struct {
+	Client IntentsIntentsIntentClientOtterizeServiceIdentity `json:"client"`
+	Server IntentsIntentsIntentServerOtterizeServiceIdentity `json:"server"`
+}
+
+// GetClient returns IntentsIntentsIntent.Client, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntent) GetClient() IntentsIntentsIntentClientOtterizeServiceIdentity {
+	return v.Client
+}
+
+// GetServer returns IntentsIntentsIntent.Server, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntent) GetServer() IntentsIntentsIntentServerOtterizeServiceIdentity {
+	return v.Server
+}
+
+// IntentsIntentsIntentClientOtterizeServiceIdentity includes the requested fields of the GraphQL type OtterizeServiceIdentity.
+type IntentsIntentsIntentClientOtterizeServiceIdentity struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	// If the service identity was resolved from a pod owner, the GroupVersionKind of the pod owner.
+	PodOwnerKind IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind `json:"podOwnerKind"`
+}
+
+// GetName returns IntentsIntentsIntentClientOtterizeServiceIdentity.Name, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentClientOtterizeServiceIdentity) GetName() string { return v.Name }
+
+// GetNamespace returns IntentsIntentsIntentClientOtterizeServiceIdentity.Namespace, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentClientOtterizeServiceIdentity) GetNamespace() string { return v.Namespace }
+
+// GetPodOwnerKind returns IntentsIntentsIntentClientOtterizeServiceIdentity.PodOwnerKind, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentClientOtterizeServiceIdentity) GetPodOwnerKind() IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind {
+	return v.PodOwnerKind
+}
+
+// IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind includes the requested fields of the GraphQL type GroupVersionKind.
+type IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind struct {
+	Group   string `json:"group"`
+	Kind    string `json:"kind"`
+	Version string `json:"version"`
+}
+
+// GetGroup returns IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Group, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetGroup() string {
+	return v.Group
+}
+
+// GetKind returns IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Kind, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetKind() string {
+	return v.Kind
+}
+
+// GetVersion returns IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Version, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentClientOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetVersion() string {
+	return v.Version
+}
+
+// IntentsIntentsIntentServerOtterizeServiceIdentity includes the requested fields of the GraphQL type OtterizeServiceIdentity.
+type IntentsIntentsIntentServerOtterizeServiceIdentity struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	// If the service identity was resolved from a pod owner, the GroupVersionKind of the pod owner.
+	PodOwnerKind IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind `json:"podOwnerKind"`
+}
+
+// GetName returns IntentsIntentsIntentServerOtterizeServiceIdentity.Name, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentServerOtterizeServiceIdentity) GetName() string { return v.Name }
+
+// GetNamespace returns IntentsIntentsIntentServerOtterizeServiceIdentity.Namespace, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentServerOtterizeServiceIdentity) GetNamespace() string { return v.Namespace }
+
+// GetPodOwnerKind returns IntentsIntentsIntentServerOtterizeServiceIdentity.PodOwnerKind, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentServerOtterizeServiceIdentity) GetPodOwnerKind() IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind {
+	return v.PodOwnerKind
+}
+
+// IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind includes the requested fields of the GraphQL type GroupVersionKind.
+type IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind struct {
+	Group   string `json:"group"`
+	Kind    string `json:"kind"`
+	Version string `json:"version"`
+}
+
+// GetGroup returns IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Group, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetGroup() string {
+	return v.Group
+}
+
+// GetKind returns IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Kind, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetKind() string {
+	return v.Kind
+}
+
+// GetVersion returns IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind.Version, and is useful for accessing the field via an interface.
+func (v *IntentsIntentsIntentServerOtterizeServiceIdentityPodOwnerKindGroupVersionKind) GetVersion() string {
+	return v.Version
+}
+
+// IntentsResponse is returned by Intents on success.
+type IntentsResponse struct {
+	// Query intents list.
+	// namespaces: Namespaces filter.
+	// includeLabels: Labels to include in the response. Ignored if includeAllLabels is specified.
+	// excludeLabels: Labels to exclude from the response. Ignored if includeAllLabels is specified.
+	// includeAllLabels: Return all labels for the pod in the response.
+	Intents []IntentsIntentsIntent `json:"intents"`
+}
+
+// GetIntents returns IntentsResponse.Intents, and is useful for accessing the field via an interface.
+func (v *IntentsResponse) GetIntents() []IntentsIntentsIntent { return v.Intents }
+
 type RecordedDestinationsForSrc struct {
 	SrcIp        string        `json:"srcIp"`
 	SrcHostname  string        `json:"srcHostname"`
@@ -155,6 +266,30 @@ type SocketScanResults struct {
 // GetResults returns SocketScanResults.Results, and is useful for accessing the field via an interface.
 func (v *SocketScanResults) GetResults() []RecordedDestinationsForSrc { return v.Results }
 
+// __IntentsInput is used internally by genqlient
+type __IntentsInput struct {
+	Namespaces               []string `json:"namespaces"`
+	IncludeLabels            []string `json:"includeLabels"`
+	ExcludeServiceWithLabels []string `json:"excludeServiceWithLabels"`
+	IncludeAllLabels         bool     `json:"includeAllLabels"`
+	ServerName               string   `json:"serverName"`
+}
+
+// GetNamespaces returns __IntentsInput.Namespaces, and is useful for accessing the field via an interface.
+func (v *__IntentsInput) GetNamespaces() []string { return v.Namespaces }
+
+// GetIncludeLabels returns __IntentsInput.IncludeLabels, and is useful for accessing the field via an interface.
+func (v *__IntentsInput) GetIncludeLabels() []string { return v.IncludeLabels }
+
+// GetExcludeServiceWithLabels returns __IntentsInput.ExcludeServiceWithLabels, and is useful for accessing the field via an interface.
+func (v *__IntentsInput) GetExcludeServiceWithLabels() []string { return v.ExcludeServiceWithLabels }
+
+// GetIncludeAllLabels returns __IntentsInput.IncludeAllLabels, and is useful for accessing the field via an interface.
+func (v *__IntentsInput) GetIncludeAllLabels() bool { return v.IncludeAllLabels }
+
+// GetServerName returns __IntentsInput.ServerName, and is useful for accessing the field via an interface.
+func (v *__IntentsInput) GetServerName() string { return v.ServerName }
+
 // __ReportCaptureResultsInput is used internally by genqlient
 type __ReportCaptureResultsInput struct {
 	Results CaptureResults `json:"results"`
@@ -178,6 +313,66 @@ type __ServiceIntentsInput struct {
 
 // GetNamespaces returns __ServiceIntentsInput.Namespaces, and is useful for accessing the field via an interface.
 func (v *__ServiceIntentsInput) GetNamespaces() []string { return v.Namespaces }
+
+// The query or mutation executed by Intents.
+const Intents_Operation = `
+query Intents ($namespaces: [String!], $includeLabels: [String!], $excludeServiceWithLabels: [String!], $includeAllLabels: Boolean, $serverName: String) {
+	intents(namespaces: $namespaces, includeLabels: $includeLabels, excludeServiceWithLabels: $excludeServiceWithLabels, includeAllLabels: $includeAllLabels, serverName: $serverName) {
+		client {
+			name
+			namespace
+			podOwnerKind {
+				group
+				kind
+				version
+			}
+		}
+		server {
+			name
+			namespace
+			podOwnerKind {
+				group
+				kind
+				version
+			}
+		}
+	}
+}
+`
+
+func Intents(
+	ctx context.Context,
+	client graphql.Client,
+	namespaces []string,
+	includeLabels []string,
+	excludeServiceWithLabels []string,
+	includeAllLabels bool,
+	serverName string,
+) (*IntentsResponse, error) {
+	req := &graphql.Request{
+		OpName: "Intents",
+		Query:  Intents_Operation,
+		Variables: &__IntentsInput{
+			Namespaces:               namespaces,
+			IncludeLabels:            includeLabels,
+			ExcludeServiceWithLabels: excludeServiceWithLabels,
+			IncludeAllLabels:         includeAllLabels,
+			ServerName:               serverName,
+		},
+	}
+	var err error
+
+	var data IntentsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
 
 // The query or mutation executed by ReportCaptureResults.
 const ReportCaptureResults_Operation = `

--- a/src/mapper/pkg/resolvers/test_gql_client/genqlient.graphql
+++ b/src/mapper/pkg/resolvers/test_gql_client/genqlient.graphql
@@ -16,6 +16,41 @@ query ServiceIntents($namespaces: [String!]) {
     }
 }
 
+query Intents(
+    $namespaces: [String!],
+    $includeLabels: [String!],
+    $excludeServiceWithLabels: [String!],
+    $includeAllLabels: Boolean,
+    $serverName: String,
+) {
+    intents(
+        namespaces: $namespaces,
+        includeLabels: $includeLabels,
+        excludeServiceWithLabels: $excludeServiceWithLabels,
+        includeAllLabels: $includeAllLabels,
+        serverName: $serverName,
+    ) {
+        client {
+            name
+            namespace
+            podOwnerKind {
+                group
+                kind
+                version
+            }
+        }
+        server {
+            name
+            namespace
+            podOwnerKind {
+                group
+                kind
+                version
+            }
+        }
+    }
+}
+
 mutation ReportCaptureResults($results: CaptureResults!) {
     reportCaptureResults(results: $results)
 }

--- a/src/mapper/pkg/resolvers/test_gql_client/genqlient.graphql
+++ b/src/mapper/pkg/resolvers/test_gql_client/genqlient.graphql
@@ -21,14 +21,15 @@ query Intents(
     $includeLabels: [String!],
     $excludeServiceWithLabels: [String!],
     $includeAllLabels: Boolean,
-    $serverName: String,
+    # @genqlient(pointer: true)
+    $server: ServerFilter,
 ) {
     intents(
         namespaces: $namespaces,
         includeLabels: $includeLabels,
         excludeServiceWithLabels: $excludeServiceWithLabels,
         includeAllLabels: $includeAllLabels,
-        serverName: $serverName,
+        server: $server,
     ) {
         client {
             name

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -122,6 +122,11 @@ input IstioConnectionResults {
     results: [IstioConnection!]!
 }
 
+input ServerFilter {
+    name: String!
+    namespace: String!
+}
+
 type Query {
     """
     Kept for backwards compatibility with CLI -
@@ -144,7 +149,7 @@ type Query {
         includeLabels: [String!],
         excludeServiceWithLabels: [String!],
         includeAllLabels: Boolean,
-        serverName: String,
+        server: ServerFilter,
     ): [Intent!]!
 }
 

--- a/src/sniffer/pkg/collectors/socketscanner_test.go
+++ b/src/sniffer/pkg/collectors/socketscanner_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/otterize/network-mapper/src/sniffer/pkg/mapperclient"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/slices"
 	"gotest.tools/v3/assert"
 	"os"
 	"testing"
@@ -102,15 +103,6 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 	results := scanner.CollectResults()
 	expectedResults := []mapperclient.RecordedDestinationsForSrc{
 		{
-			SrcIp:       "192.168.35.14",
-			SrcHostname: "", // Intentional - socket scan does not currently report hostnames
-			Destinations: []mapperclient.Destination{
-				{
-					Destination: "192.168.38.211",
-				},
-			},
-		},
-		{
 			SrcIp:       "176.168.35.14",
 			SrcHostname: "", // Intentional - socket scan does not currently report hostnames
 			Destinations: []mapperclient.Destination{
@@ -119,7 +111,19 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 				},
 			},
 		},
+		{
+			SrcIp:       "192.168.35.14",
+			SrcHostname: "", // Intentional - socket scan does not currently report hostnames
+			Destinations: []mapperclient.Destination{
+				{
+					Destination: "192.168.38.211",
+				},
+			},
+		},
 	}
+	slices.SortFunc(results, func(a, b mapperclient.RecordedDestinationsForSrc) bool {
+		return a.SrcIp < b.SrcIp
+	})
 	assert.DeepEqual(s.T(), expectedResults, results, cmpopts.IgnoreTypes(time.Time{}))
 }
 


### PR DESCRIPTION
When filter intents by server we should get both server name and namespace, to make sure we get client intents from all namespaces who call this server. The namespace filter meant to filter for intents in an specific namespaces, it's not related and should be mutually exclusive with server name filter.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
