### PR TITLE
Fixing fork e2e test

### DIFF
--- a/.github/workflows/build-fork.yaml
+++ b/.github/workflows/build-fork.yaml
@@ -50,13 +50,6 @@ jobs:
         with:
           driver-opts: network=host
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test & Build production image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-fork.yaml
+++ b/.github/workflows/build-fork.yaml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ${{ matrix.service }}.tar
-          name: ${{ env.REGISTRY }}/${{ github.actor }}/${{ matrix.service }}:${{ github.sha }}
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_${{ matrix.service }}_${{ github.sha }}
 
   e2e-test:
     uses: ./.github/workflows/e2e-test.yaml

--- a/.github/workflows/build-fork.yaml
+++ b/.github/workflows/build-fork.yaml
@@ -63,13 +63,18 @@ jobs:
           context: src/
           file: build/${{ matrix.service }}.Dockerfile
           tags: ${{ env.REGISTRY }}/${{ github.actor }}/${{ matrix.service }}:${{ github.sha }}
-          push: true
           network: host
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          outputs: type=docker,dest=${{ matrix.service }}.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             "VERSION=${{ github.run_id }}"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ${{ matrix.service }}.tar
+          name: ${{ env.REGISTRY }}/${{ github.actor }}/${{ matrix.service }}:${{ github.sha }}
 
   e2e-test:
     uses: ./.github/workflows/e2e-test.yaml

--- a/.github/workflows/build-fork.yaml
+++ b/.github/workflows/build-fork.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
   packages: write
 env:
-  REGISTRY: "ghcr.io"
+  REGISTRY: "dummy"
 
 jobs:
 

--- a/.github/workflows/build-fork.yaml
+++ b/.github/workflows/build-fork.yaml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ${{ matrix.service }}.tar
-          name: ${{ env.REGISTRY }}_${{ github.actor }}_${{ matrix.service }}_${{ github.sha }}
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_${{ matrix.service }}_${{ github.sha }}.tar
 
   e2e-test:
     uses: ./.github/workflows/e2e-test.yaml

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -53,7 +53,7 @@ jobs:
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
           ls -lR
-          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_mapper_${{ github.sha }}.tar
+          docker image load -i mapper.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/mapper:${{ github.sha }}
 
       - name: Load images from GitHub Artifacts
@@ -65,7 +65,7 @@ jobs:
       - name: Load Docker image
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
-          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_sniffer_${{ github.sha }}.tar
+          docker image load -i sniffer.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/sniffer:${{ github.sha }}
 
       - name: Load images from GitHub Artifacts
@@ -77,7 +77,7 @@ jobs:
       - name: Load Docker image
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
-          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_kafka-watcher_${{ github.sha }}.tar
+          docker image load -i kafka-watcher.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/kafka-watcher:${{ github.sha }}
 
       - name: Load images from GitHub Artifacts
@@ -89,11 +89,10 @@ jobs:
       - name: Load Docker image
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
-          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_istio-watcher_${{ github.sha }}.tar
+          docker image load -i istio-watcher.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/istio-watcher:${{ github.sha }}
 
 
-# ${{ env.REGISTRY }}_${{ github.actor }}_${{ matrix.service }}_${{ github.sha }}
       - name: Login to GCR
         if: (github.event_name == 'push' && github.repository == 'otterize/network-mapper') || github.event.pull_request.head.repo.full_name == 'otterize/network-mapper'
         uses: docker/login-action@v2

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -43,14 +43,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Log in to the Container registry
-        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Login to GCR
         if: (github.event_name == 'push' && github.repository == 'otterize/network-mapper') || github.event.pull_request.head.repo.full_name == 'otterize/network-mapper'
         uses: docker/login-action@v2

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -43,6 +43,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+        with:
+          start-args: "--network-plugin=cni --cni=calico"
+
       - name: Load images from GitHub Artifacts
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         uses: actions/download-artifact@v3
@@ -103,11 +108,6 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v3
-
-      - name: Start minikube
-        uses: medyagh/setup-minikube@master
-        with:
-          start-args: "--network-plugin=cni --cni=calico"
 
       - name: Wait for Calico startup
         run: |-

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -43,6 +43,56 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Load images from GitHub Artifacts
+        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_mapper_${{ github.sha }}
+
+      - name: Load Docker image
+        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
+        run: |-
+          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_mapper_${{ github.sha }}
+          minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/mapper:${{ github.sha }}
+
+      - name: Load images from GitHub Artifacts
+        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_sniffer_${{ github.sha }}
+
+      - name: Load Docker image
+        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
+        run: |-
+          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_sniffer_${{ github.sha }}
+          minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/sniffer:${{ github.sha }}
+
+      - name: Load images from GitHub Artifacts
+        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_kafka-watcher_${{ github.sha }}
+
+      - name: Load Docker image
+        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
+        run: |-
+          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_kafka-watcher_${{ github.sha }}
+          minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/kafka-watcher:${{ github.sha }}
+
+      - name: Load images from GitHub Artifacts
+        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_istio-watcher_${{ github.sha }}
+
+      - name: Load Docker image
+        if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
+        run: |-
+          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_istio-watcher_${{ github.sha }}
+          minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/istio-watcher:${{ github.sha }}
+
+
+# ${{ env.REGISTRY }}_${{ github.actor }}_${{ matrix.service }}_${{ github.sha }}
       - name: Login to GCR
         if: (github.event_name == 'push' && github.repository == 'otterize/network-mapper') || github.event.pull_request.head.repo.full_name == 'otterize/network-mapper'
         uses: docker/login-action@v2
