### PR TITLE
Use k8s built-in context handler

### DIFF
--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/metadata"
+	"sigs.k8s.io/controller-runtime"
 	clientconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -115,8 +114,7 @@ func main() {
 	resolver := resolvers.NewResolver(kubeFinder, serviceidresolver.NewResolver(mgr.GetClient()), intentsHolder)
 	resolver.Register(e)
 
-	signalHandlerCtx, signalHandlerCancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer signalHandlerCancel()
+	signalHandlerCtx := controllerruntime.SetupSignalHandler()
 	cloudClient, cloudEnabled, err := cloudclient.NewClient(signalHandlerCtx)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to initialize cloud client")


### PR DESCRIPTION
### Description

Current context created in main is missing SIGINIT registration. We should just use k8s `controllerruntime` signal handler context instead of implementing it on our own, like we do in the rest of our operators.