### PR TITLE
Fix bug: Cooldown interval config used instead of report interval

### DIFF
--- a/src/kafka-watcher/pkg/logwatcher/filewatcher.go
+++ b/src/kafka-watcher/pkg/logwatcher/filewatcher.go
@@ -38,7 +38,7 @@ func (w *LogFileWatcher) RunForever(ctx context.Context) error {
 	go w.watchForever(ctx)
 
 	for {
-		time.Sleep(viper.GetDuration(config.KafkaCooldownIntervalKey))
+		time.Sleep(viper.GetDuration(config.KafkaReportIntervalKey))
 
 		if err := w.reportResults(ctx); err != nil {
 			logrus.WithError(err).Errorf("Failed reporting watcher results to mapper")

--- a/src/kafka-watcher/pkg/logwatcher/kubeneteslogwatcher.go
+++ b/src/kafka-watcher/pkg/logwatcher/kubeneteslogwatcher.go
@@ -73,7 +73,7 @@ func (w *KubernetesLogWatcher) RunForever(ctx context.Context) error {
 	}
 
 	for {
-		time.Sleep(viper.GetDuration(config.KafkaCooldownIntervalKey))
+		time.Sleep(viper.GetDuration(config.KafkaReportIntervalKey))
 		if err := w.reportResults(ctx); err != nil {
 			logrus.WithError(err).Errorf("Failed reporting watcher results to mapper")
 		}


### PR DESCRIPTION
### Description

Until this PR the `kafka-cooldown-interval` argument was used to set the time between reports to the network mapper instead of `kafka-report-interval`. This PR change it to read the right configuration.

### Testing

Since it's an infrastructural low level detail there is no test who check the interval. It can be reproduce by setting a value to report interval argument and checking time between reports in the logs.

### Checklist

There is no new functionality to document