@@ -68,11 +118,6 @@ jobs:
 
       - name: Deploy Network Mapper
         run: |-
-          docker pull ${{ env.REGISTRY }}/${{ inputs.mapper-image }}:${{ inputs.mapper-tag }}
-          minikube image load ${{ env.REGISTRY }}/${{ inputs.mapper-image }}:${{ inputs.mapper-tag }}
-          docker pull ${{ env.REGISTRY }}/${{ inputs.sniffer-image }}:${{ inputs.sniffer-tag }}
-          minikube image load  ${{ env.REGISTRY }}/${{ inputs.sniffer-image }}:${{ inputs.sniffer-tag }}
-          
           MAPPER_FLAGS="--set-string networkMapper.mapper.repository=${{ env.REGISTRY }} --set-string networkMapper.mapper.image=${{ inputs.mapper-image }} --set-string networkMapper.mapper.tag=${{ inputs.mapper-tag }} --set-string networkMapper.mapper.pullPolicy=Never"
           SNIFFER_FLAGS="--set-string networkMapper.sniffer.repository=${{ env.REGISTRY }} --set-string networkMapper.sniffer.image=${{ inputs.sniffer-image }} --set-string networkMapper.sniffer.tag=${{ inputs.sniffer-tag }} --set-string networkMapper.sniffer.pullPolicy=Never"
           TELEMETRY_FLAG="--set global.telemetry.enabled=false"

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -47,48 +47,49 @@ jobs:
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.REGISTRY }}_${{ github.actor }}_mapper_${{ github.sha }}
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_mapper_${{ github.sha }}.tar
 
       - name: Load Docker image
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
-          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_mapper_${{ github.sha }}
+          ls -lR
+          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_mapper_${{ github.sha }}.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/mapper:${{ github.sha }}
 
       - name: Load images from GitHub Artifacts
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.REGISTRY }}_${{ github.actor }}_sniffer_${{ github.sha }}
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_sniffer_${{ github.sha }}.tar
 
       - name: Load Docker image
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
-          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_sniffer_${{ github.sha }}
+          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_sniffer_${{ github.sha }}.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/sniffer:${{ github.sha }}
 
       - name: Load images from GitHub Artifacts
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.REGISTRY }}_${{ github.actor }}_kafka-watcher_${{ github.sha }}
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_kafka-watcher_${{ github.sha }}.tar
 
       - name: Load Docker image
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
-          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_kafka-watcher_${{ github.sha }}
+          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_kafka-watcher_${{ github.sha }}.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/kafka-watcher:${{ github.sha }}
 
       - name: Load images from GitHub Artifacts
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.REGISTRY }}_${{ github.actor }}_istio-watcher_${{ github.sha }}
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_istio-watcher_${{ github.sha }}.tar
 
       - name: Load Docker image
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
-          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_istio-watcher_${{ github.sha }}
+          docker image load -i ${{ env.REGISTRY }}_${{ github.actor }}_istio-watcher_${{ github.sha }}.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/istio-watcher:${{ github.sha }}
 
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -52,7 +52,6 @@ jobs:
       - name: Load Docker image
         if: github.repository != 'otterize/network-mapper' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/network-mapper')
         run: |-
-          ls -lR
           docker image load -i mapper.tar
           minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/mapper:${{ github.sha }}
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/otterize/network-mapper/src)](https://goreportcard.com/report/github.com/otterize/network-mapper/src)
 [![community](https://img.shields.io/badge/slack-Otterize_Slack-purple.svg?logo=slack)](https://joinslack.otterize.com)
 
+
 * [About](#about)
 * [Try the network mapper](#try-the-network-mapper)
 * [Installation instructions](#installation-instructions)


### PR DESCRIPTION
This PR fixes fork branch builds failing on the new end-to-end test, which was relying on the existence of a container registry to get the images between build steps. This PR now uses `actions/upload-artifact` and `actions/download-artifact` to achieve the same thing.