### PR TITLE
Fix flaky test TestUploadIntentsInBatches

### DIFF
--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -98,15 +98,11 @@ func (s *CloudUploaderTestSuite) TestUploadIntentsInBatches() {
 		intentInput("client1", s.testNamespace, "server2", "external-namespace"),
 	}
 
-	firstReport := s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher([]cloudclient.IntentInput{intents1[0]})).Return(nil).Times(1)
-	secondReport := s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher([]cloudclient.IntentInput{intents1[1]})).Return(nil).Times(1)
-	gomock.InOrder(
-		firstReport,
-		secondReport,
-	)
+	// This can happen in any order, but either way only one intent should be uploaded at a batch
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher([]cloudclient.IntentInput{intents1[0]})).Return(nil).Times(1)
+	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher([]cloudclient.IntentInput{intents1[1]})).Return(nil).Times(1)
 
 	s.cloudUploader.uploadDiscoveredIntents(context.Background())
-
 }
 
 func (s *CloudUploaderTestSuite) TestDontUploadWithoutIntents() {


### PR DESCRIPTION
The intents in the test are send in batches, but there is no guarantee that it will be sent in order. This is OK since the test only check the batch size, the order isn't important. 