### PR TITLE
Allow reporting errors with context id from sniffer and watchers

### DIFF
--- a/src/istio-watcher/cmd/main.go
+++ b/src/istio-watcher/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 	mapperClient := mapperclient.NewMapperClient(viper.GetString(sharedconfig.MapperApiUrlKey))
 	istioWatcher, err := istiowatcher.NewWatcher(mapperClient)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when creating new watcher")
+		logrus.WithError(err).Panic()
 	}
 
 	healthServer := echo.New()
@@ -78,19 +78,19 @@ func main() {
 
 	err = errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when running server or HTTP server")
+		logrus.WithError(err).Fatal("Error when running server or HTTP server")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = healthServer.Shutdown(timeoutCtx)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down health server")
+		logrus.WithError(err).Fatal("Error when shutting down")
 	}
 
 	err = metricsServer.Shutdown(timeoutCtx)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down metrics server")
+		logrus.WithError(err).Fatal("Error when shutting down")
 	}
 
 }

--- a/src/istio-watcher/cmd/main.go
+++ b/src/istio-watcher/cmd/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	errgrp.Go(func() error {
 		defer bugsnag.AutoNotify(errGroupCtx)
-		return componentutils.WaitAndSetContextId()
+		return componentutils.WaitAndSetContextId(errGroupCtx)
 	})
 
 	err = errgrp.Wait()

--- a/src/istio-watcher/cmd/main.go
+++ b/src/istio-watcher/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 	mapperClient := mapperclient.NewMapperClient(viper.GetString(sharedconfig.MapperApiUrlKey))
 	istioWatcher, err := istiowatcher.NewWatcher(mapperClient)
 	if err != nil {
-		logrus.WithError(err).Panic()
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when creating new watcher")
 	}
 
 	healthServer := echo.New()
@@ -78,19 +78,19 @@ func main() {
 
 	err = errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		logrus.WithError(err).Fatal("Error when running server or HTTP server")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when running server or HTTP server")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = healthServer.Shutdown(timeoutCtx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error when shutting down")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down health server")
 	}
 
 	err = metricsServer.Shutdown(timeoutCtx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error when shutting down")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down metrics server")
 	}
 
 }

--- a/src/istio-watcher/cmd/main.go
+++ b/src/istio-watcher/cmd/main.go
@@ -71,6 +71,11 @@ func main() {
 		return err
 	})
 
+	errgrp.Go(func() error {
+		defer bugsnag.AutoNotify(errGroupCtx)
+		return componentutils.WaitAndSetContextId()
+	})
+
 	err = errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logrus.WithError(err).Fatal("Error when running server or HTTP server")

--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -114,6 +114,11 @@ func main() {
 		return err
 	})
 
+	errgrp.Go(func() error {
+		defer bugsnag.AutoNotify(errGroupCtx)
+		return componentutils.WaitAndSetContextId()
+	})
+
 	err = errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logrus.WithError(err).Fatal("Error when running server or HTTP server")

