### PR TITLE
Fix bug where pod source identity could be incorrectly resolved

### DIFF
--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -37,7 +37,6 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 		for _, dest := range captureItem.Destinations {
 			destAddress := dest.Destination
 			if !strings.HasSuffix(destAddress, viper.GetString(config.ClusterDomainKey)) {
-				// not a k8s service, ignore
 				err := r.handleDNSCaptureResultsAsExternalTraffic(ctx, dest, srcSvcIdentity)
 				if err != nil {
 					logrus.WithError(err).Error("could not handle DNS capture result as external traffic")

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -35,9 +35,10 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 			continue
 		}
 		for _, dest := range captureItem.Destinations {
+			destCopy := dest
 			destAddress := dest.Destination
 			if !strings.HasSuffix(destAddress, viper.GetString(config.ClusterDomainKey)) {
-				err := r.handleDNSCaptureResultsAsExternalTraffic(ctx, dest, srcSvcIdentity)
+				err := r.handleDNSCaptureResultsAsExternalTraffic(ctx, destCopy, srcSvcIdentity)
 				if err != nil {
 					logrus.WithError(err).Error("could not handle DNS capture result as external traffic")
 					continue
@@ -46,7 +47,7 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 				continue
 			}
 
-			err := r.handleDNSCaptureResultsAsKubernetesPods(ctx, dest, srcSvcIdentity)
+			err := r.handleDNSCaptureResultsAsKubernetesPods(ctx, destCopy, srcSvcIdentity)
 			if err != nil {
 				logrus.WithError(err).Error("could not handle DNS capture result as pod")
 				continue
@@ -67,7 +68,8 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 			continue
 		}
 		for _, dest := range socketScanItem.Destinations {
-			isService, err := r.tryHandleSocketScanDestinationAsService(ctx, srcSvcIdentity, dest)
+			destCopy := dest
+			isService, err := r.tryHandleSocketScanDestinationAsService(ctx, srcSvcIdentity, destCopy)
 			if err != nil {
 				logrus.WithError(err).Errorf("failed to handle IP '%s' as service, it may or may not be a service. This error only occurs if something failed; not if the IP does not belong to a service.", dest.Destination)
 				// Log error but don't stop handling other destinations.
@@ -78,14 +80,14 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 				continue // No need to try to handle IP as Pod, since IP belonged to a service.
 			}
 
-			destPod, err := r.kubeFinder.ResolveIPToPod(ctx, dest.Destination)
+			destPod, err := r.kubeFinder.ResolveIPToPod(ctx, destCopy.Destination)
 			if err != nil {
 				logrus.WithError(err).Debugf("Could not resolve %s to pod", dest.Destination)
 				// Log error but don't stop handling other destinations.
 				continue
 			}
 
-			err = r.addSocketScanPodIntent(ctx, srcSvcIdentity, dest, destPod)
+			err = r.addSocketScanPodIntent(ctx, srcSvcIdentity, destCopy, destPod)
 			if err != nil {
 				logrus.WithError(err).Errorf("failed to resolve IP '%s' to pod", dest.Destination)
 				// Log error but don't stop handling other destinations.

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -64,7 +64,7 @@ func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results 
 	for _, socketScanItem := range results.Results {
 		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, socketScanItem)
 		if err != nil {
-			logrus.WithError(err).Errorf("could not discover src identity for '%s'", socketScanItem.SrcIP)
+			logrus.WithError(err).Debugf("could not discover src identity for '%s'", socketScanItem.SrcIP)
 			continue
 		}
 		for _, dest := range socketScanItem.Destinations {

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -35,7 +35,7 @@ type ControllerManagerTestSuiteBase struct {
 	Mgr              manager.Manager
 }
 
-func (s *ControllerManagerTestSuiteBase) SetupSuite() {
+func (s *ControllerManagerTestSuiteBase) SetupTest() {
 	s.testEnv = &envtest.Environment{}
 	var err error
 	s.cfg, err = s.testEnv.Start()
@@ -46,16 +46,8 @@ func (s *ControllerManagerTestSuiteBase) SetupSuite() {
 	s.K8sDirectClient, err = kubernetes.NewForConfig(s.cfg)
 	s.Require().NoError(err)
 	s.Require().NotNil(s.K8sDirectClient)
-}
-
-func (s *ControllerManagerTestSuiteBase) TearDownSuite() {
-	s.Require().NoError(s.testEnv.Stop())
-}
-
-func (s *ControllerManagerTestSuiteBase) SetupTest() {
 	s.mgrCtx, s.mgrCtxCancelFunc = context.WithCancel(context.Background())
 
-	var err error
 	s.Mgr, err = manager.New(s.cfg, manager.Options{MetricsBindAddress: "0"})
 	s.Require().NoError(err)
 	testName := s.T().Name()[strings.LastIndex(s.T().Name(), "/")+1:]
@@ -81,6 +73,7 @@ func (s *ControllerManagerTestSuiteBase) TearDownTest() {
 	s.mgrCtxCancelFunc()
 	err := s.K8sDirectClient.CoreV1().Namespaces().Delete(context.Background(), s.TestNamespace, metav1.DeleteOptions{})
 	s.Require().NoError(err)
+	s.Require().NoError(s.testEnv.Stop())
 }
 
 // waitForObjectToBeCreated tries to get an object multiple times until it is available in the k8s API server

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +41,7 @@ func (s *ControllerManagerTestSuiteBase) SetupSuite() {
 	s.cfg, err = s.testEnv.Start()
 	s.Require().NoError(err)
 	s.Require().NotNil(s.cfg)
+	logrus.SetLevel(logrus.DebugLevel)
 
 	s.K8sDirectClient, err = kubernetes.NewForConfig(s.cfg)
 	s.Require().NoError(err)


### PR DESCRIPTION
### Description

In some cases, empty source identities would be returned, causing erroneous reporting to Otterize Cloud. This PR fixes the problem and also adds regression tests.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality