### PR TITLE
Fix bug where network sniffer would write a log indicating success reporting to mapper alongside log indicating failure

### DIFF
--- a/src/sniffer/pkg/sniffer/sniffer.go
+++ b/src/sniffer/pkg/sniffer/sniffer.go
@@ -43,6 +43,7 @@ func (s *Sniffer) reportCaptureResults(ctx context.Context) {
 		err := s.mapperClient.ReportCaptureResults(timeoutCtx, mapperclient.CaptureResults{Results: results})
 		if err != nil {
 			logrus.WithError(err).Error("Failed to report capture results")
+			return
 		}
 		logrus.Infof("Reported captured requests of %d clients to Mapper", len(results))
 		prometheus.IncrementDNSCaptureReports(len(results))
@@ -64,6 +65,7 @@ func (s *Sniffer) reportSocketScanResults(ctx context.Context) {
 		err := s.mapperClient.ReportSocketScanResults(timeoutCtx, mapperclient.SocketScanResults{Results: results})
 		if err != nil {
 			logrus.WithError(err).Error("Failed to report socket scan results")
+			return
 		}
 		logrus.Infof("Reported scanned requests of %d clients to Mapper", len(results))
 		prometheus.IncrementSocketScanReports(len(results))


### PR DESCRIPTION
### Description

Previously, the network sniffer would not `return` once it logged an error for reporting to the mapper. This has no adverse effect, but the log that was produced was confusing, as it would log both an error and success:

```
{"error":"Post \"http://otterize-network-mapper:9090/query\": dial tcp 10.96.2.146:9090: i/o timeout","level":"error","msg":"Failed to report capture results","time":"2023-12-10T23:52:25Z"}                       │
{"level":"info","msg":"Reported captured requests of 1 clients to Mapper","time":"2023-12-10T23:52:25Z"}  
```

This PR fixes that.