### PR TITLE
Network mapper now buffers incoming reports instead of handling them synchronously, and collects statistics on loads and drops

### DIFF
--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -189,7 +189,7 @@ func main() {
 	})
 
 	err = errgrp.Wait()
-	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+	if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.Canceled) {
 		logrus.WithError(err).Fatal("Error when running server or HTTP server")
 	}
 

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -183,6 +183,10 @@ func main() {
 		defer bugsnag.AutoNotify(errGroupCtx)
 		return mapperServer.Start(":9090")
 	})
+	errgrp.Go(func() error {
+		defer bugsnag.AutoNotify(errGroupCtx)
+		return resolver.RunForever(errGroupCtx)
+	})
 
 	err = errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/src/mapper/pkg/graph/model/results_length.go
+++ b/src/mapper/pkg/graph/model/results_length.go
@@ -1,0 +1,17 @@
+package model
+
+func (c CaptureResults) Length() int {
+	return len(c.Results)
+}
+
+func (c KafkaMapperResults) Length() int {
+	return len(c.Results)
+}
+
+func (c SocketScanResults) Length() int {
+	return len(c.Results)
+}
+
+func (c IstioConnectionResults) Length() int {
+	return len(c.Results)
+}

--- a/src/mapper/pkg/prometheus/metrics.go
+++ b/src/mapper/pkg/prometheus/metrics.go
@@ -22,6 +22,22 @@ var (
 		Name: "istio_reported_connections",
 		Help: "The total number of Istio-sourced connections",
 	})
+	socketScanDrops = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "socketscan_dropped_connections",
+		Help: "The total number of socket scan-sourced reported connections that were dropped for performance",
+	})
+	dnsCaptureDrops = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "dns_dropped_connections",
+		Help: "The total number of DNS-sourced reported connections that were dropped for performance",
+	})
+	kafkaReportsDrops = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "kafka_dropped_topics",
+		Help: "The total number of Kafka-sourced reported topics that were dropped for performance",
+	})
+	istioReportsDrops = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "istio_dropped_connections",
+		Help: "The total number of Istio-sourced reported connections that were dropped for performance",
+	})
 )
 
 func IncrementSocketScanReports(count int) {
@@ -38,4 +54,20 @@ func IncrementKafkaReports(count int) {
 
 func IncrementIstioReports(count int) {
 	istioReports.Add(float64(count))
+}
+
+func IncrementSocketScanDrops(count int) {
+	socketScanDrops.Add(float64(count))
+}
+
+func IncrementDNSCaptureDrops(count int) {
+	dnsCaptureDrops.Add(float64(count))
+}
+
+func IncrementKafkaDrops(count int) {
+	kafkaReportsDrops.Add(float64(count))
+}
+
+func IncrementIstioDrops(count int) {
+	istioReportsDrops.Add(float64(count))
 }

--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -22,7 +22,7 @@ func podLabelsToOtterizeLabels(pod *corev1.Pod) []model.PodLabel {
 	return labels
 }
 
-func (r *mutationResolver) discoverSrcIdentity(ctx context.Context, src model.RecordedDestinationsForSrc) (model.OtterizeServiceIdentity, error) {
+func (r *Resolver) discoverSrcIdentity(ctx context.Context, src model.RecordedDestinationsForSrc) (model.OtterizeServiceIdentity, error) {
 	srcPod, err := r.kubeFinder.ResolveIPToPod(ctx, src.SrcIP)
 	if err != nil {
 		if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -31,10 +31,14 @@ type ResolverTestSuite struct {
 	kubeFinder                   *kubefinder.KubeFinder
 	intentsHolder                *intentsstore.IntentsHolder
 	externalTrafficIntentsHolder *externaltrafficholder.ExternalTrafficIntentsHolder
+	resolverCtx                  context.Context
+	resolverCtxCancel            context.CancelFunc
+	resolver                     *Resolver
 }
 
 func (s *ResolverTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
+	s.resolverCtx, s.resolverCtxCancel = context.WithCancel(context.Background())
 	e := echo.New()
 	var err error
 	s.kubeFinder, err = kubefinder.NewKubeFinder(context.Background(), s.Mgr)
@@ -42,9 +46,46 @@ func (s *ResolverTestSuite) SetupTest() {
 	s.intentsHolder = intentsstore.NewIntentsHolder()
 	s.externalTrafficIntentsHolder = externaltrafficholder.NewExternalTrafficIntentsHolder()
 	resolver := NewResolver(s.kubeFinder, serviceidresolver.NewResolver(s.Mgr.GetClient()), s.intentsHolder, s.externalTrafficIntentsHolder)
+	s.resolver = resolver
 	resolver.Register(e)
+	go func() {
+		err := resolver.RunForever(s.resolverCtx)
+		if err != nil {
+			logrus.WithError(err).Panic("failed to run resolver")
+		}
+	}()
 	s.server = httptest.NewServer(e)
 	s.client = graphql.NewClient(s.server.URL+"/query", s.server.Client())
+}
+
+func (s *ResolverTestSuite) TearDownTest() {
+	s.ControllerManagerTestSuiteBase.TearDownTest()
+	s.resolverCtxCancel()
+}
+
+func (s *ResolverTestSuite) waitForCaptureResultsProcessed(timeout time.Duration) {
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	select {
+	case <-ctxTimeout.Done():
+		s.Require().Fail("Timed out waiting for capture results to be processed")
+	case <-s.resolver.gotResultsCtx.Done():
+		return
+	}
+}
+
+func (s *ResolverTestSuite) waitForCaptureResultsCount(count int) {
+	s.Require().NoError(wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
+		if err != nil {
+			return false, err
+		}
+		if len(res.ServiceIntents) != 0 {
+			return true, nil
+		}
+
+		return false, nil
+	}))
 }
 
 func (s *ResolverTestSuite) TestReportCaptureResults() {
@@ -91,6 +132,8 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 		},
 	})
 	s.Require().NoError(err)
+
+	s.waitForCaptureResultsProcessed(10 * time.Second)
 
 	res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
 	s.Require().NoError(err)
@@ -203,6 +246,8 @@ func (s *ResolverTestSuite) TestReportCaptureResultsHostnameMismatch() {
 		},
 	})
 	s.Require().NoError(err)
