### PR TITLE
Report discovered intents to the cloud in batches

### DIFF
--- a/src/mapper/pkg/clouduploader/cloud_config.go
+++ b/src/mapper/pkg/clouduploader/cloud_config.go
@@ -7,11 +7,13 @@ import (
 )
 
 type Config struct {
-	UploadInterval time.Duration
+	UploadInterval  time.Duration
+	UploadBatchSize int
 }
 
 func ConfigFromViper() Config {
 	return Config{
-		UploadInterval: time.Duration(viper.GetInt(config.UploadIntervalSecondsKey)) * time.Second,
+		UploadInterval:  time.Duration(viper.GetInt(config.UploadIntervalSecondsKey)) * time.Second,
+		UploadBatchSize: viper.GetInt(config.UploadBatchSizeKey),
 	}
 }

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -56,13 +56,17 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 	discoveredIntentsChunks := lo.Chunk(discoveredIntents, c.config.UploadBatchSize)
 	currentChunk := 0
 	err := backoff.Retry(func() error {
-		err := c.client.ReportDiscoveredIntents(ctx, discoveredIntentsChunks[currentChunk])
-		if err != nil {
-			logrus.WithError(err).Error("Failed to report discovered intents to cloud, retrying")
-			return err
+		for {
+			if currentChunk >= len(discoveredIntentsChunks) {
+				return nil
+			}
+			err := c.client.ReportDiscoveredIntents(ctx, discoveredIntentsChunks[currentChunk])
+			if err != nil {
+				logrus.WithError(err).Error("Failed to report discovered intents to cloud, retrying")
+				return err
+			}
+			currentChunk += 1
 		}
-		currentChunk += 1
-		return nil
 	}, exponentialBackoff)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to report discovered intents to cloud, giving up after 10 retries")

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -56,17 +56,15 @@ func (c *CloudUploader) uploadDiscoveredIntents(ctx context.Context) {
 	discoveredIntentsChunks := lo.Chunk(discoveredIntents, c.config.UploadBatchSize)
 	currentChunk := 0
 	err := backoff.Retry(func() error {
-		for {
-			if currentChunk >= len(discoveredIntentsChunks) {
-				return nil
-			}
+		for currentChunk < len(discoveredIntentsChunks) {
 			err := c.client.ReportDiscoveredIntents(ctx, discoveredIntentsChunks[currentChunk])
 			if err != nil {
-				logrus.WithError(err).Error("Failed to report discovered intents to cloud, retrying")
+				logrus.WithError(err).Errorf("Failed to report discovered intents chunk %d to cloud, retrying", currentChunk)
 				return err
 			}
 			currentChunk += 1
 		}
+		return nil
 	}, exponentialBackoff)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to report discovered intents to cloud, giving up after 10 retries")

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -14,7 +14,7 @@ const (
 	CloudApiAddrDefault          = "https://app.otterize.com/api"
 	UploadIntervalSecondsKey     = "upload-interval-seconds"
 	UploadIntervalSecondsDefault = 60
-	UploadBatchSizeKey           = "upload-interval-seconds"
+	UploadBatchSizeKey           = "upload-batch-size"
 	UploadBatchSizeDefault       = 500
 	ExcludedNamespacesKey        = "exclude-namespaces"
 )

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -14,6 +14,8 @@ const (
 	CloudApiAddrDefault          = "https://app.otterize.com/api"
 	UploadIntervalSecondsKey     = "upload-interval-seconds"
 	UploadIntervalSecondsDefault = 60
+	UploadBatchSizeKey           = "upload-interval-seconds"
+	UploadBatchSizeDefault       = 500
 	ExcludedNamespacesKey        = "exclude-namespaces"
 )
 
@@ -28,5 +30,6 @@ func init() {
 	viper.SetDefault(ClusterDomainKey, ClusterDomainDefault) // If not set by the user, the main.go of mapper will try to find the cluster domain and set it itself.
 	viper.SetDefault(CloudApiAddrKey, CloudApiAddrDefault)
 	viper.SetDefault(UploadIntervalSecondsKey, UploadIntervalSecondsDefault)
+	viper.SetDefault(UploadBatchSizeKey, UploadBatchSizeDefault)
 	excludedNamespaces = goset.FromSlice(viper.GetStringSlice(ExcludedNamespacesKey))
 }


### PR DESCRIPTION
### Description

Following a bug related to the length of the discovered intents list, in order to future proof the process of reporting intents to the cloud, we would like to send intents to the cloud in batches.



### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [X] This change adds test coverage for new/changed/fixed functionality