--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -53,8 +53,8 @@ func main() {
 		logPath := viper.GetString(config.KafkaAuthZLogPathKey)
 
 		if logPath == "" {
-			logrus.Fatalf("Kafka log path is not set - please set %s", sharedconfig.GetEnvVarForKey(config.KafkaAuthZLogPathKey))
-
+			msg := fmt.Sprintf("Kafka log path is not set - please set %s", sharedconfig.GetEnvVarForKey(config.KafkaAuthZLogPathKey))
+			componentutils.ExitDueToInitFailure(logrus.WithError(errors.New(msg)), msg)
 		}
 
 		logrus.Infof("Kafka watcher: reading from filesystem - %s", logPath)
@@ -66,24 +66,26 @@ func main() {
 
 		watcher, err = logwatcher2.NewLogFileWatcher(mapperClient, logPath, serverName)
 		if err != nil {
-			logrus.WithError(err).Fatal("could not initialize log file watcher")
+			componentutils.ExitDueToInitFailure(logrus.WithError(err), "could not initialize log file watcher")
 		}
 	case config.KubernetesLogReadMode:
 		kafkaServers, parseErr := parseKafkaServers(viper.GetStringSlice(config.KafkaServersKey))
 		logrus.Infof("Reading from k8s logs - %d servers", len(kafkaServers))
 
 		if parseErr != nil {
-			logrus.WithError(err).Fatal("could not parse Kafka servers list")
+			componentutils.ExitDueToInitFailure(logrus.WithError(parseErr), "could not parse Kafka servers list")
 		}
 
 		watcher, err = logwatcher2.NewKubernetesLogWatcher(mapperClient, kafkaServers)
 		if err != nil {
-			logrus.WithError(err).Fatal("could not initialize Kubernetes log watcher")
+			componentutils.ExitDueToInitFailure(logrus.WithError(err), "could not initialize Kubernetes log watcher")
 		}
 	case "":
-		logrus.Fatalf("Kafka watcher mode is not set - please set %s", sharedconfig.GetEnvVarForKey(config.KafkaLogReadModeKey))
+		msg := fmt.Sprintf("Kafka watcher mode is not set - please set %s", sharedconfig.GetEnvVarForKey(config.KafkaLogReadModeKey))
+		componentutils.ExitDueToInitFailure(logrus.WithError(errors.New(msg)), msg)
 	default:
-		logrus.Fatalf("Kafka watcher mode (%s) is not set to a valid mode", mode)
+		msg := fmt.Sprintf("Kafka watcher mode (%s) is not set to a valid mode", mode)
+		componentutils.ExitDueToInitFailure(logrus.WithError(errors.New(msg)), msg)
 	}
 
 	healthServer := echo.New()
@@ -121,19 +123,19 @@ func main() {
 
 	err = errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		logrus.WithError(err).Fatal("Error when running server or HTTP server")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when running server or HTTP server")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = healthServer.Shutdown(timeoutCtx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error when shutting down")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down health server")
 	}
 
 	err = metricsServer.Shutdown(timeoutCtx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error when shutting down")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down metrics server")
 	}
 }
 