+
+	s.waitForCaptureResultsProcessed(10 * time.Second)
 
 	res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
 	s.Require().NoError(err)
@@ -329,6 +374,8 @@ func (s *ResolverTestSuite) TestReportCaptureResultsPodDeletion() {
 	})
 	s.Require().NoError(err)
 
+	s.waitForCaptureResultsProcessed(10 * time.Second)
+
 	res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
 	s.Require().NoError(err)
 	s.Require().ElementsMatch(res.ServiceIntents, []test_gql_client.ServiceIntentsServiceIntents{
@@ -434,6 +481,8 @@ func (s *ResolverTestSuite) TestReportCaptureResultsIPReuse() {
 	})
 	s.Require().NoError(err)
 
+	s.waitForCaptureResultsProcessed(10 * time.Second)
+
 	res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
 	s.Require().NoError(err)
 	s.Require().ElementsMatch(res.ServiceIntents, []test_gql_client.ServiceIntentsServiceIntents{
@@ -522,6 +571,8 @@ func (s *ResolverTestSuite) TestReportCaptureResultsIgnoreOldPacket() {
 	})
 	s.Require().NoError(err)
 
+	s.waitForCaptureResultsProcessed(10 * time.Second)
+
 	res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
 	s.Require().NoError(err)
 	s.Require().ElementsMatch(res.ServiceIntents, []test_gql_client.ServiceIntentsServiceIntents{})
@@ -581,6 +632,8 @@ func (s *ResolverTestSuite) TestSocketScanResults() {
 		},
 	})
 	s.Require().NoError(err)
+
+	s.waitForCaptureResultsProcessed(10 * time.Second)
 
 	res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
 	s.Require().NoError(err)
