### PR TITLE
Change default Kafka read mode to Kubernetes log watch

### DIFF
--- a/src/kafka-watcher/pkg/config/config.go
+++ b/src/kafka-watcher/pkg/config/config.go
@@ -12,7 +12,7 @@ const (
 
 const (
 	KafkaLogReadModeKey          = "kafka-log-read-mode"
-	KafkaLogReadModeDefault      = FileReadMode
+	KafkaLogReadModeDefault      = KubernetesLogReadMode
 	KafkaServersKey              = "kafka-servers"
 	KafkaReportIntervalKey       = "kafka-report-interval"
 	KafkaReportIntervalDefault   = 10 * time.Second


### PR DESCRIPTION
### Description

The default Kafka log read mode was erroneously set to reading from file logs. This PR changes the default to Kubernetes log watching.