--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -116,7 +116,7 @@ func main() {
 
 	errgrp.Go(func() error {
 		defer bugsnag.AutoNotify(errGroupCtx)
-		return componentutils.WaitAndSetContextId()
+		return componentutils.WaitAndSetContextId(errGroupCtx)
 	})
 
 	err = errgrp.Wait()

--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -53,8 +53,8 @@ func main() {
 		logPath := viper.GetString(config.KafkaAuthZLogPathKey)
 
 		if logPath == "" {
-			msg := fmt.Sprintf("Kafka log path is not set - please set %s", sharedconfig.GetEnvVarForKey(config.KafkaAuthZLogPathKey))
-			componentutils.ExitDueToInitFailure(logrus.WithError(errors.New(msg)), msg)
+			logrus.Fatalf("Kafka log path is not set - please set %s", sharedconfig.GetEnvVarForKey(config.KafkaAuthZLogPathKey))
+
 		}
 
 		logrus.Infof("Kafka watcher: reading from filesystem - %s", logPath)
@@ -66,26 +66,24 @@ func main() {
 
 		watcher, err = logwatcher2.NewLogFileWatcher(mapperClient, logPath, serverName)
 		if err != nil {
-			componentutils.ExitDueToInitFailure(logrus.WithError(err), "could not initialize log file watcher")
+			logrus.WithError(err).Fatal("could not initialize log file watcher")
 		}
 	case config.KubernetesLogReadMode:
 		kafkaServers, parseErr := parseKafkaServers(viper.GetStringSlice(config.KafkaServersKey))
 		logrus.Infof("Reading from k8s logs - %d servers", len(kafkaServers))
 
 		if parseErr != nil {
-			componentutils.ExitDueToInitFailure(logrus.WithError(parseErr), "could not parse Kafka servers list")
+			logrus.WithError(err).Fatal("could not parse Kafka servers list")
 		}
 
 		watcher, err = logwatcher2.NewKubernetesLogWatcher(mapperClient, kafkaServers)
 		if err != nil {
-			componentutils.ExitDueToInitFailure(logrus.WithError(err), "could not initialize Kubernetes log watcher")
+			logrus.WithError(err).Fatal("could not initialize Kubernetes log watcher")
 		}
 	case "":
-		msg := fmt.Sprintf("Kafka watcher mode is not set - please set %s", sharedconfig.GetEnvVarForKey(config.KafkaLogReadModeKey))
-		componentutils.ExitDueToInitFailure(logrus.WithError(errors.New(msg)), msg)
+		logrus.Fatalf("Kafka watcher mode is not set - please set %s", sharedconfig.GetEnvVarForKey(config.KafkaLogReadModeKey))
 	default:
-		msg := fmt.Sprintf("Kafka watcher mode (%s) is not set to a valid mode", mode)
-		componentutils.ExitDueToInitFailure(logrus.WithError(errors.New(msg)), msg)
+		logrus.Fatalf("Kafka watcher mode (%s) is not set to a valid mode", mode)
 	}
 
 	healthServer := echo.New()
@@ -123,19 +121,19 @@ func main() {
 
 	err = errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when running server or HTTP server")
+		logrus.WithError(err).Fatal("Error when running server or HTTP server")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = healthServer.Shutdown(timeoutCtx)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down health server")
+		logrus.WithError(err).Fatal("Error when shutting down")
 	}
 
 	err = metricsServer.Shutdown(timeoutCtx)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down metrics server")
+		logrus.WithError(err).Fatal("Error when shutting down")
 	}
 }
 

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -13,11 +13,13 @@ import (
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/metadata"
 	"net/http"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -113,7 +115,12 @@ func main() {
 	} else {
 		kubeSystemUID = string(kubeSystemNs.UID)
 	}
-	componentinfo.SetGlobalContextId(telemetrysender.Anonymize(kubeSystemUID))
+	contextID := telemetrysender.Anonymize(kubeSystemUID)
+	componentinfo.SetGlobalContextId(contextID)
+	err = WriteContextIDToConfigMap(mgr.GetClient(), contextID)
+	if err != nil {
+		logrus.WithError(err).Error("unable to write context id to config map")
+	}
 
 	// start API server
 	mapperServer.GET("/healthz", func(c echo.Context) error {
@@ -193,4 +200,32 @@ func main() {
 		logrus.WithError(err).Fatal("Error when running server or HTTP server")
 	}
 
+}
+
+func WriteContextIDToConfigMap(k8sClient client.Client, contextID string) error {
+	namespace, err := kubeutils.GetCurrentNamespace()
+	if err != nil {
+		return err
+	}
+
+	configMapName := viper.GetString(sharedconfig.ComponentMetadataConfigmapNameKey)
+	var configMap corev1.ConfigMap
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: configMapName}, &configMap)
+	if err != nil {
+		return err
+	}
+
+	if configMap.Data == nil {
+		configMap.Data = make(map[string]string)
+	}
+
+	contextIdKey := viper.GetString(sharedconfig.ComponentMetadataContextIdKeyKey)
+	configMap.Data[contextIdKey] = contextID
+	err = k8sClient.Update(context.Background(), &configMap)
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Successfully wrote context id to config map")
+	return nil
 }

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -12,13 +12,13 @@ import (
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
-	"github.com/otterize/network-mapper/src/shared/componentutils"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/metadata"
 	"net/http"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
@@ -78,13 +78,15 @@ func main() {
 	// start manager with operators
 	mgr, err := manager.New(clientconfig.GetConfigOrDie(), manager.Options{MetricsBindAddress: "0"})
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Unable to set up overall controller manager")
+		logrus.Errorf("unable to set up overall controller manager: %s", err)
+		os.Exit(1)
 	}
 
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
 	kubeFinder, err := kubefinder.NewKubeFinder(errGroupCtx, mgr)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Failed to initialize kube finder")
+		logrus.Error(err)
+		os.Exit(1)
 	}
 
 	errgrp.Go(func() error {
@@ -99,11 +101,11 @@ func main() {
 
 	metadataClient, err := metadata.NewForConfig(clientconfig.GetConfigOrDie())
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Failed to initialize metadata client")
+		logrus.WithError(err).Fatal("unable to create metadata client")
 	}
 	mapping, err := mgr.GetRESTMapper().RESTMapping(schema.GroupKind{Group: "", Kind: "Namespace"}, "v1")
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "unable to create Kubernetes API REST mapping")
+		logrus.WithError(err).Fatal("unable to create Kubernetes API REST mapping")
 	}
 	kubeSystemUID := ""
 	kubeSystemNs, err := metadataClient.Resource(mapping.Resource).Get(context.Background(), "kube-system", metav1.GetOptions{})
@@ -142,7 +144,7 @@ func main() {
 
 	cloudClient, cloudEnabled, err := cloudclient.NewClient(errGroupCtx)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Failed to initialize cloud client")
+		logrus.WithError(err).Fatal("Failed to initialize cloud client")
 	}
 
 	cloudUploaderConfig := clouduploader.ConfigFromViper()