@@ -691,6 +744,8 @@ func (s *ResolverTestSuite) TestIntents() {
 		},
 	})
 	s.Require().NoError(err)
+
+	s.waitForCaptureResultsProcessed(10 * time.Second)
 
 	logrus.Info("Testing Intents query")
 	res, err := test_gql_client.Intents(context.Background(), s.client, nil, nil, nil, true, nil)
@@ -838,6 +893,8 @@ func (s *ResolverTestSuite) TestIntentsFilterByServer() {
 		},
 	})
 	s.Require().NoError(err)
+
+	s.waitForCaptureResultsProcessed(10 * time.Second)
 
 	logrus.Info("Waiting for report to be processed")
 	serverFilter := &test_gql_client.ServerFilter{

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -74,20 +74,6 @@ func (s *ResolverTestSuite) waitForCaptureResultsProcessed(timeout time.Duration
 	}
 }
 
-func (s *ResolverTestSuite) waitForCaptureResultsCount(count int) {
-	s.Require().NoError(wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		res, err := test_gql_client.ServiceIntents(context.Background(), s.client, nil)
-		if err != nil {
-			return false, err
-		}
-		if len(res.ServiceIntents) != 0 {
-			return true, nil
-		}
-
-		return false, nil
-	}))
-}
-
 func (s *ResolverTestSuite) TestReportCaptureResults() {
 	s.AddDeploymentWithService("service1", []string{"1.1.1.1"}, map[string]string{"app": "service1"}, "10.0.0.16")
 	s.AddDeploymentWithService("service2", []string{"1.1.1.2"}, map[string]string{"app": "service2"}, "10.0.0.17")

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -224,16 +224,6 @@ func (r *Resolver) handleDNSCaptureResultsAsKubernetesPods(ctx context.Context, 
 	return nil
 }
 
-// waitForHandledResults is used in tests as result handling is now async.
-func (r *Resolver) waitForHandledResults(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-r.gotResultsCtx.Done():
-		return nil
-	}
-}
-
 func (r *Resolver) handleReportCaptureResults(ctx context.Context, results model.CaptureResults) error {
 	var newResults int
 	for _, captureItem := range results.Results {

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
+	"strings"
 )
 
 type SourceType string
@@ -49,7 +50,7 @@ func updateTelemetriesCounters(sourceType SourceType, intent model.Intent) {
 	}
 }
 
