### PR TITLE
Support for reporting internet-facing traffic

### DIFF
--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/neko-neko/echo-logrus/v2/log"
+	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"golang.org/x/sync/errgroup"
 	"net/http"
 	"os"
@@ -121,7 +122,7 @@ func main() {
 	mgr.GetCache().WaitForCacheSync(initCtx) // needed to let the manager initialize before used in intentsHolder
 
 	intentsHolder := intentsstore.NewIntentsHolder()
-	externalTrafficIntentsHolder := resolvers.NewExternalTrafficIntentsHolder()
+	externalTrafficIntentsHolder := externaltrafficholder.NewExternalTrafficIntentsHolder()
 
 	resolver := resolvers.NewResolver(kubeFinder, serviceidresolver.NewResolver(mgr.GetClient()), intentsHolder, externalTrafficIntentsHolder)
 	resolver.Register(mapperServer)

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -10,13 +10,14 @@ import (
 type CloudClient interface {
 	ReportDiscoveredIntents(ctx context.Context, intents []*DiscoveredIntentInput) error
 	ReportComponentStatus(ctx context.Context, component ComponentType) error
+	ReportExternalTrafficDiscoveredIntents(ctx context.Context, intents []ExternalTrafficDiscoveredIntentInput) error
 }
 
 type CloudClientImpl struct {
 	client graphql.Client
 }
 
-func NewClient(ctx context.Context) (CloudClient, bool, error) {
+func NewClient(ctx context.Context) (*CloudClientImpl, bool, error) {
 	client, ok, err := otterizecloudclient.NewClient(ctx)
 	if !ok {
 		return nil, false, nil
@@ -31,6 +32,17 @@ func (c *CloudClientImpl) ReportDiscoveredIntents(ctx context.Context, intents [
 	logrus.Info("Uploading intents to cloud, count: ", len(intents))
 
 	_, err := ReportDiscoveredIntents(ctx, c.client, intents)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CloudClientImpl) ReportExternalTrafficDiscoveredIntents(ctx context.Context, intents []ExternalTrafficDiscoveredIntentInput) error {
+	logrus.Info("Uploading external traffic intents to cloud, count: ", len(intents))
+
+	_, err := ReportExternalTrafficDiscoveredIntents(ctx, c.client, intents)
 	if err != nil {
 		return err
 	}

--- a/src/mapper/pkg/cloudclient/generate.go
+++ b/src/mapper/pkg/cloudclient/generate.go
@@ -3,6 +3,6 @@ package cloudclient
 import _ "github.com/suessflorian/gqlfetch"
 
 // The check for $CI makes sure we don't redownload the schema in CI.
-//go:generate sh -c "if [ -z $CI ]; then go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint https://app.staging.otterize.com/api/graphql/v1beta > schema.graphql; fi"
+//go:generate sh -c "if [ -z $CI ]; then go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint http://localhost:3000/api/graphql/v1beta > schema.graphql; fi"
 //go:generate go run github.com/Khan/genqlient ./genqlient.yaml
 //go:generate go run github.com/golang/mock/mockgen@v1.6.0 -destination=./mocks/mocks.go  -package=cloudclientmocks -source=./cloud_client.go CloudClient

--- a/src/mapper/pkg/cloudclient/generate.go
+++ b/src/mapper/pkg/cloudclient/generate.go
@@ -3,6 +3,6 @@ package cloudclient
 import _ "github.com/suessflorian/gqlfetch"
 
 // The check for $CI makes sure we don't redownload the schema in CI.
-//go:generate sh -c "if [ -z $CI ]; then go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint http://localhost:3000/api/graphql/v1beta > schema.graphql; fi"
+//go:generate sh -c "if [ -z $CI ]; then go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint https://app.staging.otterize.com/api/graphql/v1beta > schema.graphql; fi"
 //go:generate go run github.com/Khan/genqlient ./genqlient.yaml
 //go:generate go run github.com/golang/mock/mockgen@v1.6.0 -destination=./mocks/mocks.go  -package=cloudclientmocks -source=./cloud_client.go CloudClient

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -18,15 +18,15 @@ const (
 )
 
 type DNSIPPairInput struct {
-	DnsName string `json:"dnsName"`
-	Ip      string `json:"ip"`
+	DnsName string   `json:"dnsName"`
+	Ips     []string `json:"ips"`
 }
 
 // GetDnsName returns DNSIPPairInput.DnsName, and is useful for accessing the field via an interface.
 func (v *DNSIPPairInput) GetDnsName() string { return v.DnsName }
 
-// GetIp returns DNSIPPairInput.Ip, and is useful for accessing the field via an interface.
-func (v *DNSIPPairInput) GetIp() string { return v.Ip }
+// GetIps returns DNSIPPairInput.Ips, and is useful for accessing the field via an interface.
+func (v *DNSIPPairInput) GetIps() []string { return v.Ips }
 
 type DatabaseConfigInput struct {
 	Dbname     *string              `json:"dbname"`

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -18,9 +18,13 @@ const (
 )
 
 type DatabaseConfigInput struct {
+	Dbname     *string              `json:"dbname"`
 	Table      *string              `json:"table"`
 	Operations []*DatabaseOperation `json:"operations"`
 }
+
+// GetDbname returns DatabaseConfigInput.Dbname, and is useful for accessing the field via an interface.
+func (v *DatabaseConfigInput) GetDbname() *string { return v.Dbname }
 
 // GetTable returns DatabaseConfigInput.Table, and is useful for accessing the field via an interface.
 func (v *DatabaseConfigInput) GetTable() *string { return v.Table }

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -17,6 +17,17 @@ const (
 	ComponentTypeNetworkMapper       ComponentType = "NETWORK_MAPPER"
 )
 
+type DNSIPPairInput struct {
+	DnsName string `json:"dnsName"`
+	Ip      string `json:"ip"`
+}
+
+// GetDnsName returns DNSIPPairInput.DnsName, and is useful for accessing the field via an interface.
+func (v *DNSIPPairInput) GetDnsName() string { return v.DnsName }
+
+// GetIp returns DNSIPPairInput.Ip, and is useful for accessing the field via an interface.
+func (v *DNSIPPairInput) GetIp() string { return v.Ip }
+
 type DatabaseConfigInput struct {
 	Dbname     *string              `json:"dbname"`
 	Table      *string              `json:"table"`
@@ -52,6 +63,34 @@ func (v *DiscoveredIntentInput) GetDiscoveredAt() *time.Time { return v.Discover
 
 // GetIntent returns DiscoveredIntentInput.Intent, and is useful for accessing the field via an interface.
 func (v *DiscoveredIntentInput) GetIntent() *IntentInput { return v.Intent }
+
+type ExternalTrafficDiscoveredIntentInput struct {
+	DiscoveredAt time.Time                  `json:"discoveredAt"`
+	Intent       ExternalTrafficIntentInput `json:"intent"`
+}
+
+// GetDiscoveredAt returns ExternalTrafficDiscoveredIntentInput.DiscoveredAt, and is useful for accessing the field via an interface.
+func (v *ExternalTrafficDiscoveredIntentInput) GetDiscoveredAt() time.Time { return v.DiscoveredAt }
+
+// GetIntent returns ExternalTrafficDiscoveredIntentInput.Intent, and is useful for accessing the field via an interface.
+func (v *ExternalTrafficDiscoveredIntentInput) GetIntent() ExternalTrafficIntentInput {
+	return v.Intent
+}
+
+type ExternalTrafficIntentInput struct {
+	Namespace  string         `json:"namespace"`
+	ClientName string         `json:"clientName"`
+	Target     DNSIPPairInput `json:"target"`
+}
+
+// GetNamespace returns ExternalTrafficIntentInput.Namespace, and is useful for accessing the field via an interface.
+func (v *ExternalTrafficIntentInput) GetNamespace() string { return v.Namespace }
+
+// GetClientName returns ExternalTrafficIntentInput.ClientName, and is useful for accessing the field via an interface.
+func (v *ExternalTrafficIntentInput) GetClientName() string { return v.ClientName }
+
+// GetTarget returns ExternalTrafficIntentInput.Target, and is useful for accessing the field via an interface.
+func (v *ExternalTrafficIntentInput) GetTarget() DNSIPPairInput { return v.Target }
 
 type HTTPConfigInput struct {
 	Path    *string       `json:"path"`
@@ -205,6 +244,16 @@ func (v *ReportDiscoveredIntentsResponse) GetReportDiscoveredIntents() *bool {
 	return v.ReportDiscoveredIntents
 }
 
+// ReportExternalTrafficDiscoveredIntentsResponse is returned by ReportExternalTrafficDiscoveredIntents on success.
+type ReportExternalTrafficDiscoveredIntentsResponse struct {
+	ReportExternalTrafficDiscoveredIntents bool `json:"reportExternalTrafficDiscoveredIntents"`
+}
+
+// GetReportExternalTrafficDiscoveredIntents returns ReportExternalTrafficDiscoveredIntentsResponse.ReportExternalTrafficDiscoveredIntents, and is useful for accessing the field via an interface.
+func (v *ReportExternalTrafficDiscoveredIntentsResponse) GetReportExternalTrafficDiscoveredIntents() bool {
+	return v.ReportExternalTrafficDiscoveredIntents
+}
+
 // __ReportComponentStatusInput is used internally by genqlient
 type __ReportComponentStatusInput struct {
 	Component ComponentType `json:"component"`
@@ -220,6 +269,16 @@ type __ReportDiscoveredIntentsInput struct {
 
 // GetIntents returns __ReportDiscoveredIntentsInput.Intents, and is useful for accessing the field via an interface.
 func (v *__ReportDiscoveredIntentsInput) GetIntents() []*DiscoveredIntentInput { return v.Intents }
+
+// __ReportExternalTrafficDiscoveredIntentsInput is used internally by genqlient
+type __ReportExternalTrafficDiscoveredIntentsInput struct {
+	Intents []ExternalTrafficDiscoveredIntentInput `json:"intents"`
+}
+
+// GetIntents returns __ReportExternalTrafficDiscoveredIntentsInput.Intents, and is useful for accessing the field via an interface.
+func (v *__ReportExternalTrafficDiscoveredIntentsInput) GetIntents() []ExternalTrafficDiscoveredIntentInput {
+	return v.Intents
+}
 
 // The query or mutation executed by ReportComponentStatus.
 const ReportComponentStatus_Operation = `
@@ -276,6 +335,39 @@ func ReportDiscoveredIntents(
 	var err error
 
 	var data ReportDiscoveredIntentsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by ReportExternalTrafficDiscoveredIntents.
+const ReportExternalTrafficDiscoveredIntents_Operation = `
+mutation ReportExternalTrafficDiscoveredIntents ($intents: [ExternalTrafficDiscoveredIntentInput!]!) {
+	reportExternalTrafficDiscoveredIntents(intents: $intents)
+}
+`
+
+func ReportExternalTrafficDiscoveredIntents(
+	ctx context.Context,
+	client graphql.Client,
+	intents []ExternalTrafficDiscoveredIntentInput,
+) (*ReportExternalTrafficDiscoveredIntentsResponse, error) {
+	req := &graphql.Request{
+		OpName: "ReportExternalTrafficDiscoveredIntents",
+		Query:  ReportExternalTrafficDiscoveredIntents_Operation,
+		Variables: &__ReportExternalTrafficDiscoveredIntentsInput{
+			Intents: intents,
+		},
+	}
+	var err error
+
+	var data ReportExternalTrafficDiscoveredIntentsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -3,6 +3,10 @@ mutation ReportDiscoveredIntents($intents: [DiscoveredIntentInput!]!) {
     reportDiscoveredIntents(intents: $intents)
 }
 
+mutation ReportExternalTrafficDiscoveredIntents($intents: [ExternalTrafficDiscoveredIntentInput!]!) {
+    reportExternalTrafficDiscoveredIntents(intents: $intents)
+}
+
 mutation ReportComponentStatus($component: ComponentType!) {
     reportIntegrationComponentStatus(component: $component)
 }

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -62,3 +62,17 @@ func (mr *MockCloudClientMockRecorder) ReportDiscoveredIntents(ctx, intents inte
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportDiscoveredIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportDiscoveredIntents), ctx, intents)
 }
+
+// ReportExternalTrafficDiscoveredIntents mocks base method.
+func (m *MockCloudClient) ReportExternalTrafficDiscoveredIntents(ctx context.Context, intents []cloudclient.ExternalTrafficDiscoveredIntentInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReportExternalTrafficDiscoveredIntents", ctx, intents)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReportExternalTrafficDiscoveredIntents indicates an expected call of ReportExternalTrafficDiscoveredIntents.
+func (mr *MockCloudClientMockRecorder) ReportExternalTrafficDiscoveredIntents(ctx, intents interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportExternalTrafficDiscoveredIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportExternalTrafficDiscoveredIntents), ctx, intents)
+}

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -215,11 +215,13 @@ enum CustomConstraint {
 }
 
 type DatabaseConfig {
+	dbname: String!
 	table: String!
 	operations: [DatabaseOperation!]
 }
 
 input DatabaseConfigInput {
+	dbname: String!
 	table: String!
 	operations: [DatabaseOperation!]!
 }
@@ -230,13 +232,11 @@ input DatabaseCredentialsInput {
 }
 
 type DatabaseInfo {
-	name: String!
 	address: String!
 	databaseType: DatabaseType!
 }
 
 input DatabaseInfoInput {
-	name: String!
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentialsInput!

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -131,6 +131,12 @@ enum CertificateProvider {
 	NONE
 }
 
+input CLICommand {
+	noun: String!
+	verb: String!
+	modifiers: [String!]
+}
+
 type ClientIntentsFileRepresentation {
 	service: Service!
 	rows: [ClientIntentsRow!]!
@@ -141,6 +147,17 @@ type ClientIntentsRow {
 	text: String!
 	diff: RowDiff
 	calledServerId: ID
+}
+
+input CLIIdentifier {
+	version: String!
+	contextId: String!
+	cloudClientId: String
+}
+
+input CLITelemetry {
+	identifier: CLIIdentifier!
+	command: CLICommand!
 }
 
 type Cluster {
@@ -182,6 +199,14 @@ type ClusterFormSettings {
 input ClusterFormSettingsInput {
 	certificateProvider: CertificateProvider!
 	enforcement: Boolean!
+}
+
+input Component {
+	componentType: TelemetryComponentType!
+	componentInstanceId: ID!
+	contextId: ID!
+	version: String!
+	cloudClientId: String
 }
 
 type ComponentStatus {
@@ -267,12 +292,12 @@ input DiscoveredIntentInput {
 
 type DNSIPPair {
 	dnsName: String!
-	ip: String
+	ips: [String!]
 }
 
 input DNSIPPairInput {
 	dnsName: String!
-	ip: String
+	ips: [String!]
 }
 
 type EdgeAccessStatus {
@@ -327,6 +352,35 @@ type Environment {
 	namespaces: [Namespace!]!
 	serviceCount: Int!
 	appliedIntentsCount: Int!
+}
+
+enum EventType {
+	INTENTS_DELETED
+	INTENTS_APPLIED
+	INTENTS_APPLIED_KAFKA
+	INTENTS_APPLIED_HTTP
+	INTENTS_APPLIED_DATABASE
+	INTENTS_DISCOVERED
+	INTENTS_DISCOVERED_SOCKET_SCAN
+	INTENTS_DISCOVERED_CAPTURE
+	INTENTS_DISCOVERED_KAFKA
+	INTENTS_DISCOVERED_ISTIO
+	MAPPER_EXPORT
+	MAPPER_VISUALIZE
+	KAFKA_SERVER_CONFIG_APPLIED
+	KAFKA_SERVER_CONFIG_DELETED
+	NETWORK_POLICIES_CREATED
+	NETWORK_POLICIES_DELETED
+	KAFKA_ACLS_CREATED
+	KAFKA_ACLS_DELETED
+	ISTIO_POLICIES_CREATED
+	ISTIO_POLICIES_DELETED
+	STARTED
+	SERVICE_DISCOVERED
+	NAMESPACE_DISCOVERED
+	PROTECTED_SERVICE_APPLIED
+	PROTECTED_SERVICE_DELETED
+	ACTIVE
 }
 
 type ExternalTrafficDiscoveredIntent {
@@ -754,6 +808,12 @@ type Mutation {
 		namespace: String!
 		services: [ProtectedServiceInput!]!
 	): Boolean!
+	sendTelemetries(
+		telemetries: [TelemetryInput!]!
+	): Boolean!
+	sendCLITelemetries(
+		telemetries: [CLITelemetry!]!
+	): Boolean!
 }
 
 type Namespace {
@@ -850,6 +910,9 @@ type Query {
 		clusterId: ID
 		name: String
 	): Integration!
+	testDatabaseConnection(
+		databaseInfo: DatabaseInfoInput!
+	): TestDatabaseConnectionResponse!
 """List user invites"""
 	invites(
 		email: String
@@ -1014,6 +1077,28 @@ enum ServiceType {
 	KAFKA
 	AWS
 	DATABASE
+}
+
+enum TelemetryComponentType {
+	INTENTS_OPERATOR
+	CREDENTIALS_OPERATOR
+	NETWORK_MAPPER
+	CLI
+}
+
+input TelemetryData {
+	eventType: EventType!
+	count: Int
+}
+
+input TelemetryInput {
+	component: Component!
+	data: TelemetryData!
+}
+
+type TestDatabaseConnectionResponse {
+	success: Boolean!
+	errorMessage: String!
 }
 
 scalar Time

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -37,6 +37,7 @@ type AccessGraphEdge {
 	client: Service!
 	server: Service!
 	discoveredIntents: [Intent!]!
+	externalTrafficDiscoveredIntents: [ExternalTrafficIntent!]!
 	appliedIntents: [Intent!]!
 	accessStatus: EdgeAccessStatus!
 }
@@ -264,6 +265,16 @@ input DiscoveredIntentInput {
 	intent: IntentInput!
 }
 
+type DNSIPPair {
+	dnsName: String!
+	ip: String
+}
+
+input DNSIPPairInput {
+	dnsName: String!
+	ip: String
+}
+
 type EdgeAccessStatus {
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
@@ -316,6 +327,29 @@ type Environment {
 	namespaces: [Namespace!]!
 	serviceCount: Int!
 	appliedIntentsCount: Int!
+}
+
+type ExternalTrafficDiscoveredIntent {
+	discoveredAt: Time!
+	intent: ExternalTrafficIntent!
+}
+
+input ExternalTrafficDiscoveredIntentInput {
+	discoveredAt: Time!
+	intent: ExternalTrafficIntentInput!
+}
+
+type ExternalTrafficIntent {
+	id: ID!
+	server: Service!
+	client: Service!
+	target: DNSIPPair!
+}
+
+input ExternalTrafficIntentInput {
+	namespace: String!
+	clientName: String!
+	target: DNSIPPairInput!
 }
 
 type HTTPConfig {
@@ -662,6 +696,9 @@ type Mutation {
 	): Boolean!
 	reportDiscoveredIntents(
 		intents: [DiscoveredIntentInput!]!
+	): Boolean!
+	reportExternalTrafficDiscoveredIntents(
+		intents: [ExternalTrafficDiscoveredIntentInput!]!
 	): Boolean!
 	reportAppliedKubernetesIntents(
 		namespace: String!

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -2,7 +2,7 @@ package clouduploader
 
 import (
 	"context"
-	"github.com/otterize/network-mapper/src/mapper/pkg/resolvers"
+	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -71,7 +71,7 @@ func (c *CloudUploader) NotifyIntents(ctx context.Context, intents []intentsstor
 	}
 }
 
-func (c *CloudUploader) NotifyExternalTrafficIntents(ctx context.Context, intents []resolvers.TimestampedExternalTrafficIntent) {
+func (c *CloudUploader) NotifyExternalTrafficIntents(ctx context.Context, intents []externaltrafficholder.TimestampedExternalTrafficIntent) {
 	if len(intents) == 0 {
 		return
 	}
@@ -79,7 +79,7 @@ func (c *CloudUploader) NotifyExternalTrafficIntents(ctx context.Context, intent
 	logrus.Debugf("Got external traffic notification, len %d", len(intents))
 	//logrus.Debugf("Saw external traffic, from '%s.%s' to '%s' (IP '%s')", srcSvcIdentity.Name, srcSvcIdentity.Namespace, dest.Destination, ip)
 
-	discoveredIntents := lo.Map(intents, func(intent resolvers.TimestampedExternalTrafficIntent, _ int) cloudclient.ExternalTrafficDiscoveredIntentInput {
+	discoveredIntents := lo.Map(intents, func(intent externaltrafficholder.TimestampedExternalTrafficIntent, _ int) cloudclient.ExternalTrafficDiscoveredIntentInput {
 		output := cloudclient.ExternalTrafficDiscoveredIntentInput{
 			DiscoveredAt: intent.Timestamp,
 			Intent: cloudclient.ExternalTrafficIntentInput{

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -2,6 +2,7 @@ package clouduploader
 
 import (
 	"context"
+	"github.com/otterize/network-mapper/src/mapper/pkg/resolvers"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -26,8 +27,10 @@ func NewCloudUploader(intentsHolder *intentsstore.IntentsHolder, config Config, 
 	}
 }
 
-func (c *CloudUploader) GetIntentCallback(ctx context.Context, intents []intentsstore.TimestampedIntent) {
-	logrus.Info("Search for intents")
+func (c *CloudUploader) NotifyIntents(ctx context.Context, intents []intentsstore.TimestampedIntent) {
+	if len(intents) == 0 {
+		return
+	}
 
 	discoveredIntents := lo.Map(intents, func(intent intentsstore.TimestampedIntent, _ int) *cloudclient.DiscoveredIntentInput {
 		return &cloudclient.DiscoveredIntentInput{
@@ -48,10 +51,6 @@ func (c *CloudUploader) GetIntentCallback(ctx context.Context, intents []intents
 		}
 	})
 
-	if len(discoveredIntents) == 0 {
-		return
-	}
-
 	exponentialBackoff := backoff.NewExponentialBackOff()
 
 	discoveredIntentsChunks := lo.Chunk(discoveredIntents, c.config.UploadBatchSize)
@@ -59,6 +58,51 @@ func (c *CloudUploader) GetIntentCallback(ctx context.Context, intents []intents
 	err := backoff.Retry(func() error {
 		for currentChunk < len(discoveredIntentsChunks) {
 			err := c.client.ReportDiscoveredIntents(ctx, discoveredIntentsChunks[currentChunk])
+			if err != nil {
+				logrus.WithError(err).Errorf("Failed to report discovered intents chunk %d to cloud, retrying", currentChunk)
+				return err
+			}
+			currentChunk += 1
+		}
+		return nil
+	}, exponentialBackoff)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to report discovered intents to cloud, giving up after 10 retries")
+	}
+}
+
+func (c *CloudUploader) NotifyExternalTrafficIntents(ctx context.Context, intents []resolvers.TimestampedExternalTrafficIntent) {
+	if len(intents) == 0 {
+		return
+	}
+
+	logrus.Debugf("Got external traffic notification, len %d", len(intents))
+	//logrus.Debugf("Saw external traffic, from '%s.%s' to '%s' (IP '%s')", srcSvcIdentity.Name, srcSvcIdentity.Namespace, dest.Destination, ip)
+
+	discoveredIntents := lo.Map(intents, func(intent resolvers.TimestampedExternalTrafficIntent, _ int) cloudclient.ExternalTrafficDiscoveredIntentInput {
+		output := cloudclient.ExternalTrafficDiscoveredIntentInput{
+			DiscoveredAt: intent.Timestamp,
+			Intent: cloudclient.ExternalTrafficIntentInput{
+				ClientName: intent.Intent.Client.Name,
+				Namespace:  intent.Intent.Client.Namespace,
+				Target: cloudclient.DNSIPPairInput{
+					DnsName: intent.Intent.DNSName,
+				},
+			},
+		}
+		for ip := range intent.Intent.IPs {
+			output.Intent.Target.Ips = append(output.Intent.Target.Ips, string(ip))
+		}
+		return output
+	})
+
+	exponentialBackoff := backoff.NewExponentialBackOff()
+
+	discoveredIntentsChunks := lo.Chunk(discoveredIntents, c.config.UploadBatchSize)
+	currentChunk := 0
+	err := backoff.Retry(func() error {
+		for currentChunk < len(discoveredIntentsChunks) {
+			err := c.client.ReportExternalTrafficDiscoveredIntents(ctx, discoveredIntentsChunks[currentChunk])
 			if err != nil {
 				logrus.WithError(err).Errorf("Failed to report discovered intents chunk %d to cloud, retrying", currentChunk)
 				return err

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -77,7 +77,6 @@ func (c *CloudUploader) NotifyExternalTrafficIntents(ctx context.Context, intent
 	}
 
 	logrus.Debugf("Got external traffic notification, len %d", len(intents))
-	//logrus.Debugf("Saw external traffic, from '%s.%s' to '%s' (IP '%s')", srcSvcIdentity.Name, srcSvcIdentity.Namespace, dest.Destination, ip)
 
 	discoveredIntents := lo.Map(intents, func(intent externaltrafficholder.TimestampedExternalTrafficIntent, _ int) cloudclient.ExternalTrafficDiscoveredIntentInput {
 		output := cloudclient.ExternalTrafficDiscoveredIntentInput{

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -78,7 +78,7 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents1)).Return(nil).Times(1)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 
 	s.addIntent("client2", s.testNamespace, "server1", s.testNamespace)
 
@@ -88,7 +88,7 @@ func (s *CloudUploaderTestSuite) TestUploadIntents() {
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents2)).Return(nil).Times(1)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 }
 
 func (s *CloudUploaderTestSuite) TestUploadIntentsWithOperations() {
@@ -141,7 +141,7 @@ func (s *CloudUploaderTestSuite) TestUploadIntentsWithOperations() {
 	}
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(cloudIntent)).Return(nil).Times(1)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 
 	newTimestamp := testTimestamp.Add(time.Hour)
 	s.intentsHolder.AddIntent(newTimestamp, discoveredProduce)
@@ -166,7 +166,7 @@ func (s *CloudUploaderTestSuite) TestUploadIntentsWithOperations() {
 	}
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(produceOnly)).Return(nil).Times(1)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 }
 
 func (s *CloudUploaderTestSuite) TestUploadIntentsInBatches() {
@@ -183,13 +183,13 @@ func (s *CloudUploaderTestSuite) TestUploadIntentsInBatches() {
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher([]cloudclient.IntentInput{intents1[0]})).Return(nil).Times(1)
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher([]cloudclient.IntentInput{intents1[1]})).Return(nil).Times(1)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 }
 
 func (s *CloudUploaderTestSuite) TestDontUploadWithoutIntents() {
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), gomock.Any()).Times(0)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 }
 
 func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
@@ -201,11 +201,11 @@ func (s *CloudUploaderTestSuite) TestUploadSameIntentOnce() {
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents)).Return(nil).Times(1)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents)).Return(nil).Times(1)
 	s.addIntent("client", s.testNamespace, "server", s.testNamespace)
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 }
 
 func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
@@ -219,7 +219,7 @@ func (s *CloudUploaderTestSuite) TestRetryOnFailed() {
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents)).Return(nil).Times(1)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 }
 
 func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
@@ -231,8 +231,8 @@ func (s *CloudUploaderTestSuite) TestDontUploadWhenNothingNew() {
 
 	s.clientMock.EXPECT().ReportDiscoveredIntents(gomock.Any(), GetMatcher(intents)).Return(nil).Times(1)
 
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
-	s.cloudUploader.GetIntentCallback(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
+	s.cloudUploader.NotifyIntents(context.Background(), s.intentsHolder.GetNewIntentsSinceLastGet())
 }
 
 func (s *CloudUploaderTestSuite) TestReportMapperComponent() {

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -8,19 +8,21 @@ import (
 )
 
 const (
-	ClusterDomainKey             = "cluster-domain"
-	ClusterDomainDefault         = kubeutils.DefaultClusterDomain
-	CloudApiAddrKey              = "api-address"
-	CloudApiAddrDefault          = "https://app.otterize.com/api"
-	UploadIntervalSecondsKey     = "upload-interval-seconds"
-	UploadIntervalSecondsDefault = 60
-	UploadBatchSizeKey           = "upload-batch-size"
-	UploadBatchSizeDefault       = 500
-	ExcludedNamespacesKey        = "exclude-namespaces"
-	OTelEnabledKey               = "enable-otel-export"
-	OTelEnabledDefault           = false
-	OTelMetricKey                = "otel-metric-name"
-	OTelMetricDefault            = "traces_service_graph_request_total" // same as expected in otel-collector-contrib's servicegraphprocessor
+	ClusterDomainKey                     = "cluster-domain"
+	ClusterDomainDefault                 = kubeutils.DefaultClusterDomain
+	CloudApiAddrKey                      = "api-address"
+	CloudApiAddrDefault                  = "https://app.otterize.com/api"
+	UploadIntervalSecondsKey             = "upload-interval-seconds"
+	UploadIntervalSecondsDefault         = 60
+	UploadBatchSizeKey                   = "upload-batch-size"
+	UploadBatchSizeDefault               = 500
+	ExcludedNamespacesKey                = "exclude-namespaces"
+	OTelEnabledKey                       = "enable-otel-export"
+	OTelEnabledDefault                   = false
+	OTelMetricKey                        = "otel-metric-name"
+	OTelMetricDefault                    = "traces_service_graph_request_total" // same as expected in otel-collector-contrib's servicegraphprocessor
+	ExternalTrafficCaptureEnabledKey     = "capture-external-traffic-enabled"
+	ExternalTrafficCaptureEnabledDefault = true // FIXME change to false
 )
 
 var excludedNamespaces *goset.Set[string]
@@ -37,5 +39,6 @@ func init() {
 	viper.SetDefault(UploadBatchSizeKey, UploadBatchSizeDefault)
 	viper.SetDefault(OTelEnabledKey, OTelEnabledDefault)
 	viper.SetDefault(OTelMetricKey, OTelMetricDefault)
+	viper.SetDefault(ExternalTrafficCaptureEnabledKey, ExternalTrafficCaptureEnabledDefault)
 	excludedNamespaces = goset.FromSlice(viper.GetStringSlice(ExcludedNamespacesKey))
 }

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -22,7 +22,7 @@ const (
 	OTelMetricKey                        = "otel-metric-name"
 	OTelMetricDefault                    = "traces_service_graph_request_total" // same as expected in otel-collector-contrib's servicegraphprocessor
 	ExternalTrafficCaptureEnabledKey     = "capture-external-traffic-enabled"
-	ExternalTrafficCaptureEnabledDefault = true // FIXME change to false
+	ExternalTrafficCaptureEnabledDefault = false
 )
 
 var excludedNamespaces *goset.Set[string]

--- a/src/mapper/pkg/externaltrafficholder/externaltrafficholder.go
+++ b/src/mapper/pkg/externaltrafficholder/externaltrafficholder.go
@@ -1,0 +1,121 @@
+package externaltrafficholder
+
+import (
+	"context"
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
+	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
+	"github.com/sirupsen/logrus"
+	"sync"
+	"time"
+)
+
+type IP string
+
+type ExternalTrafficIntent struct {
+	Client   model.OtterizeServiceIdentity `json:"client"`
+	LastSeen time.Time
+	DNSName  string
+	IPs      map[IP]struct{}
+}
+
+type TimestampedExternalTrafficIntent struct {
+	Timestamp time.Time
+	Intent    ExternalTrafficIntent
+}
+
+type ExternalTrafficKey struct {
+	ClientName      string
+	ClientNamespace string
+	DestDNSName     string
+}
+
+type ExternalTrafficIntentsHolder struct {
+	intents   map[ExternalTrafficKey]TimestampedExternalTrafficIntent
+	lock      sync.Mutex
+	callbacks []ExternalTrafficCallbackFunc
+}
+
+type ExternalTrafficCallbackFunc func(context.Context, []TimestampedExternalTrafficIntent)
+
+func NewExternalTrafficIntentsHolder() *ExternalTrafficIntentsHolder {
+	return &ExternalTrafficIntentsHolder{
+		intents: make(map[ExternalTrafficKey]TimestampedExternalTrafficIntent),
+	}
+}
+
+func (h *ExternalTrafficIntentsHolder) RegisterNotifyIntents(callback ExternalTrafficCallbackFunc) {
+	h.callbacks = append(h.callbacks, callback)
+}
+
+func (h *ExternalTrafficIntentsHolder) PeriodicIntentsUpload(ctx context.Context, interval time.Duration) {
+	logrus.Info("Starting periodic external traffic intents upload")
+
+	for {
+		select {
+		case <-time.After(interval):
+			if len(h.callbacks) == 0 {
+				continue
+			}
+
+			intents := h.GetNewIntentsSinceLastGet()
+			if len(intents) == 0 {
+				continue
+			}
+			for _, callback := range h.callbacks {
+				callback(ctx, intents)
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (h *ExternalTrafficIntentsHolder) GetNewIntentsSinceLastGet() []TimestampedExternalTrafficIntent {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	intents := make([]TimestampedExternalTrafficIntent, 0, len(h.intents))
+
+	for _, intent := range h.intents {
+		intents = append(intents, intent)
+	}
+
+	h.intents = make(map[ExternalTrafficKey]TimestampedExternalTrafficIntent)
+
+	return intents
+}
+
+func (h *ExternalTrafficIntentsHolder) AddIntent(intent ExternalTrafficIntent) {
+	if config.ExcludedNamespaces().Contains(intent.Client.Namespace) {
+		return
+	}
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	key := ExternalTrafficKey{
+		ClientName:      intent.Client.Name,
+		ClientNamespace: intent.Client.Namespace,
+		DestDNSName:     intent.DNSName,
+	}
+	_, ok := h.intents[key]
+	if !ok {
+		h.intents[key] = TimestampedExternalTrafficIntent{
+			Timestamp: intent.LastSeen,
+			Intent:    intent,
+		}
+		return
+	}
+
+	mergedIntent := h.intents[key]
+
+	for ip := range intent.IPs {
+		mergedIntent.Intent.IPs[ip] = struct{}{}
+	}
+	if intent.LastSeen.After(mergedIntent.Timestamp) {
+		mergedIntent.Timestamp = intent.LastSeen
+	}
+
+	h.intents[key] = mergedIntent
+}

--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -431,6 +431,8 @@ var sources = []*ast.Source{
 input Destination {
     # Could be either IP addr or hostname
     destination: String!
+    # If destination is a hostname, this _may_ be the IP it resolves to if it is known, but is not required.
+    destinationIP: String
     lastSeen: Time!
 }
 
@@ -3122,6 +3124,14 @@ func (ec *executionContext) unmarshalInputDestination(ctx context.Context, obj i
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("destination"))
 			it.Destination, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "destinationIP":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("destinationIP"))
+			it.DestinationIP, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -14,8 +14,9 @@ type CaptureResults struct {
 }
 
 type Destination struct {
-	Destination string    `json:"destination"`
-	LastSeen    time.Time `json:"lastSeen"`
+	Destination   string    `json:"destination"`
+	DestinationIP *string   `json:"destinationIP"`
+	LastSeen      time.Time `json:"lastSeen"`
 }
 
 type GroupVersionKind struct {

--- a/src/mapper/pkg/intentsstore/holder.go
+++ b/src/mapper/pkg/intentsstore/holder.go
@@ -157,12 +157,12 @@ func (i *IntentsHolder) addIntentToStore(store IntentsStore, newTimestamp time.T
 	store[key] = existingIntent
 }
 
-func (i *IntentsHolder) PeriodicIntentsUpload(ctx context.Context, d time.Duration) {
+func (i *IntentsHolder) PeriodicIntentsUpload(ctx context.Context, interval time.Duration) {
 	logrus.Info("Starting periodic intents upload")
 
 	for {
 		select {
-		case <-time.After(d):
+		case <-time.After(interval):
 			if len(i.callbacks) == 0 {
 				return
 			}
@@ -178,7 +178,7 @@ func (i *IntentsHolder) PeriodicIntentsUpload(ctx context.Context, d time.Durati
 	}
 }
 
-func (i *IntentsHolder) RegisterGetCallback(callback func(context.Context, []TimestampedIntent)) {
+func (i *IntentsHolder) RegisterNotifyIntents(callback func(context.Context, []TimestampedIntent)) {
 	i.callbacks = append(i.callbacks, callback)
 }
 

--- a/src/mapper/pkg/metricexporter/metric_exporter.go
+++ b/src/mapper/pkg/metricexporter/metric_exporter.go
@@ -22,7 +22,7 @@ func NewMetricExporter(ctx context.Context) (*MetricExporter, error) {
 	}, nil
 }
 
-func (o *MetricExporter) GetIntentCallback(ctx context.Context, intents []intentsstore.TimestampedIntent) {
+func (o *MetricExporter) NotifyIntents(ctx context.Context, intents []intentsstore.TimestampedIntent) {
 	for _, intent := range intents {
 		clientName := intent.Intent.Client.Name
 		serverName := intent.Intent.Server.Name

--- a/src/mapper/pkg/metricexporter/metric_exporter_test.go
+++ b/src/mapper/pkg/metricexporter/metric_exporter_test.go
@@ -52,7 +52,7 @@ func (o *MetricExporterTestSuite) TestExportIntents() {
 	o.addIntent("client1", o.testNamespace, "server2", "external-namespace")
 	o.edgeMock.EXPECT().Record(context.Background(), "client1", "server1").Times(1)
 	o.edgeMock.EXPECT().Record(context.Background(), "client1", "server2").Times(1)
-	o.metricExporter.GetIntentCallback(context.Background(), o.intentsHolder.GetNewIntentsSinceLastGet())
+	o.metricExporter.NotifyIntents(context.Background(), o.intentsHolder.GetNewIntentsSinceLastGet())
 }
 
 func TestRunSuite(t *testing.T) {

--- a/src/mapper/pkg/resolvers/resolver.go
+++ b/src/mapper/pkg/resolvers/resolver.go
@@ -1,12 +1,18 @@
 package resolvers
 
 import (
+	"context"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/generated"
+	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/otterize/network-mapper/src/mapper/pkg/intentsstore"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
+	"github.com/sirupsen/logrus"
+	"sync"
+	"time"
 )
 
 // This file will not be regenerated automatically.
@@ -14,16 +20,129 @@ import (
 // It serves as dependency injection for your app, add any dependencies you require here.
 
 type Resolver struct {
-	kubeFinder        *kubefinder.KubeFinder
-	serviceIdResolver *serviceidresolver.Resolver
-	intentsHolder     *intentsstore.IntentsHolder
+	kubeFinder                   *kubefinder.KubeFinder
+	serviceIdResolver            *serviceidresolver.Resolver
+	intentsHolder                *intentsstore.IntentsHolder
+	externalTrafficIntentsHolder *ExternalTrafficIntentsHolder
 }
 
-func NewResolver(kubeFinder *kubefinder.KubeFinder, serviceIdResolver *serviceidresolver.Resolver, intentsHolder *intentsstore.IntentsHolder) *Resolver {
+type IP string
+
+type ExternalTrafficIntent struct {
+	Client   model.OtterizeServiceIdentity `json:"client"`
+	LastSeen time.Time
+	DNSName  string
+	IPs      map[IP]struct{}
+}
+
+type TimestampedExternalTrafficIntent struct {
+	Timestamp time.Time
+	Intent    ExternalTrafficIntent
+}
+
+type ExternalTrafficKey struct {
+	ClientName      string
+	ClientNamespace string
+	DestDNSName     string
+}
+
+type ExternalTrafficIntentsHolder struct {
+	intents   map[ExternalTrafficKey]TimestampedExternalTrafficIntent
+	lock      sync.Mutex
+	callbacks []ExternalTrafficCallbackFunc
+}
+
+type ExternalTrafficCallbackFunc func(context.Context, []TimestampedExternalTrafficIntent)
+
+func NewExternalTrafficIntentsHolder() *ExternalTrafficIntentsHolder {
+	return &ExternalTrafficIntentsHolder{
+		intents: make(map[ExternalTrafficKey]TimestampedExternalTrafficIntent),
+	}
+}
+
+func (h *ExternalTrafficIntentsHolder) RegisterNotifyIntents(callback ExternalTrafficCallbackFunc) {
+	h.callbacks = append(h.callbacks, callback)
+}
+
+func (h *ExternalTrafficIntentsHolder) PeriodicIntentsUpload(ctx context.Context, interval time.Duration) {
+	logrus.Info("Starting periodic external traffic intents upload")
+
+	for {
+		select {
+		case <-time.After(interval):
+			if len(h.callbacks) == 0 {
+				continue
+			}
+
+			intents := h.GetNewIntentsSinceLastGet()
+			if len(intents) == 0 {
+				continue
+			}
+			for _, callback := range h.callbacks {
+				callback(ctx, intents)
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (h *ExternalTrafficIntentsHolder) GetNewIntentsSinceLastGet() []TimestampedExternalTrafficIntent {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	intents := make([]TimestampedExternalTrafficIntent, 0, len(h.intents))
+
+	for _, intent := range h.intents {
+		intents = append(intents, intent)
+	}
+
+	h.intents = make(map[ExternalTrafficKey]TimestampedExternalTrafficIntent)
+
+	return intents
+}
+
+func (h *ExternalTrafficIntentsHolder) AddIntent(intent ExternalTrafficIntent) {
+	if config.ExcludedNamespaces().Contains(intent.Client.Namespace) {
+		return
+	}
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	key := ExternalTrafficKey{
+		ClientName:      intent.Client.Name,
+		ClientNamespace: intent.Client.Namespace,
+		DestDNSName:     intent.DNSName,
+	}
+	_, ok := h.intents[key]
+	if !ok {
+		h.intents[key] = TimestampedExternalTrafficIntent{
+			Timestamp: intent.LastSeen,
+			Intent:    intent,
+		}
+		return
+	}
+
+	mergedIntent := h.intents[key]
+
+	for ip := range intent.IPs {
+		mergedIntent.Intent.IPs[ip] = struct{}{}
+	}
+	if intent.LastSeen.After(mergedIntent.Timestamp) {
+		mergedIntent.Timestamp = intent.LastSeen
+	}
+
+	h.intents[key] = mergedIntent
+}
+
+func NewResolver(kubeFinder *kubefinder.KubeFinder, serviceIdResolver *serviceidresolver.Resolver, intentsHolder *intentsstore.IntentsHolder, externalTrafficHolder *ExternalTrafficIntentsHolder) *Resolver {
 	return &Resolver{
-		kubeFinder:        kubeFinder,
-		serviceIdResolver: serviceIdResolver,
-		intentsHolder:     intentsHolder,
+		kubeFinder:                   kubeFinder,
+		serviceIdResolver:            serviceIdResolver,
+		intentsHolder:                intentsHolder,
+		externalTrafficIntentsHolder: externalTrafficHolder,
 	}
 }
 

--- a/src/mapper/pkg/resolvers/resolver.go
+++ b/src/mapper/pkg/resolvers/resolver.go
@@ -1,18 +1,13 @@
 package resolvers
 
 import (
-	"context"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
-	"github.com/otterize/network-mapper/src/mapper/pkg/config"
+	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/generated"
-	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/otterize/network-mapper/src/mapper/pkg/intentsstore"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
-	"github.com/sirupsen/logrus"
-	"sync"
-	"time"
 )
 
 // This file will not be regenerated automatically.
@@ -23,121 +18,10 @@ type Resolver struct {
 	kubeFinder                   *kubefinder.KubeFinder
 	serviceIdResolver            *serviceidresolver.Resolver
 	intentsHolder                *intentsstore.IntentsHolder
-	externalTrafficIntentsHolder *ExternalTrafficIntentsHolder
+	externalTrafficIntentsHolder *externaltrafficholder.ExternalTrafficIntentsHolder
 }
 
-type IP string
-
-type ExternalTrafficIntent struct {
-	Client   model.OtterizeServiceIdentity `json:"client"`
-	LastSeen time.Time
-	DNSName  string
-	IPs      map[IP]struct{}
-}
-
-type TimestampedExternalTrafficIntent struct {
-	Timestamp time.Time
-	Intent    ExternalTrafficIntent
-}
-
-type ExternalTrafficKey struct {
-	ClientName      string
-	ClientNamespace string
-	DestDNSName     string
-}
-
-type ExternalTrafficIntentsHolder struct {
-	intents   map[ExternalTrafficKey]TimestampedExternalTrafficIntent
-	lock      sync.Mutex
-	callbacks []ExternalTrafficCallbackFunc
-}
-
-type ExternalTrafficCallbackFunc func(context.Context, []TimestampedExternalTrafficIntent)
-
-func NewExternalTrafficIntentsHolder() *ExternalTrafficIntentsHolder {
-	return &ExternalTrafficIntentsHolder{
-		intents: make(map[ExternalTrafficKey]TimestampedExternalTrafficIntent),
-	}
-}
-
-func (h *ExternalTrafficIntentsHolder) RegisterNotifyIntents(callback ExternalTrafficCallbackFunc) {
-	h.callbacks = append(h.callbacks, callback)
-}
-
-func (h *ExternalTrafficIntentsHolder) PeriodicIntentsUpload(ctx context.Context, interval time.Duration) {
-	logrus.Info("Starting periodic external traffic intents upload")
-
-	for {
-		select {
-		case <-time.After(interval):
-			if len(h.callbacks) == 0 {
-				continue
-			}
-
-			intents := h.GetNewIntentsSinceLastGet()
-			if len(intents) == 0 {
-				continue
-			}
-			for _, callback := range h.callbacks {
-				callback(ctx, intents)
-			}
-
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (h *ExternalTrafficIntentsHolder) GetNewIntentsSinceLastGet() []TimestampedExternalTrafficIntent {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
-	intents := make([]TimestampedExternalTrafficIntent, 0, len(h.intents))
-
-	for _, intent := range h.intents {
-		intents = append(intents, intent)
-	}
-
-	h.intents = make(map[ExternalTrafficKey]TimestampedExternalTrafficIntent)
-
-	return intents
-}
-
-func (h *ExternalTrafficIntentsHolder) AddIntent(intent ExternalTrafficIntent) {
-	if config.ExcludedNamespaces().Contains(intent.Client.Namespace) {
-		return
-	}
-
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
-	key := ExternalTrafficKey{
-		ClientName:      intent.Client.Name,
-		ClientNamespace: intent.Client.Namespace,
-		DestDNSName:     intent.DNSName,
-	}
-	_, ok := h.intents[key]
-	if !ok {
-		h.intents[key] = TimestampedExternalTrafficIntent{
-			Timestamp: intent.LastSeen,
-			Intent:    intent,
-		}
-		return
-	}
-
-	mergedIntent := h.intents[key]
-
-	for ip := range intent.IPs {
-		mergedIntent.Intent.IPs[ip] = struct{}{}
-	}
-	if intent.LastSeen.After(mergedIntent.Timestamp) {
-		mergedIntent.Timestamp = intent.LastSeen
-	}
-
-	h.intents[key] = mergedIntent
-}
-
-func NewResolver(kubeFinder *kubefinder.KubeFinder, serviceIdResolver *serviceidresolver.Resolver, intentsHolder *intentsstore.IntentsHolder, externalTrafficHolder *ExternalTrafficIntentsHolder) *Resolver {
+func NewResolver(kubeFinder *kubefinder.KubeFinder, serviceIdResolver *serviceidresolver.Resolver, intentsHolder *intentsstore.IntentsHolder, externalTrafficHolder *externaltrafficholder.ExternalTrafficIntentsHolder) *Resolver {
 	return &Resolver{
 		kubeFinder:                   kubeFinder,
 		serviceIdResolver:            serviceIdResolver,

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/intentsstore"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/resolvers/test_gql_client"
@@ -23,7 +24,7 @@ type ResolverTestSuite struct {
 	client                       graphql.Client
 	kubeFinder                   *kubefinder.KubeFinder
 	intentsHolder                *intentsstore.IntentsHolder
-	externalTrafficIntentsHolder *ExternalTrafficIntentsHolder
+	externalTrafficIntentsHolder *externaltrafficholder.ExternalTrafficIntentsHolder
 }
 
 func (s *ResolverTestSuite) SetupTest() {
@@ -33,7 +34,7 @@ func (s *ResolverTestSuite) SetupTest() {
 	s.kubeFinder, err = kubefinder.NewKubeFinder(context.Background(), s.Mgr)
 	s.Require().NoError(err)
 	s.intentsHolder = intentsstore.NewIntentsHolder()
-	s.externalTrafficIntentsHolder = NewExternalTrafficIntentsHolder()
+	s.externalTrafficIntentsHolder = externaltrafficholder.NewExternalTrafficIntentsHolder()
 	resolver := NewResolver(s.kubeFinder, serviceidresolver.NewResolver(s.Mgr.GetClient()), s.intentsHolder, s.externalTrafficIntentsHolder)
 	resolver.Register(e)
 	s.server = httptest.NewServer(e)

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -19,10 +19,11 @@ import (
 
 type ResolverTestSuite struct {
 	testbase.ControllerManagerTestSuiteBase
-	server        *httptest.Server
-	client        graphql.Client
-	kubeFinder    *kubefinder.KubeFinder
-	intentsHolder *intentsstore.IntentsHolder
+	server                       *httptest.Server
+	client                       graphql.Client
+	kubeFinder                   *kubefinder.KubeFinder
+	intentsHolder                *intentsstore.IntentsHolder
+	externalTrafficIntentsHolder *ExternalTrafficIntentsHolder
 }
 
 func (s *ResolverTestSuite) SetupTest() {
@@ -32,7 +33,8 @@ func (s *ResolverTestSuite) SetupTest() {
 	s.kubeFinder, err = kubefinder.NewKubeFinder(context.Background(), s.Mgr)
 	s.Require().NoError(err)
 	s.intentsHolder = intentsstore.NewIntentsHolder()
-	resolver := NewResolver(s.kubeFinder, serviceidresolver.NewResolver(s.Mgr.GetClient()), s.intentsHolder)
+	s.externalTrafficIntentsHolder = NewExternalTrafficIntentsHolder()
+	resolver := NewResolver(s.kubeFinder, serviceidresolver.NewResolver(s.Mgr.GetClient()), s.intentsHolder, s.externalTrafficIntentsHolder)
 	resolver.Register(e)
 	s.server = httptest.NewServer(e)
 	s.client = graphql.NewClient(s.server.URL+"/query", s.server.Client())

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
 	"github.com/otterize/network-mapper/src/mapper/pkg/config"
+	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/prometheus"
@@ -147,7 +148,7 @@ func (r *mutationResolver) handleDNSCaptureResultsAsExternalTraffic(_ context.Co
 	if !viper.GetBool(config.ExternalTrafficCaptureEnabledKey) {
 		return nil
 	}
-	intent := ExternalTrafficIntent{
+	intent := externaltrafficholder.ExternalTrafficIntent{
 		Client:   srcSvcIdentity,
 		LastSeen: dest.LastSeen,
 		DNSName:  dest.Destination,
@@ -155,7 +156,7 @@ func (r *mutationResolver) handleDNSCaptureResultsAsExternalTraffic(_ context.Co
 	ip := "(unknown)"
 	if dest.DestinationIP != nil {
 		ip = *dest.DestinationIP
-		intent.IPs = map[IP]struct{}{IP(*dest.DestinationIP): {}}
+		intent.IPs = map[externaltrafficholder.IP]struct{}{externaltrafficholder.IP(*dest.DestinationIP): {}}
 	}
 	logrus.Debugf("Saw external traffic, from '%s.%s' to '%s' (IP '%s')", srcSvcIdentity.Name, srcSvcIdentity.Namespace, dest.Destination, ip)
 

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -142,11 +142,19 @@ func (r *mutationResolver) addSocketScanPodIntent(ctx context.Context, srcSvcIde
 }
 
 func (r *mutationResolver) handleDNSCaptureResultsAsExternalTraffic(_ context.Context, dest model.Destination, srcSvcIdentity model.OtterizeServiceIdentity) error {
+	intent := ExternalTrafficIntent{
+		Client:   srcSvcIdentity,
+		LastSeen: dest.LastSeen,
+		DNSName:  dest.Destination,
+	}
 	ip := "(unknown)"
 	if dest.DestinationIP != nil {
 		ip = *dest.DestinationIP
+		intent.IPs = map[IP]struct{}{IP(*dest.DestinationIP): {}}
 	}
 	logrus.Debugf("Saw external traffic, from '%s.%s' to '%s' (IP '%s')", srcSvcIdentity.Name, srcSvcIdentity.Namespace, dest.Destination, ip)
+
+	r.externalTrafficIntentsHolder.AddIntent(intent)
 	return nil
 }
 

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -142,7 +142,11 @@ func (r *mutationResolver) addSocketScanPodIntent(ctx context.Context, srcSvcIde
 }
 
 func (r *mutationResolver) handleDNSCaptureResultsAsExternalTraffic(_ context.Context, dest model.Destination, srcSvcIdentity model.OtterizeServiceIdentity) error {
-	logrus.Debugf("Saw external traffic, from '%s.%s' to '%s' (IP '%s')", srcSvcIdentity.Name, srcSvcIdentity.Namespace, dest.Destination, dest.DestinationIP)
+	ip := "(unknown)"
+	if dest.DestinationIP != nil {
+		ip = *dest.DestinationIP
+	}
+	logrus.Debugf("Saw external traffic, from '%s.%s' to '%s' (IP '%s')", srcSvcIdentity.Name, srcSvcIdentity.Namespace, dest.Destination, ip)
 	return nil
 }
 

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/prometheus"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -142,6 +144,9 @@ func (r *mutationResolver) addSocketScanPodIntent(ctx context.Context, srcSvcIde
 }
 
 func (r *mutationResolver) handleDNSCaptureResultsAsExternalTraffic(_ context.Context, dest model.Destination, srcSvcIdentity model.OtterizeServiceIdentity) error {
+	if !viper.GetBool(config.ExternalTrafficCaptureEnabledKey) {
+		return nil
+	}
 	intent := ExternalTrafficIntent{
 		Client:   srcSvcIdentity,
 		LastSeen: dest.LastSeen,

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -31,7 +31,7 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 	for _, captureItem := range results.Results {
 		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, captureItem)
 		if err != nil {
-			logrus.WithError(err).Errorf("could not discover src identity for '%s'", captureItem.SrcIP)
+			logrus.WithError(err).Debugf("could not discover src identity for '%s'", captureItem.SrcIP)
 			continue
 		}
 		for _, dest := range captureItem.Destinations {
@@ -44,6 +44,7 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 					continue
 				}
 				newResults++
+				continue
 			}
 
 			err := r.handleDNSCaptureResultsAsKubernetesPods(ctx, dest, srcSvcIdentity)

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -29,69 +29,28 @@ func (r *mutationResolver) ResetCapture(ctx context.Context) (bool, error) {
 func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results model.CaptureResults) (bool, error) {
 	var newResults int
 	for _, captureItem := range results.Results {
-		srcSvcIdentity := r.discoverSrcIdentity(ctx, captureItem)
-		if srcSvcIdentity == nil {
+		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, captureItem)
+		if err != nil {
+			logrus.WithError(err).Errorf("could not discover src identity for '%s'", captureItem.SrcIP)
 			continue
 		}
 		for _, dest := range captureItem.Destinations {
 			destAddress := dest.Destination
 			if !strings.HasSuffix(destAddress, viper.GetString(config.ClusterDomainKey)) {
 				// not a k8s service, ignore
-				continue
-			}
-			ips, serviceName, err := r.kubeFinder.ResolveServiceAddressToIps(ctx, destAddress)
-			if err != nil {
-				logrus.WithError(err).Warningf("Could not resolve service address %s", dest)
-				continue
-			}
-			if len(ips) == 0 {
-				logrus.Debugf("Service address %s is currently not backed by any pod, ignoring", dest)
-				continue
-			}
-			destPod, err := r.kubeFinder.ResolveIPToPod(ctx, ips[0])
-			if err != nil {
-				if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
-					logrus.WithError(err).Debugf("Ip %s belongs to more than one pod, ignoring", ips[0])
-				} else {
-					logrus.WithError(err).Debugf("Could not resolve %s to pod", ips[0])
+				err := r.handleDNSCaptureResultsAsExternalTraffic(ctx, dest, srcSvcIdentity)
+				if err != nil {
+					logrus.WithError(err).Error("could not handle DNS capture result as external traffic")
+					continue
 				}
-				continue
+				newResults++
 			}
 
-			if destPod.CreationTimestamp.After(dest.LastSeen) {
-				logrus.Debugf("Pod %s was created after capture time %s, ignoring", destPod.Name, dest.LastSeen)
-				continue
-			}
-
-			if destPod.DeletionTimestamp != nil {
-				logrus.Debugf("Pod %s is being deleted, ignoring", destPod.Name)
-				continue
-			}
-
-			dstService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, destPod)
+			err := r.handleDNSCaptureResultsAsKubernetesPods(ctx, dest, srcSvcIdentity)
 			if err != nil {
-				logrus.WithError(err).Debugf("Could not resolve pod %s to identity", destPod.Name)
+				logrus.WithError(err).Error("could not handle DNS capture result as pod")
 				continue
 			}
-
-			dstSvcIdentity := &model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: destPod.Namespace, Labels: podLabelsToOtterizeLabels(destPod)}
-			if dstService.OwnerObject != nil {
-				dstSvcIdentity.PodOwnerKind = model.GroupVersionKindFromKubeGVK(dstService.OwnerObject.GetObjectKind().GroupVersionKind())
-			}
-			if serviceName != "" {
-				dstSvcIdentity.KubernetesService = lo.ToPtr(serviceName)
-			}
-
-			intent := model.Intent{
-				Client: srcSvcIdentity,
-				Server: dstSvcIdentity,
-			}
-
-			updateTelemetriesCounters(SourceTypeDNSCapture, intent)
-			r.intentsHolder.AddIntent(
-				dest.LastSeen,
-				intent,
-			)
 			newResults++
 		}
 	}
@@ -102,8 +61,9 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 
 func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results model.SocketScanResults) (bool, error) {
 	for _, socketScanItem := range results.Results {
-		srcSvcIdentity := r.discoverSrcIdentity(ctx, socketScanItem)
-		if srcSvcIdentity == nil {
+		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, socketScanItem)
+		if err != nil {
+			logrus.WithError(err).Errorf("could not discover src identity for '%s'", socketScanItem.SrcIP)
 			continue
 		}
 		for _, dest := range socketScanItem.Destinations {

--- a/src/mapper/pkg/resolvers/test_gql_client/generated.go
+++ b/src/mapper/pkg/resolvers/test_gql_client/generated.go
@@ -17,12 +17,16 @@ type CaptureResults struct {
 func (v *CaptureResults) GetResults() []RecordedDestinationsForSrc { return v.Results }
 
 type Destination struct {
-	Destination string    `json:"destination"`
-	LastSeen    time.Time `json:"lastSeen"`
+	Destination   string    `json:"destination"`
+	DestinationIP string    `json:"destinationIP"`
+	LastSeen      time.Time `json:"lastSeen"`
 }
 
 // GetDestination returns Destination.Destination, and is useful for accessing the field via an interface.
 func (v *Destination) GetDestination() string { return v.Destination }
+
+// GetDestinationIP returns Destination.DestinationIP, and is useful for accessing the field via an interface.
+func (v *Destination) GetDestinationIP() string { return v.DestinationIP }
 
 // GetLastSeen returns Destination.LastSeen, and is useful for accessing the field via an interface.
 func (v *Destination) GetLastSeen() time.Time { return v.LastSeen }

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -3,6 +3,8 @@ scalar Time # Equivalent of Go's time.Time provided by gqlgen
 input Destination {
     # Could be either IP addr or hostname
     destination: String!
+    # If destination is a hostname, this _may_ be the IP it resolves to if it is known, but is not required.
+    destinationIP: String
     lastSeen: Time!
 }
 

--- a/src/sniffer/pkg/collectors/collector.go
+++ b/src/sniffer/pkg/collectors/collector.go
@@ -7,9 +7,10 @@ import (
 )
 
 type UniqueRequest struct {
-	srcIP       string
-	srcHostname string
-	dest        string // IP or hostname
+	srcIP            string
+	srcHostname      string
+	destHostnameOrIP string // IP or hostname
+	destIP           string
 }
 
 // For each unique request info, we store the time of the last request (no need to report duplicates)
@@ -23,8 +24,8 @@ func (c *NetworkCollector) resetData() {
 	c.capturedRequests = make(capturesMap)
 }
 
-func (c *NetworkCollector) addCapturedRequest(srcIp string, srcHost string, dest string, seenAt time.Time) {
-	req := UniqueRequest{srcIp, srcHost, dest}
+func (c *NetworkCollector) addCapturedRequest(srcIp string, srcHost string, destNameOrIP string, destIP string, seenAt time.Time) {
+	req := UniqueRequest{srcIp, srcHost, destNameOrIP, destIP}
 	c.capturedRequests[req] = seenAt
 }
 
@@ -41,7 +42,7 @@ func (c *NetworkCollector) CollectResults() []mapperclient.RecordedDestinationsF
 		if _, ok := srcToDests[src]; !ok {
 			srcToDests[src] = make([]mapperclient.Destination, 0)
 		}
-		srcToDests[src] = append(srcToDests[src], mapperclient.Destination{Destination: reqInfo.dest, LastSeen: reqLastSeen})
+		srcToDests[src] = append(srcToDests[src], mapperclient.Destination{Destination: reqInfo.destHostnameOrIP, DestinationIP: reqInfo.destIP, LastSeen: reqLastSeen})
 	}
 
 	results := make([]mapperclient.RecordedDestinationsForSrc, 0)

--- a/src/sniffer/pkg/collectors/dnssniffer.go
+++ b/src/sniffer/pkg/collectors/dnssniffer.go
@@ -12,10 +12,11 @@ import (
 )
 
 type pendingCapture struct {
-	srcIp       string
-	srcHostname string
-	dest        string
-	time        time.Time
+	srcIp            string
+	srcHostname      string
+	destHostnameOrIP string
+	destIPFromDNS    string // The destination IP, if it is known at the time of capture.
+	time             time.Time
 }
 
 type DNSSniffer struct {
@@ -69,7 +70,7 @@ func (s *DNSSniffer) HandlePacket(packet gopacket.Packet) {
 				} else {
 					// Resolver cache could be outdated, verify same resolving result after next poll
 					s.pending = append(s.pending, pendingCapture{
-						srcIp: ip.DstIP.String(), srcHostname: hostname, dest: string(answer.Name), time: captureTime,
+						srcIp: ip.DstIP.String(), srcHostname: hostname, destHostnameOrIP: string(answer.Name), destIPFromDNS: answer.IP.String(), time: captureTime,
 					})
 				}
 			}
@@ -93,7 +94,7 @@ func (s *DNSSniffer) RefreshHostsMapping() error {
 			logrus.Debugf("IP %s was resolved to %s, but now resolves to %s. skipping packet", p.srcIp, p.srcHostname, hostname)
 			continue
 		}
-		s.addCapturedRequest(p.srcIp, hostname, p.dest, p.time)
+		s.addCapturedRequest(p.srcIp, hostname, p.destHostnameOrIP, p.destIPFromDNS, p.time)
 	}
 	s.pending = make([]pendingCapture, 0)
 	s.lastRefresh = time.Now()

--- a/src/sniffer/pkg/collectors/dnssniffer_test.go
+++ b/src/sniffer/pkg/collectors/dnssniffer_test.go
@@ -31,19 +31,19 @@ func (s *SnifferTestSuite) TestHandlePacket() {
 	packet.Metadata().CaptureInfo.Timestamp = timestamp
 	sniffer.HandlePacket(packet)
 	_ = sniffer.RefreshHostsMapping()
-	time.Sleep(1 * time.Second)
 
-	s.Require().Equal(sniffer.CollectResults(), []mapperclient.RecordedDestinationsForSrc{
+	s.Require().Equal([]mapperclient.RecordedDestinationsForSrc{
 		{
 			SrcIp: "10.101.81.13",
 			Destinations: []mapperclient.Destination{
 				{
-					Destination: "sts.us-east-1.amazonaws.com",
-					LastSeen:    timestamp,
+					Destination:   "sts.us-east-1.amazonaws.com",
+					DestinationIP: "72.21.206.96",
+					LastSeen:      timestamp,
 				},
 			},
 		},
-	})
+	}, sniffer.CollectResults())
 }
 
 func TestDNSSnifferSuite(t *testing.T) {

--- a/src/sniffer/pkg/collectors/socketscanner.go
+++ b/src/sniffer/pkg/collectors/socketscanner.go
@@ -46,7 +46,7 @@ func (s *SocketScanner) scanTcpFile(hostname string, path string) {
 		// Only report sockets from the client-side by checking if the local port for this socket is the same port as a listen socket.
 		if _, isServersideSocket := listenPorts[sock.LocalAddr.Port]; !isServersideSocket {
 			// The hostname we have here is the hostname for the client.
-			s.addCapturedRequest(sock.LocalAddr.IP.String(), hostname, sock.RemoteAddr.IP.String(), time.Now())
+			s.addCapturedRequest(sock.LocalAddr.IP.String(), hostname, sock.RemoteAddr.IP.String(), sock.RemoteAddr.IP.String(), time.Now())
 		}
 	}
 }

--- a/src/sniffer/pkg/collectors/socketscanner_test.go
+++ b/src/sniffer/pkg/collectors/socketscanner_test.go
@@ -107,7 +107,8 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 			SrcHostname: "thisverypod",
 			Destinations: []mapperclient.Destination{
 				{
-					Destination: "10.98.14.179",
+					Destination:   "10.98.14.179",
+					DestinationIP: "10.98.14.179",
 				},
 			},
 		},
@@ -116,7 +117,8 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 			SrcHostname: "thisverypod",
 			Destinations: []mapperclient.Destination{
 				{
-					Destination: "207.168.35.14",
+					Destination:   "207.168.35.14",
+					DestinationIP: "207.168.35.14",
 				},
 			},
 		},

--- a/src/sniffer/pkg/config/config.go
+++ b/src/sniffer/pkg/config/config.go
@@ -6,16 +6,18 @@ import (
 )
 
 const (
-	HostProcDirKey                     = "host-proc-dir"
-	HostProcDirDefault                 = "/hostproc"
-	CallsTimeoutKey                    = "calls-timeout"
-	CallsTimeoutDefault                = 60 * time.Second
-	SnifferReportIntervalKey           = "sniffer-report-interval"
-	SnifferReportIntervalDefault       = 10 * time.Second
-	PacketsBufferLengthKey             = "packets-buffer-length"
-	PacketsBufferLengthDefault         = 4096
-	HostsMappingRefreshIntervalKey     = "hosts-mapping-refresh-interval"
-	HostsMappingRefreshIntervalDefault = 500 * time.Millisecond
+	HostProcDirKey                       = "host-proc-dir"
+	HostProcDirDefault                   = "/hostproc"
+	CallsTimeoutKey                      = "calls-timeout"
+	CallsTimeoutDefault                  = 60 * time.Second
+	SnifferReportIntervalKey             = "sniffer-report-interval"
+	SnifferReportIntervalDefault         = 10 * time.Second
+	PacketsBufferLengthKey               = "packets-buffer-length"
+	PacketsBufferLengthDefault           = 4096
+	HostsMappingRefreshIntervalKey       = "hosts-mapping-refresh-interval"
+	HostsMappingRefreshIntervalDefault   = 500 * time.Millisecond
+	ExternalTrafficCaptureEnabledKey     = "capture-external-traffic-enabled"
+	ExternalTrafficCaptureEnabledDefault = true // FIXME change to false
 )
 
 func init() {
@@ -24,4 +26,5 @@ func init() {
 	viper.SetDefault(CallsTimeoutKey, CallsTimeoutDefault)
 	viper.SetDefault(HostProcDirKey, HostProcDirDefault)
 	viper.SetDefault(HostsMappingRefreshIntervalKey, HostsMappingRefreshIntervalDefault)
+	viper.SetDefault(ExternalTrafficCaptureEnabledKey, ExternalTrafficCaptureEnabledDefault)
 }

--- a/src/sniffer/pkg/config/config.go
+++ b/src/sniffer/pkg/config/config.go
@@ -6,18 +6,16 @@ import (
 )
 
 const (
-	HostProcDirKey                       = "host-proc-dir"
-	HostProcDirDefault                   = "/hostproc"
-	CallsTimeoutKey                      = "calls-timeout"
-	CallsTimeoutDefault                  = 60 * time.Second
-	SnifferReportIntervalKey             = "sniffer-report-interval"
-	SnifferReportIntervalDefault         = 10 * time.Second
-	PacketsBufferLengthKey               = "packets-buffer-length"
-	PacketsBufferLengthDefault           = 4096
-	HostsMappingRefreshIntervalKey       = "hosts-mapping-refresh-interval"
-	HostsMappingRefreshIntervalDefault   = 500 * time.Millisecond
-	ExternalTrafficCaptureEnabledKey     = "capture-external-traffic-enabled"
-	ExternalTrafficCaptureEnabledDefault = false
+	HostProcDirKey                     = "host-proc-dir"
+	HostProcDirDefault                 = "/hostproc"
+	CallsTimeoutKey                    = "calls-timeout"
+	CallsTimeoutDefault                = 60 * time.Second
+	SnifferReportIntervalKey           = "sniffer-report-interval"
+	SnifferReportIntervalDefault       = 10 * time.Second
+	PacketsBufferLengthKey             = "packets-buffer-length"
+	PacketsBufferLengthDefault         = 4096
+	HostsMappingRefreshIntervalKey     = "hosts-mapping-refresh-interval"
+	HostsMappingRefreshIntervalDefault = 500 * time.Millisecond
 )
 
 func init() {
@@ -26,5 +24,4 @@ func init() {
 	viper.SetDefault(CallsTimeoutKey, CallsTimeoutDefault)
 	viper.SetDefault(HostProcDirKey, HostProcDirDefault)
 	viper.SetDefault(HostsMappingRefreshIntervalKey, HostsMappingRefreshIntervalDefault)
-	viper.SetDefault(ExternalTrafficCaptureEnabledKey, ExternalTrafficCaptureEnabledDefault)
 }

--- a/src/sniffer/pkg/config/config.go
+++ b/src/sniffer/pkg/config/config.go
@@ -17,7 +17,7 @@ const (
 	HostsMappingRefreshIntervalKey       = "hosts-mapping-refresh-interval"
 	HostsMappingRefreshIntervalDefault   = 500 * time.Millisecond
 	ExternalTrafficCaptureEnabledKey     = "capture-external-traffic-enabled"
-	ExternalTrafficCaptureEnabledDefault = true // FIXME change to false
+	ExternalTrafficCaptureEnabledDefault = false
 )
 
 func init() {

--- a/src/sniffer/pkg/mapperclient/generated.go
+++ b/src/sniffer/pkg/mapperclient/generated.go
@@ -17,12 +17,16 @@ type CaptureResults struct {
 func (v *CaptureResults) GetResults() []RecordedDestinationsForSrc { return v.Results }
 
 type Destination struct {
-	Destination string    `json:"destination"`
-	LastSeen    time.Time `json:"lastSeen"`
+	Destination   string    `json:"destination"`
+	DestinationIP string    `json:"destinationIP"`
+	LastSeen      time.Time `json:"lastSeen"`
 }
 
 // GetDestination returns Destination.Destination, and is useful for accessing the field via an interface.
 func (v *Destination) GetDestination() string { return v.Destination }
+
+// GetDestinationIP returns Destination.DestinationIP, and is useful for accessing the field via an interface.
+func (v *Destination) GetDestinationIP() string { return v.DestinationIP }
 
 // GetLastSeen returns Destination.LastSeen, and is useful for accessing the field via an interface.
 func (v *Destination) GetLastSeen() time.Time { return v.LastSeen }


### PR DESCRIPTION
### Description

This PR adds supporting for reporting internet-facing traffic. Up until now, the network mapper would see this traffic, but discard it. Now, the network mapper has gained the capability to report this traffic to Otterize Cloud. This will be used to display Internet traffic in the access graph, and in the future can be used for automatically bootstrapping Internet-facing intents, as well as matching traffic with services from other clusters, or managed databases, and so on.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