@@ -159,7 +161,7 @@ func main() {
 		otelExporter, err := metricexporter.NewMetricExporter(errGroupCtx)
 		intentsHolder.RegisterNotifyIntents(otelExporter.NotifyIntents)
 		if err != nil {
-			componentutils.ExitDueToInitFailure(logrus.WithError(err), "Failed to initialize otel exporter")
+			logrus.WithError(err).Fatal("Failed to initialize otel exporter")
 		}
 	}
 
@@ -195,7 +197,7 @@ func main() {
 
 	err = errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.Canceled) {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when running server or HTTP server")
+		logrus.WithError(err).Fatal("Error when running server or HTTP server")
 	}
 
 }

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/neko-neko/echo-logrus/v2/log"
+	errors2 "github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
@@ -58,6 +59,7 @@ func getClusterDomainOrDefault() string {
 
 func main() {
 	errorreporter.Init("network-mapper", version.Version(), viper.GetString(sharedconfig.TelemetryErrorsAPIKeyKey))
+	defer bugsnag.AutoNotify(context.Background())
 	if !viper.IsSet(config.ClusterDomainKey) || viper.GetString(config.ClusterDomainKey) == "" {
 		clusterDomain := getClusterDomainOrDefault()
 		viper.Set(config.ClusterDomainKey, clusterDomain)
@@ -203,14 +205,14 @@ func main() {
 func WriteContextIDToConfigMap(k8sClient client.Client, contextID string) error {
 	namespace, err := kubeutils.GetCurrentNamespace()
 	if err != nil {
-		return err
+		return errors2.Wrap(err)
 	}
 
 	configMapName := viper.GetString(sharedconfig.ComponentMetadataConfigmapNameKey)
 	var configMap corev1.ConfigMap
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: configMapName}, &configMap)
 	if err != nil {
-		return err
+		return errors2.Wrap(err)
 	}
 
 	if configMap.Data == nil {
@@ -221,7 +223,7 @@ func WriteContextIDToConfigMap(k8sClient client.Client, contextID string) error 
 	configMap.Data[contextIdKey] = contextID
 	err = k8sClient.Update(context.Background(), &configMap)
 	if err != nil {
-		return err
+		return errors2.Wrap(err)
 	}
 
 	logrus.Info("Successfully wrote context id to config map")

--- a/src/shared/componentutils/utils.go
+++ b/src/shared/componentutils/utils.go
@@ -58,3 +58,14 @@ func setContextId() (bool, error) {
 	componentinfo.SetGlobalContextId(string(res))
 	return true, nil
 }
+
+func ExitDueToInitFailure(entry *logrus.Entry, message string) {
+	if entry != nil {
+		entry.Error(message)
+	} else {
+		logrus.Error(message)
+	}
+	// Wait to allow error reporter to notify the error
+	time.Sleep(15 * time.Millisecond)
+	os.Exit(1)
+}

--- a/src/shared/componentutils/utils.go
+++ b/src/shared/componentutils/utils.go
@@ -29,6 +29,7 @@ func WaitAndSetContextId(ctx context.Context) error {
 			return err
 		}
 		if ok {
+			logrus.Info("Context id set successfully")
 			return nil
 		}
 

--- a/src/shared/componentutils/utils.go
+++ b/src/shared/componentutils/utils.go
@@ -59,14 +59,3 @@ func setContextId() (bool, error) {
 	componentinfo.SetGlobalContextId(string(res))
 	return true, nil
 }
-
-func ExitDueToInitFailure(entry *logrus.Entry, message string) {
-	if entry != nil {
-		entry.Error(message)
-	} else {
-		logrus.Error(message)
-	}
-	// Wait to allow error reporter to notify the error
-	time.Sleep(15 * time.Millisecond)
-	os.Exit(1)
-}

--- a/src/shared/componentutils/utils.go
+++ b/src/shared/componentutils/utils.go
@@ -61,15 +61,12 @@ func setContextId() (bool, error) {
 }
 
 func ExitDueToInitFailure(entry *logrus.Entry, message string) {
-	if entry == nil {
-		panic(message)
+	if entry != nil {
+		entry.Error(message)
+	} else {
+		logrus.Error(message)
 	}
-	msg, err := entry.WithField("message", message).String()
-	if err != nil {
-		// Entry format error, just use the original message
-		msg, _ = logrus.WithField("error formatting message", err).WithField("message", message).String()
-	}
-
-	// Bugsnag panic synchronously, making sure the massage is sent before exiting
-	panic(msg)
+	// Wait to allow error reporter to notify the error
+	time.Sleep(15 * time.Millisecond)
+	os.Exit(1)
 }

--- a/src/shared/componentutils/utils.go
+++ b/src/shared/componentutils/utils.go
@@ -61,12 +61,15 @@ func setContextId() (bool, error) {
 }
 
 func ExitDueToInitFailure(entry *logrus.Entry, message string) {
-	if entry != nil {
-		entry.Error(message)
-	} else {
-		logrus.Error(message)
+	if entry == nil {
+		panic(message)
 	}
-	// Wait to allow error reporter to notify the error
-	time.Sleep(15 * time.Millisecond)
-	os.Exit(1)
+	msg, err := entry.WithField("message", message).String()
+	if err != nil {
+		// Entry format error, just use the original message
+		msg, _ = logrus.WithField("error formatting message", err).WithField("message", message).String()
+	}
+
+	// Bugsnag panic synchronously, making sure the massage is sent before exiting
+	panic(msg)
 }

--- a/src/shared/componentutils/utils.go
+++ b/src/shared/componentutils/utils.go
@@ -1,13 +1,54 @@
 package componentutils
 
 import (
+	"errors"
+	"fmt"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
+	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"os"
+	"time"
 )
 
 func SetCloudClientId() {
 	// Cloud client ID is set inside the cloud client initialization, this method is meant to be used from components
 	// that don't use the cloud client, but still need it for their telemetry data.
 	componentinfo.SetGlobalCloudClientId(viper.GetString(otterizecloudclient.ApiClientIdKey))
+}
+
+func WaitAndSetContextId() error {
+	interval := viper.GetDuration(sharedconfig.ReadContextIdIntervalKey)
+
+	for {
+		ok, err := setContextId()
+		if err != nil {
+			logrus.WithError(err).Error("Error when setting context id")
+			return err
+		}
+		if ok {
+			return nil
+		}
+
+		time.Sleep(interval)
+	}
+}
+
+func setContextId() (bool, error) {
+	dirPath := viper.GetString(sharedconfig.ComponentMetadataConfigmapMountPathKey)
+	fileName := viper.GetString(sharedconfig.ComponentMetadataContextIdKeyKey)
+	filePath := fmt.Sprintf("%s/%s", dirPath, fileName)
+	res, err := os.ReadFile(filePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+
+	logrus.Info("Setting context id")
+	componentinfo.SetGlobalContextId(string(res))
+	return true, nil
 }

--- a/src/shared/config/config.go
+++ b/src/shared/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/spf13/viper"
 	"strings"
+	"time"
 )
 
 /*
@@ -11,17 +12,24 @@ Shared config keys between all reporter components - DNS Sniffer, Kafka watcher,
 */
 
 const (
-	MapperApiUrlKey              = "mapper-api-url"
-	MapperApiUrlDefault          = "http://mapper:9090/query"
-	DebugKey                     = "debug"
-	DebugDefault                 = false
-	PrometheusMetricsPortKey     = "metrics-port"
-	PrometheusMetricsPortDefault = 2112
-	TelemetryErrorsAPIKeyKey     = "telemetry-errors-api-key"
-	TelemetryErrorsAPIKeyDefault = "d86195588a41fa03aa6711993bb1c765"
-
-	EnvPodKey       = "pod"
-	EnvNamespaceKey = "namespace"
+	MapperApiUrlKey                            = "mapper-api-url"
+	MapperApiUrlDefault                        = "http://mapper:9090/query"
+	DebugKey                                   = "debug"
+	DebugDefault                               = false
+	PrometheusMetricsPortKey                   = "metrics-port"
+	PrometheusMetricsPortDefault               = 2112
+	TelemetryErrorsAPIKeyKey                   = "telemetry-errors-api-key"
+	TelemetryErrorsAPIKeyDefault               = "d86195588a41fa03aa6711993bb1c765"
+	ComponentMetadataConfigmapNameKey          = "component-metadata-configmap-name"
+	componentMetadataConfigmapNameDefault      = "otterize-network-mapper-component-config-map"
+	ReadContextIdIntervalKey                   = "read-context-id-interval"
+	ReadContextIdIntervalDefault               = 5 * time.Second
+	ComponentMetadataConfigmapMountPathKey     = "component-configmap-path"
+	ComponentMetadataConfigmapMountPathDefault = "/etc/otterize"
+	ComponentMetadataContextIdKeyKey           = "context-id-key"
+	ComponentMetadataContextIdKeyDefault       = "CONTEXT_ID"
+	EnvPodKey                                  = "pod"
+	EnvNamespaceKey                            = "namespace"
 
 	envPrefix = "OTTERIZE"
 )
@@ -37,6 +45,10 @@ func init() {
 	viper.SetDefault(DebugKey, DebugDefault)
 	viper.SetDefault(PrometheusMetricsPortKey, PrometheusMetricsPortDefault)
 	viper.SetDefault(TelemetryErrorsAPIKeyKey, TelemetryErrorsAPIKeyDefault)
+	viper.SetDefault(ComponentMetadataConfigmapNameKey, componentMetadataConfigmapNameDefault)
+	viper.SetDefault(ReadContextIdIntervalKey, ReadContextIdIntervalDefault)
+	viper.SetDefault(ComponentMetadataConfigmapMountPathKey, ComponentMetadataConfigmapMountPathDefault)
+	viper.SetDefault(ComponentMetadataContextIdKeyKey, ComponentMetadataContextIdKeyDefault)
 	viper.SetEnvPrefix(envPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/src/shared/kubeutils/kubeutils.go
+++ b/src/shared/kubeutils/kubeutils.go
@@ -2,8 +2,6 @@ package kubeutils
 
 import (
 	"fmt"
-	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
-	"github.com/spf13/viper"
 	"os"
 	"strings"
 )
@@ -15,11 +13,6 @@ const (
 )
 
 func GetCurrentNamespace() (string, error) {
-	// For local development only
-	if viper.IsSet(sharedconfig.EnvNamespaceKey) {
-		return viper.GetString(sharedconfig.EnvNamespaceKey), nil
-	}
-
 	data, err := os.ReadFile(namespaceFile)
 	if err != nil {
 		return "", err

--- a/src/shared/kubeutils/kubeutils.go
+++ b/src/shared/kubeutils/kubeutils.go
@@ -2,6 +2,8 @@ package kubeutils
 
 import (
 	"fmt"
+	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
+	"github.com/spf13/viper"
 	"os"
 	"strings"
 )
@@ -13,6 +15,11 @@ const (
 )
 
 func GetCurrentNamespace() (string, error) {
+	// For local development only
+	if viper.IsSet(sharedconfig.EnvNamespaceKey) {
+		return viper.GetString(sharedconfig.EnvNamespaceKey), nil
+	}
+
 	data, err := os.ReadFile(namespaceFile)
 	if err != nil {
 		return "", err

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -79,18 +79,18 @@ func main() {
 
 	err := errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when running server or HTTP server")
+		logrus.WithError(err).Fatal("Error when running server or HTTP server")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = healthServer.Shutdown(timeoutCtx)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down")
+		logrus.WithError(err).Fatal("Error when shutting down")
 	}
 
 	err = metricsServer.Shutdown(timeoutCtx)
 	if err != nil {
-		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down")
+		logrus.WithError(err).Fatal("Error when shutting down")
 	}
 }

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -79,18 +79,18 @@ func main() {
 
 	err := errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		logrus.WithError(err).Fatal("Error when running server or HTTP server")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when running server or HTTP server")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = healthServer.Shutdown(timeoutCtx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error when shutting down")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down")
 	}
 
 	err = metricsServer.Shutdown(timeoutCtx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error when shutting down")
+		componentutils.ExitDueToInitFailure(logrus.WithError(err), "Error when shutting down")
 	}
 }

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	errgrp.Go(func() error {
 		defer bugsnag.AutoNotify(errGroupCtx)
-		return componentutils.WaitAndSetContextId()
+		return componentutils.WaitAndSetContextId(errGroupCtx)
 	})
 
 	err := errgrp.Wait()

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -72,6 +72,11 @@ func main() {
 		return snifferInstance.RunForever(errGroupCtx)
 	})
 
+	errgrp.Go(func() error {
+		defer bugsnag.AutoNotify(errGroupCtx)
+		return componentutils.WaitAndSetContextId()
+	})
+
 	err := errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logrus.WithError(err).Fatal("Error when running server or HTTP server")


### PR DESCRIPTION
### Description

Allow sharing the mapper context id with the other components who don't call directly to the control plane.

[Related Helm PR
](https://github.com/otterize/helm-charts/pull/146)
### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