-func (r *mutationResolver) tryHandleSocketScanDestinationAsService(ctx context.Context, srcSvcIdentity model.OtterizeServiceIdentity, dest model.Destination) (bool, error) {
+func (r *Resolver) tryHandleSocketScanDestinationAsService(ctx context.Context, srcSvcIdentity model.OtterizeServiceIdentity, dest model.Destination) (bool, error) {
 	destSvc, foundSvc, err := r.kubeFinder.ResolveIPToService(ctx, dest.Destination)
 	if err != nil {
 		return false, err
@@ -64,7 +65,7 @@ func (r *mutationResolver) tryHandleSocketScanDestinationAsService(ctx context.C
 	return true, nil
 }
 
-func (r *mutationResolver) addSocketScanServiceIntent(ctx context.Context, srcSvcIdentity model.OtterizeServiceIdentity, dest model.Destination, svc *corev1.Service) error {
+func (r *Resolver) addSocketScanServiceIntent(ctx context.Context, srcSvcIdentity model.OtterizeServiceIdentity, dest model.Destination, svc *corev1.Service) error {
 	pods, err := r.kubeFinder.ResolveServiceToPods(ctx, svc)
 	if err != nil {
 		return err
@@ -109,7 +110,7 @@ func (r *mutationResolver) addSocketScanServiceIntent(ctx context.Context, srcSv
 	return nil
 }
 
-func (r *mutationResolver) addSocketScanPodIntent(ctx context.Context, srcSvcIdentity model.OtterizeServiceIdentity, dest model.Destination, destPod *corev1.Pod) error {
+func (r *Resolver) addSocketScanPodIntent(ctx context.Context, srcSvcIdentity model.OtterizeServiceIdentity, dest model.Destination, destPod *corev1.Pod) error {
 	if destPod.DeletionTimestamp != nil {
 		logrus.Debugf("Pod %s is being deleted, ignoring", destPod.Name)
 		return nil
@@ -144,7 +145,7 @@ func (r *mutationResolver) addSocketScanPodIntent(ctx context.Context, srcSvcIde
 	return nil
 }
 
-func (r *mutationResolver) handleDNSCaptureResultsAsExternalTraffic(_ context.Context, dest model.Destination, srcSvcIdentity model.OtterizeServiceIdentity) error {
+func (r *Resolver) handleDNSCaptureResultsAsExternalTraffic(_ context.Context, dest model.Destination, srcSvcIdentity model.OtterizeServiceIdentity) error {
 	if !viper.GetBool(config.ExternalTrafficCaptureEnabledKey) {
 		return nil
 	}
@@ -164,7 +165,7 @@ func (r *mutationResolver) handleDNSCaptureResultsAsExternalTraffic(_ context.Co
 	return nil
 }
 
-func (r *mutationResolver) handleDNSCaptureResultsAsKubernetesPods(ctx context.Context, dest model.Destination, srcSvcIdentity model.OtterizeServiceIdentity) error {
+func (r *Resolver) handleDNSCaptureResultsAsKubernetesPods(ctx context.Context, dest model.Destination, srcSvcIdentity model.OtterizeServiceIdentity) error {
 	destAddress := dest.Destination
 	ips, serviceName, err := r.kubeFinder.ResolveServiceAddressToIps(ctx, destAddress)
 	if err != nil {
@@ -221,4 +222,220 @@ func (r *mutationResolver) handleDNSCaptureResultsAsKubernetesPods(ctx context.C
 	updateTelemetriesCounters(SourceTypeDNSCapture, intent)
 
 	return nil
+}
+
+func (r *Resolver) handleReportCaptureResults(ctx context.Context, results model.CaptureResults) error {
+	var newResults int
+	for _, captureItem := range results.Results {
+		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, captureItem)
+		if err != nil {
+			logrus.WithError(err).Debugf("could not discover src identity for '%s'", captureItem.SrcIP)
+			continue
+		}
+		for _, dest := range captureItem.Destinations {
+			destCopy := dest
+			destAddress := dest.Destination
+			if !strings.HasSuffix(destAddress, viper.GetString(config.ClusterDomainKey)) {
+				err := r.handleDNSCaptureResultsAsExternalTraffic(ctx, destCopy, srcSvcIdentity)
+				if err != nil {
+					logrus.WithError(err).Error("could not handle DNS capture result as external traffic")
+					continue
+				}
+				newResults++
+				continue
+			}
+
+			err := r.handleDNSCaptureResultsAsKubernetesPods(ctx, destCopy, srcSvcIdentity)
+			if err != nil {
+				logrus.WithError(err).Error("could not handle DNS capture result as pod")
+				continue
+			}
+			newResults++
+		}
+	}
+
+	prometheus.IncrementDNSCaptureReports(newResults)
+	return nil
+}
+
+func (r *Resolver) handleReportSocketScanResults(ctx context.Context, results model.SocketScanResults) error {
+	for _, socketScanItem := range results.Results {
+		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, socketScanItem)
+		if err != nil {
+			logrus.WithError(err).Debugf("could not discover src identity for '%s'", socketScanItem.SrcIP)
+			continue
+		}
+		for _, dest := range socketScanItem.Destinations {
+			destCopy := dest
+			isService, err := r.tryHandleSocketScanDestinationAsService(ctx, srcSvcIdentity, destCopy)
+			if err != nil {
+				logrus.WithError(err).Errorf("failed to handle IP '%s' as service, it may or may not be a service. This error only occurs if something failed; not if the IP does not belong to a service.", dest.Destination)
+				// Log error but don't stop handling other destinations.
+				continue
+			}
+
+			if isService {
+				continue // No need to try to handle IP as Pod, since IP belonged to a service.
+			}
+
+			destPod, err := r.kubeFinder.ResolveIPToPod(ctx, destCopy.Destination)
+			if err != nil {
+				logrus.WithError(err).Debugf("Could not resolve %s to pod", dest.Destination)
+				// Log error but don't stop handling other destinations.
+				continue
+			}
+
+			err = r.addSocketScanPodIntent(ctx, srcSvcIdentity, destCopy, destPod)
+			if err != nil {
+				logrus.WithError(err).Errorf("failed to resolve IP '%s' to pod", dest.Destination)
+				// Log error but don't stop handling other destinations.
+				continue
+			}
+		}
+	}
+	return nil
+}
+
+func (r *Resolver) handleReportKafkaMapperResults(ctx context.Context, results model.KafkaMapperResults) error {
+	var newResults int
+	for _, result := range results.Results {
+		srcPod, err := r.kubeFinder.ResolveIPToPod(ctx, result.SrcIP)
+		if err != nil {
+			if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
+				logrus.WithError(err).Debugf("Ip %s belongs to more than one pod, ignoring", result.SrcIP)
+			} else {
+				logrus.WithError(err).Debugf("Could not resolve %s to pod", result.SrcIP)
+			}
+			continue
+		}
+
+		if srcPod.DeletionTimestamp != nil {
+			logrus.Debugf("Pod %s is being deleted, ignoring", srcPod.Name)
+			continue
+		}
+
+		if srcPod.CreationTimestamp.After(result.LastSeen) {
+			logrus.Debugf("Pod %s was created after scan time %s, ignoring", srcPod.Name, result.LastSeen)
+			continue
+		}
+
+		srcService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, srcPod)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", srcPod.Name)
+			continue
+		}
+
+		srcSvcIdentity := model.OtterizeServiceIdentity{Name: srcService.Name, Namespace: srcPod.Namespace, Labels: podLabelsToOtterizeLabels(srcPod)}
+
+		dstPod, err := r.kubeFinder.ResolvePodByName(ctx, result.ServerPodName, result.ServerNamespace)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", result.ServerPodName)
+			continue
+		}
+		dstService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, dstPod)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", dstPod.Name)
+			continue
+		}
+		dstSvcIdentity := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: dstPod.Namespace, Labels: podLabelsToOtterizeLabels(dstPod)}
+
+		operation, err := model.KafkaOpFromText(result.Operation)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not resolve kafka operation %s", result.Operation)
+			return err
+		}
+
+		intent := model.Intent{
+			Client: &srcSvcIdentity,
+			Server: &dstSvcIdentity,
+			Type:   lo.ToPtr(model.IntentTypeKafka),
+			KafkaTopics: []model.KafkaConfig{
+				{
+					Name:       result.Topic,
+					Operations: []model.KafkaOperation{operation},
+				},
+			},
+		}
+
+		updateTelemetriesCounters(SourceTypeKafkaMapper, intent)
+		r.intentsHolder.AddIntent(
+			result.LastSeen,
+			intent,
+		)
+		newResults++
+	}
+
+	prometheus.IncrementKafkaReports(newResults)
+	return nil
+}
+
+func (r *Resolver) handleReportIstioConnectionResults(ctx context.Context, results model.IstioConnectionResults) error {
+	var newResults int
+	for _, result := range results.Results {
+		srcPod, err := r.kubeFinder.ResolveIstioWorkloadToPod(ctx, result.SrcWorkload, result.SrcWorkloadNamespace)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not resolve workload %s to pod", result.SrcWorkload)
+			continue
+		}
+		dstPod, err := r.kubeFinder.ResolveIstioWorkloadToPod(ctx, result.DstWorkload, result.DstWorkloadNamespace)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not resolve workload %s to pod", result.SrcWorkload)
+			continue
+		}
+		srcService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, srcPod)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", srcPod.Name)
+			continue
+		}
+		dstService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, dstPod)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", dstPod.Name)
+			continue
+		}
+
+		srcSvcIdentity := model.OtterizeServiceIdentity{Name: srcService.Name, Namespace: srcPod.Namespace, Labels: podLabelsToOtterizeLabels(srcPod)}
+		dstSvcIdentity := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: dstPod.Namespace, Labels: podLabelsToOtterizeLabels(dstPod)}
+		if srcService.OwnerObject != nil {
+			srcSvcIdentity.PodOwnerKind = model.GroupVersionKindFromKubeGVK(srcService.OwnerObject.GetObjectKind().GroupVersionKind())
+		}
+
+		if dstService.OwnerObject != nil {
+			dstSvcIdentity.PodOwnerKind = model.GroupVersionKindFromKubeGVK(dstService.OwnerObject.GetObjectKind().GroupVersionKind())
+		}
+
+		intent := model.Intent{
+			Client:        &srcSvcIdentity,
+			Server:        &dstSvcIdentity,
+			Type:          lo.ToPtr(model.IntentTypeHTTP),
+			HTTPResources: []model.HTTPResource{{Path: result.Path, Methods: result.Methods}},
+		}
+
+		updateTelemetriesCounters(SourceTypeIstio, intent)
+		r.intentsHolder.AddIntent(result.LastSeen, intent)
+		newResults++
+	}
+
+	prometheus.IncrementIstioReports(newResults)
+	return nil
+}
+
+type Results interface {
+	Length() int
+}
+
+type resultsHandlerFunc[T Results] func(ctx context.Context, results T) error
+
+func runHandleLoop[T Results](ctx context.Context, resultsChan chan T, handleFunc resultsHandlerFunc[T]) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case results := <-resultsChan:
+			err := handleFunc(ctx, results)
+			if err != nil {
+				logrus.WithError(err).Errorf("Failed to handle %d results of type '%T'", results.Length(), results)
+				// Intentionally no return
+			}
+		}
+	}
 }

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -5,18 +5,12 @@ package resolvers
 
 import (
 	"context"
-	"errors"
-	"strings"
-
-	"github.com/otterize/network-mapper/src/mapper/pkg/config"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/generated"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/otterize/network-mapper/src/mapper/pkg/intentsstore"
-	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/prometheus"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 )
 
@@ -27,198 +21,55 @@ func (r *mutationResolver) ResetCapture(ctx context.Context) (bool, error) {
 }
 
 func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results model.CaptureResults) (bool, error) {
-	var newResults int
-	for _, captureItem := range results.Results {
-		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, captureItem)
-		if err != nil {
-			logrus.WithError(err).Debugf("could not discover src identity for '%s'", captureItem.SrcIP)
-			continue
-		}
-		for _, dest := range captureItem.Destinations {
-			destCopy := dest
-			destAddress := dest.Destination
-			if !strings.HasSuffix(destAddress, viper.GetString(config.ClusterDomainKey)) {
-				err := r.handleDNSCaptureResultsAsExternalTraffic(ctx, destCopy, srcSvcIdentity)
-				if err != nil {
-					logrus.WithError(err).Error("could not handle DNS capture result as external traffic")
-					continue
-				}
-				newResults++
-				continue
-			}
-
-			err := r.handleDNSCaptureResultsAsKubernetesPods(ctx, destCopy, srcSvcIdentity)
-			if err != nil {
-				logrus.WithError(err).Error("could not handle DNS capture result as pod")
-				continue
-			}
-			newResults++
-		}
+	select {
+	case r.dnsCaptureResults <- results:
+		prometheus.IncrementDNSCaptureReports(len(results.Results))
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+		prometheus.IncrementDNSCaptureDrops(len(results.Results))
+		return false, nil
 	}
-
-	prometheus.IncrementDNSCaptureReports(newResults)
-	return true, nil
 }
 
 func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results model.SocketScanResults) (bool, error) {
-	for _, socketScanItem := range results.Results {
-		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, socketScanItem)
-		if err != nil {
-			logrus.WithError(err).Debugf("could not discover src identity for '%s'", socketScanItem.SrcIP)
-			continue
-		}
-		for _, dest := range socketScanItem.Destinations {
-			destCopy := dest
-			isService, err := r.tryHandleSocketScanDestinationAsService(ctx, srcSvcIdentity, destCopy)
-			if err != nil {
-				logrus.WithError(err).Errorf("failed to handle IP '%s' as service, it may or may not be a service. This error only occurs if something failed; not if the IP does not belong to a service.", dest.Destination)
-				// Log error but don't stop handling other destinations.
-				continue
-			}
-
-			if isService {
-				continue // No need to try to handle IP as Pod, since IP belonged to a service.
-			}
-
-			destPod, err := r.kubeFinder.ResolveIPToPod(ctx, destCopy.Destination)
-			if err != nil {
-				logrus.WithError(err).Debugf("Could not resolve %s to pod", dest.Destination)
-				// Log error but don't stop handling other destinations.
-				continue
-			}
-
-			err = r.addSocketScanPodIntent(ctx, srcSvcIdentity, destCopy, destPod)
-			if err != nil {
-				logrus.WithError(err).Errorf("failed to resolve IP '%s' to pod", dest.Destination)
-				// Log error but don't stop handling other destinations.
-				continue
-			}
-		}
+	select {
+	case r.socketScanResults <- results:
+		prometheus.IncrementSocketScanReports(len(results.Results))
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+		prometheus.IncrementSocketScanDrops(len(results.Results))
+		return false, nil
 	}
-	return true, nil
 }
 
 func (r *mutationResolver) ReportKafkaMapperResults(ctx context.Context, results model.KafkaMapperResults) (bool, error) {
-	var newResults int
-	for _, result := range results.Results {
-		srcPod, err := r.kubeFinder.ResolveIPToPod(ctx, result.SrcIP)
-		if err != nil {
-			if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
-				logrus.WithError(err).Debugf("Ip %s belongs to more than one pod, ignoring", result.SrcIP)
-			} else {
-				logrus.WithError(err).Debugf("Could not resolve %s to pod", result.SrcIP)
-			}
-			continue
-		}
-
-		if srcPod.DeletionTimestamp != nil {
-			logrus.Debugf("Pod %s is being deleted, ignoring", srcPod.Name)
-			continue
-		}
-
-		if srcPod.CreationTimestamp.After(result.LastSeen) {
-			logrus.Debugf("Pod %s was created after scan time %s, ignoring", srcPod.Name, result.LastSeen)
-			continue
-		}
-
-		srcService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, srcPod)
-		if err != nil {
-			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", srcPod.Name)
-			continue
-		}
-
-		srcSvcIdentity := model.OtterizeServiceIdentity{Name: srcService.Name, Namespace: srcPod.Namespace, Labels: podLabelsToOtterizeLabels(srcPod)}
-
-		dstPod, err := r.kubeFinder.ResolvePodByName(ctx, result.ServerPodName, result.ServerNamespace)
-		if err != nil {
-			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", result.ServerPodName)
-			continue
-		}
-		dstService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, dstPod)
-		if err != nil {
-			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", dstPod.Name)
-			continue
-		}
-		dstSvcIdentity := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: dstPod.Namespace, Labels: podLabelsToOtterizeLabels(dstPod)}
-
-		operation, err := model.KafkaOpFromText(result.Operation)
-		if err != nil {
-			logrus.WithError(err).Debugf("Could not resolve kafka operation %s", result.Operation)
-			return false, err
-		}
-
-		intent := model.Intent{
-			Client: &srcSvcIdentity,
-			Server: &dstSvcIdentity,
-			Type:   lo.ToPtr(model.IntentTypeKafka),
-			KafkaTopics: []model.KafkaConfig{
-				{
-					Name:       result.Topic,
-					Operations: []model.KafkaOperation{operation},
-				},
-			},
-		}
-
-		updateTelemetriesCounters(SourceTypeKafkaMapper, intent)
-		r.intentsHolder.AddIntent(
-			result.LastSeen,
-			intent,
-		)
-		newResults++
+	select {
+	case r.kafkaMapperResults <- results:
+		prometheus.IncrementKafkaReports(len(results.Results))
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+		prometheus.IncrementKafkaDrops(len(results.Results))
+		return false, nil
 	}
-
-	prometheus.IncrementKafkaReports(newResults)
-	return true, nil
 }
 
 func (r *mutationResolver) ReportIstioConnectionResults(ctx context.Context, results model.IstioConnectionResults) (bool, error) {
-	var newResults int
-	for _, result := range results.Results {
-		srcPod, err := r.kubeFinder.ResolveIstioWorkloadToPod(ctx, result.SrcWorkload, result.SrcWorkloadNamespace)
-		if err != nil {
-			logrus.WithError(err).Debugf("Could not resolve workload %s to pod", result.SrcWorkload)
-			continue
-		}
-		dstPod, err := r.kubeFinder.ResolveIstioWorkloadToPod(ctx, result.DstWorkload, result.DstWorkloadNamespace)
-		if err != nil {
-			logrus.WithError(err).Debugf("Could not resolve workload %s to pod", result.SrcWorkload)
-			continue
-		}
-		srcService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, srcPod)
-		if err != nil {
-			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", srcPod.Name)
-			continue
-		}
-		dstService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, dstPod)
-		if err != nil {
-			logrus.WithError(err).Debugf("Could not resolve pod %s to identity", dstPod.Name)
-			continue
-		}
-
-		srcSvcIdentity := model.OtterizeServiceIdentity{Name: srcService.Name, Namespace: srcPod.Namespace, Labels: podLabelsToOtterizeLabels(srcPod)}
-		dstSvcIdentity := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: dstPod.Namespace, Labels: podLabelsToOtterizeLabels(dstPod)}
-		if srcService.OwnerObject != nil {
-			srcSvcIdentity.PodOwnerKind = model.GroupVersionKindFromKubeGVK(srcService.OwnerObject.GetObjectKind().GroupVersionKind())
-		}
-
-		if dstService.OwnerObject != nil {
-			dstSvcIdentity.PodOwnerKind = model.GroupVersionKindFromKubeGVK(dstService.OwnerObject.GetObjectKind().GroupVersionKind())
-		}
-
-		intent := model.Intent{
-			Client:        &srcSvcIdentity,
-			Server:        &dstSvcIdentity,
-			Type:          lo.ToPtr(model.IntentTypeHTTP),
-			HTTPResources: []model.HTTPResource{{Path: result.Path, Methods: result.Methods}},
-		}
-
-		updateTelemetriesCounters(SourceTypeIstio, intent)
-		r.intentsHolder.AddIntent(result.LastSeen, intent)
-		newResults++
+	select {
+	case r.istioConnectionResults <- results:
+		prometheus.IncrementIstioReports(len(results.Results))
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+		prometheus.IncrementIstioDrops(len(results.Results))
+		return false, nil
 	}
-
-	prometheus.IncrementIstioReports(newResults)
-	return true, nil
 }
 
 func (r *queryResolver) ServiceIntents(ctx context.Context, namespaces []string, includeLabels []string, includeAllLabels *bool) ([]model.ServiceIntents, error) {

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -5,6 +5,7 @@ package resolvers
 
 import (
 	"context"
+
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/generated"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/otterize/network-mapper/src/mapper/pkg/intentsstore"


### PR DESCRIPTION
### Description

Previous to the PR, network sniffers and the Istio and Kafka watchers would report their data to the network mapper, which would then handle them synchronously. The network mapper now buffers a limited amount of reports in-memory (using a channel), and rejects more reports when the channel is full. This enables the network mapper to absorb peaks in reports.