### PR TITLE
Wrap errors for error reports with stack traces

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Khan/genqlient v0.6.0
 	github.com/amit7itz/goset v1.2.1
 	github.com/bombsimon/logrusr/v3 v3.0.0
-	github.com/bugsnag/bugsnag-go/v2 v2.2.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
@@ -48,6 +47,7 @@ require (
 	github.com/alexflint/go-arg v1.4.3 // indirect
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bugsnag/bugsnag-go/v2 v2.2.0 // indirect
 	github.com/bugsnag/panicwrap v1.3.4 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263
 	github.com/otterize/go-procnet v0.1.1
-	github.com/otterize/intents-operator/src v0.0.0-20231210192949-b2bb8d69efbd
+	github.com/otterize/intents-operator/src v0.0.0-20240110111055-38cf6a4dad75
 	github.com/prometheus/client_golang v1.15.1
 	github.com/samber/lo v1.33.0
 	github.com/sirupsen/logrus v1.9.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -302,8 +302,8 @@ github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263 h1:Qd1Ml+uEhpesT8Og
 github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263/go.mod h1:odkMeLkWS8G6+WP2z3Pn2vkzhPSvBtFhAUYTKXAtZMQ=
 github.com/otterize/go-procnet v0.1.1 h1:5vRwX35VrsWcy2uP05sA4PmwpRoAu2L4vMJou4og8Kk=
 github.com/otterize/go-procnet v0.1.1/go.mod h1:WEm282HzrSVBZg6DX2fNB4dpVHBPTCjzHWvqOfauV+Q=
-github.com/otterize/intents-operator/src v0.0.0-20231210192949-b2bb8d69efbd h1:rdpNMu76DPVnuyY5cZasJNR9sGv6bib9baLT7cou0Os=
-github.com/otterize/intents-operator/src v0.0.0-20231210192949-b2bb8d69efbd/go.mod h1:rhzHePKtBY9FY2/moybuccbMKQNipZR2RH9K75YjMJY=
+github.com/otterize/intents-operator/src v0.0.0-20240110111055-38cf6a4dad75 h1:qEWlrt4k5Bikc7qoXjwh8GXA5o8I0FkV13BSiioCkjw=
+github.com/otterize/intents-operator/src v0.0.0-20240110111055-38cf6a4dad75/go.mod h1:0pYcwTHklQtDAxbiQt+azsQAW9jqj3kypI66wh0gE14=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=

--- a/src/istio-watcher/cmd/main.go
+++ b/src/istio-watcher/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/bombsimon/logrusr/v3"
-	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
@@ -57,22 +56,22 @@ func main() {
 	metricsServer.GET("/metrics", echoprometheus.NewHandler())
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return metricsServer.Start(fmt.Sprintf(":%d", viper.GetInt(sharedconfig.PrometheusMetricsPortKey)))
 	})
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return healthServer.Start(":9090")
 	})
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		err := istioWatcher.RunForever(errGroupCtx)
 		return err
 	})
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return componentutils.WaitAndSetContextId(errGroupCtx)
 	})
 

--- a/src/istio-watcher/cmd/main.go
+++ b/src/istio-watcher/cmd/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/labstack/echo/v4"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
 	"github.com/otterize/network-mapper/src/istio-watcher/pkg/mapperclient"
@@ -46,7 +46,7 @@ func main() {
 	healthServer.GET("/healthz", func(c echo.Context) error {
 		err := mapperClient.Health(c.Request().Context())
 		if err != nil {
-			return err
+			return errors.Wrap(err)
 		}
 		return c.NoContent(http.StatusOK)
 	})
@@ -67,7 +67,7 @@ func main() {
 	errgrp.Go(func() error {
 		defer errorreporter.AutoNotify()
 		err := istioWatcher.RunForever(errGroupCtx)
-		return err
+		return errors.Wrap(err)
 	})
 
 	errgrp.Go(func() error {

--- a/src/istio-watcher/pkg/mapperclient/client.go
+++ b/src/istio-watcher/pkg/mapperclient/client.go
@@ -3,6 +3,7 @@ package mapperclient
 import (
 	"context"
 	"github.com/Khan/genqlient/graphql"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"net/http"
 )
 
@@ -25,10 +26,10 @@ func NewMapperClient(mapperAddress string) MapperClient {
 
 func (c *mapperClientImpl) ReportIstioConnections(ctx context.Context, results IstioConnectionResults) error {
 	_, err := reportIstioConnections(ctx, c.gqlClient, results)
-	return err
+	return errors.Wrap(err)
 }
 
 func (c *mapperClientImpl) Health(ctx context.Context) error {
 	_, err := Health(ctx, c.gqlClient)
-	return err
+	return errors.Wrap(err)
 }

--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -8,7 +8,6 @@ import (
 
 	"fmt"
 	"github.com/bombsimon/logrusr/v3"
-	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
@@ -100,22 +99,22 @@ func main() {
 	metricsServer.GET("/metrics", echoprometheus.NewHandler())
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return metricsServer.Start(fmt.Sprintf(":%d", viper.GetInt(sharedconfig.PrometheusMetricsPortKey)))
 	})
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return healthServer.Start(":9090")
 	})
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		err := watcher.RunForever(errGroupCtx)
 		return err
 	})
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return componentutils.WaitAndSetContextId(errGroupCtx)
 	})
 

--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"errors"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/network-mapper/src/shared/componentutils"
 
@@ -89,7 +89,7 @@ func main() {
 	healthServer.GET("/healthz", func(c echo.Context) error {
 		err := mapperClient.Health(c.Request().Context())
 		if err != nil {
-			return err
+			return errors.Wrap(err)
 		}
 		return c.NoContent(http.StatusOK)
 	})
@@ -110,7 +110,7 @@ func main() {
 	errgrp.Go(func() error {
 		defer errorreporter.AutoNotify()
 		err := watcher.RunForever(errGroupCtx)
-		return err
+		return errors.Wrap(err)
 	})
 
 	errgrp.Go(func() error {
@@ -141,7 +141,7 @@ func parseKafkaServers(serverNames []string) ([]types.NamespacedName, error) {
 	for _, serverName := range serverNames {
 		nameParts := strings.Split(serverName, ".")
 		if len(nameParts) != 2 {
-			return nil, fmt.Errorf("error parsing server pod name %s - should be formatted as 'name.namespace'", serverName)
+			return nil, errors.Errorf("error parsing server pod name %s - should be formatted as 'name.namespace'", serverName)
 		}
 		servers = append(servers, types.NamespacedName{
 			Name:      nameParts[0],

--- a/src/kafka-watcher/pkg/mapperclient/client.go
+++ b/src/kafka-watcher/pkg/mapperclient/client.go
@@ -3,6 +3,7 @@ package mapperclient
 import (
 	"context"
 	"github.com/Khan/genqlient/graphql"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"net/http"
 )
 
@@ -25,10 +26,10 @@ func NewMapperClient(mapperAddress string) MapperClient {
 
 func (c *mapperClientImpl) ReportKafkaMapperResults(ctx context.Context, results KafkaMapperResults) error {
 	_, err := reportKafkaMapperResults(ctx, c.gqlClient, results)
-	return err
+	return errors.Wrap(err)
 }
 
 func (c *mapperClientImpl) Health(ctx context.Context) error {
 	_, err := Health(ctx, c.gqlClient)
-	return err
+	return errors.Wrap(err)
 }

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -183,7 +183,7 @@ func main() {
 	}
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		awsIntentsHolder.PeriodicIntentsUpload(errGroupCtx, cloudUploaderConfig.UploadInterval)
 		return nil
 	})

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/bombsimon/logrusr/v3"
-	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/google/uuid"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/neko-neko/echo-logrus/v2/log"
@@ -89,7 +88,7 @@ func main() {
 	}
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		logrus.Info("Starting operator manager")
 		if err := mgr.Start(errGroupCtx); err != nil {
 			logrus.Error(err, "unable to run manager")
@@ -165,13 +164,13 @@ func main() {
 	}
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		intentsHolder.PeriodicIntentsUpload(errGroupCtx, cloudUploaderConfig.UploadInterval)
 		return nil
 	})
 	if viper.GetBool(config.ExternalTrafficCaptureEnabledKey) {
 		errgrp.Go(func() error {
-			defer bugsnag.AutoNotify(errGroupCtx)
+			defer errorreporter.AutoNotify()
 			externalTrafficIntentsHolder.PeriodicIntentsUpload(errGroupCtx, cloudUploaderConfig.UploadInterval)
 			return nil
 		})
@@ -182,15 +181,15 @@ func main() {
 	telemetrysender.NetworkMapperRunActiveReporter(errGroupCtx)
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return metricsServer.Start(fmt.Sprintf(":%d", viper.GetInt(sharedconfig.PrometheusMetricsPortKey)))
 	})
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return mapperServer.Start(":9090")
 	})
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return resolver.RunForever(errGroupCtx)
 	})
 

--- a/src/mapper/fix-errors-import.sh
+++ b/src/mapper/fix-errors-import.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env sh
+# This script is a workaround to this issue: https://github.com/99designs/gqlgen/issues/1171
+# Until they make it possible to use a custom errors package, we run this replace after gqlgen generate.
+
+if find . -name "*.resolvers.go" -exec false {} +
+then
+  echo 'no files found'
+  exit 0
+fi
+
+# Remove blank lines from imports to let gofmt sort all import lines consistently
+find . -name "*.resolvers.go" -exec sed -i '' -e '
+  /^import/,/)/ {
+    /^$/ d
+  }
+' {} +
+
+# Run gofmt, replacing native "errors" pkg with out own
+find . -name "*.resolvers.go" -exec gofmt -w -r '"errors" -> "github.com/otterize/intents-operator/src/shared/errors"' {} +

--- a/src/mapper/generate.go
+++ b/src/mapper/generate.go
@@ -1,3 +1,4 @@
 package mapper
 
 //go:generate go run github.com/99designs/gqlgen@v0.17.2
+//go:generate ./fix-errors-import.sh

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -3,6 +3,7 @@ package cloudclient
 import (
 	"context"
 	"github.com/Khan/genqlient/graphql"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/sirupsen/logrus"
 )
@@ -22,7 +23,7 @@ func NewClient(ctx context.Context) (*CloudClientImpl, bool, error) {
 	if !ok {
 		return nil, false, nil
 	} else if err != nil {
-		return nil, true, err
+		return nil, true, errors.Wrap(err)
 	}
 
 	return &CloudClientImpl{client: client}, true, nil
@@ -33,7 +34,7 @@ func (c *CloudClientImpl) ReportDiscoveredIntents(ctx context.Context, intents [
 
 	_, err := ReportDiscoveredIntents(ctx, c.client, intents)
 	if err != nil {
-		return err
+		return errors.Wrap(err)
 	}
 
 	return nil
@@ -44,7 +45,7 @@ func (c *CloudClientImpl) ReportExternalTrafficDiscoveredIntents(ctx context.Con
 
 	_, err := ReportExternalTrafficDiscoveredIntents(ctx, c.client, intents)
 	if err != nil {
-		return err
+		return errors.Wrap(err)
 	}
 
 	return nil
@@ -55,7 +56,7 @@ func (c *CloudClientImpl) ReportComponentStatus(ctx context.Context, component C
 
 	_, err := ReportComponentStatus(ctx, c.client, component)
 	if err != nil {
-		return err
+		return errors.Wrap(err)
 	}
 	return nil
 }

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -127,6 +127,7 @@ type IntentInput struct {
 	Resources         []*HTTPConfigInput     `json:"resources"`
 	DatabaseResources []*DatabaseConfigInput `json:"databaseResources"`
 	AwsActions        []*string              `json:"awsActions"`
+	Internet          *InternetConfigInput   `json:"internet"`
 	Status            *IntentStatusInput     `json:"status"`
 }
 
@@ -157,6 +158,9 @@ func (v *IntentInput) GetDatabaseResources() []*DatabaseConfigInput { return v.D
 // GetAwsActions returns IntentInput.AwsActions, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetAwsActions() []*string { return v.AwsActions }
 
+// GetInternet returns IntentInput.Internet, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetInternet() *InternetConfigInput { return v.Internet }
+
 // GetStatus returns IntentInput.Status, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetStatus() *IntentStatusInput { return v.Status }
 
@@ -175,7 +179,19 @@ const (
 	IntentTypeDatabase IntentType = "DATABASE"
 	IntentTypeAws      IntentType = "AWS"
 	IntentTypeS3       IntentType = "S3"
+	IntentTypeInternet IntentType = "INTERNET"
 )
+
+type InternetConfigInput struct {
+	Ips   []*string `json:"ips"`
+	Ports []*int    `json:"ports"`
+}
+
+// GetIps returns InternetConfigInput.Ips, and is useful for accessing the field via an interface.
+func (v *InternetConfigInput) GetIps() []*string { return v.Ips }
+
+// GetPorts returns InternetConfigInput.Ports, and is useful for accessing the field via an interface.
+func (v *InternetConfigInput) GetPorts() []*int { return v.Ports }
 
 type IstioStatusInput struct {
 	ServiceAccountName     *string `json:"serviceAccountName"`

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -106,7 +106,6 @@ type AccessGraphEdge {
 	client: Service!
 	server: Service!
 	discoveredIntents: [Intent!]!
-	externalTrafficDiscoveredIntents: [ExternalTrafficIntent!]!
 	appliedIntents: [Intent!]!
 	accessStatus: EdgeAccessStatus!
 }
@@ -259,6 +258,11 @@ enum ComponentType {
 	NETWORK_MAPPER
 }
 
+type CreateGithubIntegrationResponse {
+	integration: Integration!
+	nextURL: String!
+}
+
 type CredentialsOperatorComponent {
 	type: ComponentType!
 	status: ComponentStatus!
@@ -276,11 +280,6 @@ enum CustomConstraint {
 enum DBPermissionChange {
 	APPLY
 	DELETE
-}
-
-type DNSIPPair {
-	dnsName: String!
-	ips: [String!]
 }
 
 input DNSIPPairInput {
@@ -314,12 +313,14 @@ type DatabaseInfo {
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentials!
+	visibility: DatabaseVisibilitySettings
 }
 
 input DatabaseInfoInput {
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentialsInput!
+	visibility: DatabaseVisibilitySettingsInput
 }
 
 enum DatabaseOperation {
@@ -332,6 +333,20 @@ enum DatabaseOperation {
 
 enum DatabaseType {
 	POSTGRESQL
+}
+
+type DatabaseVisibilitySettings {
+	source: DatabaseVisibilitySource
+	gcpPubSub: GCPPubSubLogConsumerSettings
+}
+
+input DatabaseVisibilitySettingsInput {
+	source: DatabaseVisibilitySource
+	gcpPubSub: GCPPubSubLogConsumerSettingsInput
+}
+
+enum DatabaseVisibilitySource {
+	GCP_PUBSUB
 }
 
 input DiscoveredIntentInput {
@@ -353,6 +368,7 @@ enum EdgeAccessStatusReason {
 	ALLOWED_BY_APPLIED_INTENTS_OVERLY_PERMISSIVE
 	ALLOWED_BY_APPLIED_INTENTS_HTTP_OVERLY_PERMISSIVE
 	ALLOWED_BY_APPLIED_INTENTS_KAFKA_OVERLY_PERMISSIVE
+	ALLOWED_BY_APPLIED_INTENTS_DATABASE_OVERLY_PERMISSIVE
 	ALLOWED_BY_EXTERNAL_TRAFFIC_NETWORK_POLICY
 	BLOCKED_BY_APPLIED_INTENTS_UNDER_PERMISSIVE
 	BLOCKED_BY_APPLIED_INTENTS_RESOURCE_MISMATCH
@@ -361,6 +377,9 @@ enum EdgeAccessStatusReason {
 	BLOCKED_BY_APPLIED_INTENTS_KAFKA_UNDER_PERMISSIVE
 	BLOCKED_BY_APPLIED_INTENTS_KAFKA_RESOURCE_MISMATCH
 	BLOCKED_BY_KAFKA_ENFORCEMENT_CONFIG_MISSING_APPLIED_INTENTS
+	BLOCKED_BY_APPLIED_INTENTS_DATABASE_UNDER_PERMISSIVE
+	BLOCKED_BY_APPLIED_INTENTS_DATABASE_RESOURCE_MISMATCH
+	BLOCKED_BY_DATABASE_ENFORCEMENT_CONFIG_MISSING_APPLIED_INTENTS
 	BLOCKED_BY_DEFAULT_DENY
 	SHARED_SERVICE_ACCOUNT
 	CLIENT_ISTIO_SIDECAR_MISSING
@@ -400,6 +419,7 @@ enum EventType {
 	INTENTS_APPLIED_KAFKA
 	INTENTS_APPLIED_HTTP
 	INTENTS_APPLIED_DATABASE
+	INTENTS_APPLIED_INTERNET
 	INTENTS_DISCOVERED
 	INTENTS_DISCOVERED_SOCKET_SCAN
 	INTENTS_DISCOVERED_CAPTURE
@@ -428,13 +448,6 @@ input ExternalTrafficDiscoveredIntentInput {
 	intent: ExternalTrafficIntentInput!
 }
 
-type ExternalTrafficIntent {
-	id: ID!
-	server: Service!
-	client: Service!
-	target: DNSIPPair!
-}
-
 input ExternalTrafficIntentInput {
 	namespace: String!
 	clientName: String!
@@ -443,6 +456,31 @@ input ExternalTrafficIntentInput {
 
 """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""
 scalar Float
+
+type GCPPubSubLogConsumerSettings {
+	projectId: String!
+	topic: String!
+}
+
+input GCPPubSubLogConsumerSettingsInput {
+	projectId: String!
+	topic: String!
+}
+
+type GithubInfo {
+	repoOwner: String!
+	repoName: String!
+	baseBranch: String!
+	intentsPath: String!
+}
+
+input GithubInfoInput {
+	repoOwner: String!
+	repoName: String!
+	baseBranch: String!
+	intentsPath: String!
+	clusterId: String!
+}
 
 type HTTPConfig {
 	path: String!
@@ -491,6 +529,8 @@ type Integration {
 	cluster: Cluster
 	databaseInfo: DatabaseInfo
 	awsInfo: AWSInfo
+	githubInfo: GithubInfo
+	organizationId: String!
 }
 
 type IntegrationComponents {
@@ -509,6 +549,7 @@ enum IntegrationType {
 	KUBERNETES
 	DATABASE
 	AWS
+	GITHUB
 }
 
 type Intent {
@@ -520,6 +561,7 @@ type Intent {
 	httpResources: [HTTPConfig!]
 	databaseResources: [DatabaseConfig!]
 	awsActions: [String!]
+	internet: InternetConfig
 	status: IntentStatus
 }
 
@@ -533,6 +575,7 @@ input IntentInput {
 	resources: [HTTPConfigInput!]
 	databaseResources: [DatabaseConfigInput!]
 	awsActions: [String!]
+	internet: InternetConfigInput
 	status: IntentStatusInput
 }
 
@@ -553,6 +596,7 @@ enum IntentType {
 	DATABASE
 	AWS
 	S3
+	INTERNET
 }
 
 type IntentsOperatorComponent {
@@ -576,6 +620,17 @@ input IntentsOperatorConfigurationInput {
 	kafkaACLEnforcementEnabled: Boolean
 	istioPolicyEnforcementEnabled: Boolean
 	protectedServicesEnabled: Boolean
+}
+
+type InternetConfig {
+	dnsName: String!
+	ips: [String!]
+	ports: [Int!]
+}
+
+input InternetConfigInput {
+	ips: [String!]!
+	ports: [Int!]
 }
 
 type Invite {
@@ -774,6 +829,17 @@ type Mutation {
 		name: String!
 		awsIntegration: AWSInfoInput!
 	): Integration
+"""Create a new Github integration"""
+	createGithubIntegration(
+		name: String!
+		githubInfo: GithubInfoInput!
+	): CreateGithubIntegrationResponse
+"""Update Github integration"""
+	updateGithubIntegration(
+		id: ID!
+		name: String!
+		githubInfo: GithubInfoInput!
+	): Integration
 """Update AWS integration"""
 	updateAWSIntegration(
 		id: ID!
@@ -882,6 +948,14 @@ type Mutation {
 		id: ID!
 		step: QuestLogStep!
 	): Boolean!
+	saveOnboardingSelection(
+		id: ID!
+		selection: OnboardingSelection!
+	): Boolean!
+	saveOnboardingSelectionOther(
+		id: ID!
+		selection: String!
+	): Boolean!
 }
 
 type Namespace {
@@ -910,6 +984,12 @@ input NetworkPolicyInput {
 	externalNetworkTrafficPolicy: Boolean!
 }
 
+enum OnboardingSelection {
+	DEFAULT
+	AWS_IAM
+	OTHER
+}
+
 type Organization {
 	id: ID!
 	name: String
@@ -929,6 +1009,7 @@ type Query {
 	): AccessGraph!
 	serviceClientIntents(
 		id: ID!
+		asServiceId: ID
 		lastSeenAfter: Time!
 	): ServiceClientIntents!
 """Get cluster"""
@@ -978,6 +1059,10 @@ type Query {
 		databaseInfo: DatabaseInfoInput!
 		integrationId: ID
 	): TestDatabaseConnectionResponse!
+"""Test database visibility connectivity"""
+	testDatabaseVisibilityConnection(
+		databaseInfo: DatabaseInfoInput!
+	): TestDatabaseConnectionResponse!
 """List user invites"""
 	invites(
 		email: String
@@ -1016,6 +1101,8 @@ type Query {
 	organization(
 		id: ID!
 	): Organization!
+"""Checks the availability of the API server"""
+	ping: Boolean!
 """Get service"""
 	service(
 		id: ID!
@@ -1051,8 +1138,6 @@ enum QuestLogStep {
 	DECLARE_INTENTS_CLICK_ON_SERVICE
 	DECLARE_INTENTS_DOWNLOAD_YAML
 	DECLARE_INTENTS_DO_APPLY
-"""Enable intents"""
-	ENABLE_ENFORCEMENT_CREATE_PROTECTED_SERVICE
 	COMPLETED
 }
 
@@ -1103,6 +1188,7 @@ enum ServerProtectionStatusReason {
 	IGNORED_IN_CALCULATION
 	PROTECTED_BY_DATABASE_INTEGRATION
 	PROTECTED_BY_AWS_IAM_INTEGRATION
+	PROTECTED_BY_INTERNET_INTENTS
 }
 
 enum ServerProtectionStatusVerdict {
@@ -1127,6 +1213,7 @@ type Service {
 	certificateInformation: CertificateInformation
 	serviceAccount: String
 	awsResource: AWSResource
+	discoveredByIntegration: Integration
 	tlsKeyPair: KeyPair!
 	userAndPassword: UserAndPassword!
 }
@@ -1160,6 +1247,7 @@ enum ServiceType {
 	AWS
 	DATABASE
 	INTERNET
+	DATABASE_USER
 }
 
 """The `String`scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."""
@@ -1197,6 +1285,8 @@ type User {
 	authProviderUserId: String!
 	questLogStep: QuestLogStep!
 	questLogStepSeen: QuestLogStep!
+	onboardingSelection: OnboardingSelection!
+	onboardingSelectionOther: String!
 }
 
 type UserAndPassword {

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -7,6 +7,12 @@ directive @constraint(
 	example: String!
 ) on ENUM_VALUE
 
+"""The @defer directive may be specified on a fragment spread to imply de-prioritization, that causes the fragment to be omitted in the initial response, and delivered as a subsequent response afterward. A query with @defer directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred delivered in a subsequent response. @include and @skip take precedence over @defer."""
+directive @defer(
+	if: Boolean
+	label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 """The @deprecated built-in directive is used within the type system definition language to indicate deprecated portions of a GraphQL service's schema, such as deprecated fields on a type, arguments on a field, input fields on an input type, or values of an enum type."""
 directive @deprecated(
 	reason: String
@@ -394,6 +400,7 @@ enum EdgeAccessStatusReason {
 	INTERNET_ACCESS_STATUS_UNKNOWN
 	NO_INTENTS_FOUND_OF_RELEVANT_TYPE
 	IGNORED_IN_CALCULATION
+	INTERNET_INTENTS_ENFORCEMENT_DISABLED
 }
 
 enum EdgeAccessStatusVerdict {
@@ -467,19 +474,36 @@ input GCPPubSubLogConsumerSettingsInput {
 	topic: String!
 }
 
-type GithubInfo {
-	repoOwner: String!
-	repoName: String!
+type GitHubRepoFilterPair {
+	filter: AccessGraphFilter!
+	repoInfo: GitHubRepoInfo!
+}
+
+input GitHubRepoFilterPairInput {
+	filter: InputAccessGraphFilter!
+	repoInfo: GitHubRepoInfoInput!
+}
+
+type GitHubRepoInfo {
+	repository: String!
 	baseBranch: String!
 	intentsPath: String!
 }
 
-input GithubInfoInput {
-	repoOwner: String!
-	repoName: String!
+input GitHubRepoInfoInput {
+	repository: String!
 	baseBranch: String!
 	intentsPath: String!
-	clusterId: String!
+}
+
+type GitHubSettings {
+	isActive: Boolean!
+	repoFilterPairs: [GitHubRepoFilterPair!]!
+}
+
+input GitHubSettingsInput {
+	isActive: Boolean!
+	repoFilterPairs: [GitHubRepoFilterPairInput!]!
 }
 
 type HTTPConfig {
@@ -529,7 +553,7 @@ type Integration {
 	cluster: Cluster
 	databaseInfo: DatabaseInfo
 	awsInfo: AWSInfo
-	githubInfo: GithubInfo
+	githubSettings: GitHubSettings
 	organizationId: String!
 }
 
@@ -612,6 +636,7 @@ type IntentsOperatorConfiguration {
 	istioPolicyEnforcementEnabled: Boolean!
 	protectedServicesEnabled: Boolean!
 	protectedServices: [Service!]!
+	egressNetworkPolicyEnforcementEnabled: Boolean!
 }
 
 input IntentsOperatorConfigurationInput {
@@ -620,6 +645,7 @@ input IntentsOperatorConfigurationInput {
 	kafkaACLEnforcementEnabled: Boolean
 	istioPolicyEnforcementEnabled: Boolean
 	protectedServicesEnabled: Boolean
+	egressNetworkPolicyEnforcementEnabled: Boolean
 }
 
 type InternetConfig {
@@ -832,13 +858,13 @@ type Mutation {
 """Create a new Github integration"""
 	createGithubIntegration(
 		name: String!
-		githubInfo: GithubInfoInput!
+		githubSettings: GitHubSettingsInput!
 	): CreateGithubIntegrationResponse
 """Update Github integration"""
 	updateGithubIntegration(
 		id: ID!
 		name: String!
-		githubInfo: GithubInfoInput!
+		githubSettings: GitHubSettingsInput!
 	): Integration
 """Update AWS integration"""
 	updateAWSIntegration(
@@ -1011,6 +1037,7 @@ type Query {
 		id: ID!
 		asServiceId: ID
 		lastSeenAfter: Time!
+		clusterIds: [ID!]
 	): ServiceClientIntents!
 """Get cluster"""
 	cluster(

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -2,6 +2,7 @@ package clouduploader
 
 import (
 	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"time"
 
@@ -60,7 +61,7 @@ func (c *CloudUploader) NotifyIntents(ctx context.Context, intents []intentsstor
 			err := c.client.ReportDiscoveredIntents(ctx, discoveredIntentsChunks[currentChunk])
 			if err != nil {
 				logrus.WithError(err).Errorf("Failed to report discovered intents chunk %d to cloud, retrying", currentChunk)
-				return err
+				return errors.Wrap(err)
 			}
 			currentChunk += 1
 		}
@@ -104,7 +105,7 @@ func (c *CloudUploader) NotifyExternalTrafficIntents(ctx context.Context, intent
 			err := c.client.ReportExternalTrafficDiscoveredIntents(ctx, discoveredIntentsChunks[currentChunk])
 			if err != nil {
 				logrus.WithError(err).Errorf("Failed to report discovered intents chunk %d to cloud, retrying", currentChunk)
-				return err
+				return errors.Wrap(err)
 			}
 			currentChunk += 1
 		}

--- a/src/mapper/pkg/graph/model/kafkaop.go
+++ b/src/mapper/pkg/graph/model/kafkaop.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -25,7 +24,7 @@ func KafkaOpFromText(text string) (KafkaOperation, error) {
 
 	apiOp, ok := kafkaOperationToAclOperation[normalized]
 	if !ok {
-		return "", fmt.Errorf("failed parsing op %s", text)
+		return "", errors.Errorf("failed parsing op %s", text)
 	}
 	return apiOp, nil
 }

--- a/src/mapper/pkg/graph/model/kafkaop.go
+++ b/src/mapper/pkg/graph/model/kafkaop.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"strings"
 )
 

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -146,12 +146,12 @@ func (e HTTPMethod) String() string {
 func (e *HTTPMethod) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return errors.Errorf("enums must be strings")
+		return fmt.Errorf("enums must be strings")
 	}
 
 	*e = HTTPMethod(str)
 	if !e.IsValid() {
-		return errors.Errorf("%s is not a valid HttpMethod", str)
+		return fmt.Errorf("%s is not a valid HttpMethod", str)
 	}
 	return nil
 }
@@ -187,12 +187,12 @@ func (e IntentType) String() string {
 func (e *IntentType) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return errors.Errorf("enums must be strings")
+		return fmt.Errorf("enums must be strings")
 	}
 
 	*e = IntentType(str)
 	if !e.IsValid() {
-		return errors.Errorf("%s is not a valid IntentType", str)
+		return fmt.Errorf("%s is not a valid IntentType", str)
 	}
 	return nil
 }
@@ -246,12 +246,12 @@ func (e KafkaOperation) String() string {
 func (e *KafkaOperation) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return errors.Errorf("enums must be strings")
+		return fmt.Errorf("enums must be strings")
 	}
 
 	*e = KafkaOperation(str)
 	if !e.IsValid() {
-		return errors.Errorf("%s is not a valid KafkaOperation", str)
+		return fmt.Errorf("%s is not a valid KafkaOperation", str)
 	}
 	return nil
 }

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -146,12 +146,12 @@ func (e HTTPMethod) String() string {
 func (e *HTTPMethod) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("enums must be strings")
+		return errors.Errorf("enums must be strings")
 	}
 
 	*e = HTTPMethod(str)
 	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid HttpMethod", str)
+		return errors.Errorf("%s is not a valid HttpMethod", str)
 	}
 	return nil
 }
@@ -187,12 +187,12 @@ func (e IntentType) String() string {
 func (e *IntentType) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("enums must be strings")
+		return errors.Errorf("enums must be strings")
 	}
 
 	*e = IntentType(str)
 	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid IntentType", str)
+		return errors.Errorf("%s is not a valid IntentType", str)
 	}
 	return nil
 }
@@ -246,12 +246,12 @@ func (e KafkaOperation) String() string {
 func (e *KafkaOperation) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("enums must be strings")
+		return errors.Errorf("enums must be strings")
 	}
 
 	*e = KafkaOperation(str)
 	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid KafkaOperation", str)
+		return errors.Errorf("%s is not a valid KafkaOperation", str)
 	}
 	return nil
 }

--- a/src/mapper/pkg/intentsstore/holder.go
+++ b/src/mapper/pkg/intentsstore/holder.go
@@ -3,6 +3,7 @@ package intentsstore
 import (
 	"context"
 	"encoding/json"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"strings"
 	"sync"
 	"time"
@@ -226,7 +227,7 @@ func (i *IntentsHolder) GetIntents(
 		serverFilter)
 
 	if err != nil {
-		return []TimestampedIntent{}, err
+		return []TimestampedIntent{}, errors.Wrap(err)
 	}
 	return result, nil
 }
@@ -273,7 +274,7 @@ func (i *IntentsHolder) getIntentsFromStore(
 	for pair, intent := range store {
 		intentCopy, err := getIntentDeepCopy(intent)
 		if err != nil {
-			return result, err
+			return result, errors.Wrap(err)
 		}
 
 		if len(excludeServiceWithLabels) != 0 && intentCopy.containsExcludedLabels(excludedLabelsMap) {
@@ -323,10 +324,10 @@ func getIntentDeepCopy(intent TimestampedIntent) (TimestampedIntent, error) {
 	intentCopy := TimestampedIntent{}
 	intentJSON, err := json.Marshal(intent)
 	if err != nil {
-		return TimestampedIntent{}, err
+		return TimestampedIntent{}, errors.Wrap(err)
 	}
 	if err = json.Unmarshal(intentJSON, &intentCopy); err != nil {
-		return TimestampedIntent{}, err
+		return TimestampedIntent{}, errors.Wrap(err)
 	}
 	return intentCopy, nil
 }

--- a/src/mapper/pkg/metricexporter/metric_exporter.go
+++ b/src/mapper/pkg/metricexporter/metric_exporter.go
@@ -2,6 +2,7 @@ package metricexporter
 
 import (
 	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
 
 	"github.com/otterize/network-mapper/src/mapper/pkg/intentsstore"
 	"github.com/sirupsen/logrus"
@@ -14,7 +15,7 @@ type MetricExporter struct {
 func NewMetricExporter(ctx context.Context) (*MetricExporter, error) {
 	em, err := NewOtelEdgeMetric(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 
 	return &MetricExporter{

--- a/src/mapper/pkg/metricexporter/otel_edge_metric.go
+++ b/src/mapper/pkg/metricexporter/otel_edge_metric.go
@@ -2,6 +2,7 @@ package metricexporter
 
 import (
 	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"time"
 
 	"github.com/otterize/network-mapper/src/mapper/pkg/config"
@@ -38,13 +39,13 @@ func newMeterProvider(ctx context.Context, res *resource.Resource) (*sdk.MeterPr
 	// - OTEL_EXPORTER_OTLP_TIMEOUT (...)
 	metricExporter, err := otlpmetricgrpc.New(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 
 	if viper.GetBool(sharedconfig.DebugKey) {
 		stdOutExporter, err := stdoutmetric.New()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err)
 		}
 		meterProvider := sdk.NewMeterProvider(
 			sdk.WithResource(res),
@@ -69,12 +70,12 @@ func (o *OtelEdgeMetric) Record(ctx context.Context, from string, to string) {
 func NewOtelEdgeMetric(ctx context.Context) (*OtelEdgeMetric, error) {
 	res, err := newResource()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 
 	meterProvider, err := newMeterProvider(ctx, res)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 
 	var meter = meterProvider.Meter("otelexporter")
@@ -83,7 +84,7 @@ func NewOtelEdgeMetric(ctx context.Context) (*OtelEdgeMetric, error) {
 		metric.WithDescription("Count of edges between two nodes"),
 	)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 
 	return &OtelEdgeMetric{

--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
 	"github.com/sirupsen/logrus"
@@ -26,23 +25,23 @@ func (r *Resolver) discoverSrcIdentity(ctx context.Context, src model.RecordedDe
 	srcPod, err := r.kubeFinder.ResolveIPToPod(ctx, src.SrcIP)
 	if err != nil {
 		if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
-			return model.OtterizeServiceIdentity{}, fmt.Errorf("IP %s belongs to more than one pod, ignoring", src.SrcIP)
+			return model.OtterizeServiceIdentity{}, errors.Errorf("IP %s belongs to more than one pod, ignoring", src.SrcIP)
 		}
-		return model.OtterizeServiceIdentity{}, fmt.Errorf("could not resolve %s to pod: %w", src.SrcIP, err)
+		return model.OtterizeServiceIdentity{}, errors.Errorf("could not resolve %s to pod: %w", src.SrcIP, err)
 	}
 	if src.SrcHostname != "" && srcPod.Name != src.SrcHostname {
 		// This could mean a new pod is reusing the same IP
 		// TODO: Use the captured hostname to actually find the relevant pod (instead of the IP that might no longer exist or be reused)
-		return model.OtterizeServiceIdentity{}, fmt.Errorf("found pod %s (by ip %s) doesn't match captured hostname %s, ignoring", srcPod.Name, src.SrcIP, src.SrcHostname)
+		return model.OtterizeServiceIdentity{}, errors.Errorf("found pod %s (by ip %s) doesn't match captured hostname %s, ignoring", srcPod.Name, src.SrcIP, src.SrcHostname)
 	}
 
 	if srcPod.DeletionTimestamp != nil {
-		return model.OtterizeServiceIdentity{}, fmt.Errorf("pod %s is being deleted, ignoring", srcPod.Name)
+		return model.OtterizeServiceIdentity{}, errors.Errorf("pod %s is being deleted, ignoring", srcPod.Name)
 	}
 
 	srcService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, srcPod)
 	if err != nil {
-		return model.OtterizeServiceIdentity{}, fmt.Errorf("could not resolve pod %s to identity: %w", srcPod.Name, err)
+		return model.OtterizeServiceIdentity{}, errors.Errorf("could not resolve pod %s to identity: %w", srcPod.Name, err)
 	}
 	filteredDestinations := make([]model.Destination, 0)
 	for _, dest := range src.Destinations {

--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -2,7 +2,7 @@ package resolvers
 
 import (
 	"context"
-	"errors"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
 	"github.com/sirupsen/logrus"

--- a/src/mapper/pkg/resolvers/resolver.go
+++ b/src/mapper/pkg/resolvers/resolver.go
@@ -77,7 +77,7 @@ func (r *Resolver) RunForever(ctx context.Context) error {
 	})
 	err := errgrp.Wait()
 	if err != nil && !errors.Is(err, context.Canceled) {
-		return err
+		return errors.Wrap(err)
 	}
 	return nil
 }

--- a/src/mapper/pkg/resolvers/resolver.go
+++ b/src/mapper/pkg/resolvers/resolver.go
@@ -3,10 +3,10 @@ package resolvers
 import (
 	"context"
 	"github.com/99designs/gqlgen/graphql/handler"
-	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/generated"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
@@ -60,19 +60,19 @@ func (r *Resolver) Register(e *echo.Echo) {
 func (r *Resolver) RunForever(ctx context.Context) error {
 	errgrp, errGrpCtx := errgroup.WithContext(ctx)
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGrpCtx)
+		defer errorreporter.AutoNotify()
 		return runHandleLoop(errGrpCtx, r.dnsCaptureResults, r.handleReportCaptureResults)
 	})
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGrpCtx)
+		defer errorreporter.AutoNotify()
 		return runHandleLoop(errGrpCtx, r.socketScanResults, r.handleReportSocketScanResults)
 	})
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGrpCtx)
+		defer errorreporter.AutoNotify()
 		return runHandleLoop(errGrpCtx, r.kafkaMapperResults, r.handleReportKafkaMapperResults)
 	})
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGrpCtx)
+		defer errorreporter.AutoNotify()
 		return runHandleLoop(errGrpCtx, r.istioConnectionResults, r.handleReportIstioConnectionResults)
 	})
 	err := errgrp.Wait()

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Khan/genqlient/graphql"
 	"github.com/labstack/echo/v4"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/intentsstore"
@@ -15,7 +16,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"net/http/httptest"
@@ -304,7 +305,7 @@ func (s *ResolverTestSuite) TestReportCaptureResultsPodDeletion() {
 		func(ctx context.Context) (done bool, err error) {
 			var readPod v1.Pod
 			err = s.Mgr.GetClient().Get(ctx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, &readPod)
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				return false, nil
 			}
 			if err != nil {

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -308,7 +308,7 @@ func (s *ResolverTestSuite) TestReportCaptureResultsPodDeletion() {
 				return false, nil
 			}
 			if err != nil {
-				return false, err
+				return false, errors.Wrap(err)
 			}
 
 			if !slices.Contains(readPod.Finalizers, "intents.otterize.com/finalizer-so-that-object-cant-be-deleted-for-this-test") {

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -6,7 +6,6 @@ package resolvers
 import (
 	"context"
 	"github.com/otterize/intents-operator/src/shared/errors"
-
 	"github.com/otterize/network-mapper/src/mapper/pkg/awsintentsholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/generated"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -5,6 +5,7 @@ package resolvers
 
 import (
 	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
 
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/generated"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
@@ -80,7 +81,7 @@ func (r *queryResolver) ServiceIntents(ctx context.Context, namespaces []string,
 	}
 	discoveredIntents, err := r.intentsHolder.GetIntents(namespaces, includeLabels, []string{}, shouldIncludeAllLabels, nil)
 	if err != nil {
-		return []model.ServiceIntents{}, err
+		return []model.ServiceIntents{}, errors.Wrap(err)
 	}
 	intentsBySource := intentsstore.GroupIntentsBySource(discoveredIntents)
 
@@ -112,7 +113,7 @@ func (r *queryResolver) Intents(ctx context.Context, namespaces []string, includ
 		server,
 	)
 	if err != nil {
-		return []model.Intent{}, err
+		return []model.Intent{}, errors.Wrap(err)
 	}
 
 	intents := lo.Map(timestampedIntents, func(timestampedIntent intentsstore.TimestampedIntent, _ int) model.Intent {

--- a/src/shared/componentutils/utils.go
+++ b/src/shared/componentutils/utils.go
@@ -2,8 +2,8 @@ package componentutils
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
@@ -26,7 +26,7 @@ func WaitAndSetContextId(ctx context.Context) error {
 		ok, err := setContextId()
 		if err != nil {
 			logrus.WithError(err).Error("Error when setting context id")
-			return err
+			return errors.Wrap(err)
 		}
 		if ok {
 			logrus.Info("Context id set successfully")
@@ -49,7 +49,7 @@ func setContextId() (bool, error) {
 	filePath := fmt.Sprintf("%s/%s", dirPath, fileName)
 	res, err := os.ReadFile(filePath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return false, err
+		return false, errors.Wrap(err)
 	}
 
 	if errors.Is(err, os.ErrNotExist) {

--- a/src/shared/kubeutils/kubeutils.go
+++ b/src/shared/kubeutils/kubeutils.go
@@ -1,7 +1,7 @@
 package kubeutils
 
 import (
-	"fmt"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
 	"github.com/spf13/viper"
 	"os"
@@ -22,7 +22,7 @@ func GetCurrentNamespace() (string, error) {
 
 	data, err := os.ReadFile(namespaceFile)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err)
 	}
 	return strings.TrimSpace(string(data)), nil
 }
@@ -30,11 +30,11 @@ func GetCurrentNamespace() (string, error) {
 func GetClusterDomain() (string, error) {
 	namespace, err := GetCurrentNamespace()
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err)
 	}
 	data, err := os.ReadFile(resolvFile)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err)
 	}
 	expectedSearchDomainPrefix := namespace + ".svc."
 	for _, line := range strings.Split(string(data), "\n") {
@@ -49,5 +49,5 @@ func GetClusterDomain() (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("could not deduce cluster domain from %s", resolvFile)
+	return "", errors.Errorf("could not deduce cluster domain from %s", resolvFile)
 }

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -3,12 +3,13 @@ package testbase
 import (
 	"context"
 	"fmt"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -84,11 +85,11 @@ func (s *ControllerManagerTestSuiteBase) waitForObjectToBeCreated(obj client.Obj
 		true,
 		func(ctx context.Context) (done bool, err error) {
 			err = s.Mgr.GetClient().Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				return false, nil
 			}
 			if err != nil {
-				return false, err
+				return false, errors.Wrap(err)
 			}
 			return true, nil
 		}),
@@ -173,11 +174,11 @@ func (s *ControllerManagerTestSuiteBase) GetAPIServerService() *corev1.Service {
 		true,
 		func(ctx context.Context) (done bool, err error) {
 			err = s.Mgr.GetClient().Get(ctx, types.NamespacedName{Name: "kubernetes", Namespace: "default"}, service)
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				return false, nil
 			}
 			if err != nil {
-				return false, err
+				return false, errors.Wrap(err)
 			}
 			return true, nil
 		}),

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/bombsimon/logrusr/v3"
-	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
@@ -45,7 +44,7 @@ func main() {
 
 	healthServer := echo.New()
 	healthServer.GET("/healthz", func(c echo.Context) error {
-		defer bugsnag.AutoNotify(c)
+		defer errorreporter.AutoNotify()
 		err := mapperClient.Health(c.Request().Context())
 		if err != nil {
 			return err
@@ -58,22 +57,22 @@ func main() {
 	metricsServer.GET("/metrics", echoprometheus.NewHandler())
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return metricsServer.Start(fmt.Sprintf(":%d", viper.GetInt(sharedconfig.PrometheusMetricsPortKey)))
 	})
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return healthServer.Start(":9090")
 	})
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		snifferInstance := sniffer.NewSniffer(mapperClient)
 		return snifferInstance.RunForever(errGroupCtx)
 	})
 
 	errgrp.Go(func() error {
-		defer bugsnag.AutoNotify(errGroupCtx)
+		defer errorreporter.AutoNotify()
 		return componentutils.WaitAndSetContextId(errGroupCtx)
 	})
 

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/labstack/echo/v4"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
 	"github.com/otterize/network-mapper/src/shared/componentutils"
@@ -47,7 +47,7 @@ func main() {
 		defer errorreporter.AutoNotify()
 		err := mapperClient.Health(c.Request().Context())
 		if err != nil {
-			return err
+			return errors.Wrap(err)
 		}
 		return c.NoContent(http.StatusOK)
 	})

--- a/src/sniffer/pkg/collectors/dnssniffer.go
+++ b/src/sniffer/pkg/collectors/dnssniffer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/config"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/ipresolver"
 	"github.com/sirupsen/logrus"
@@ -40,11 +41,11 @@ func NewDNSSniffer(resolver ipresolver.IPResolver) *DNSSniffer {
 func (s *DNSSniffer) CreateDNSPacketStream() (chan gopacket.Packet, error) {
 	handle, err := pcap.OpenLive("any", 0, true, pcap.BlockForever)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 	err = handle.SetBPFFilter("udp port 53")
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 
 	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
@@ -81,7 +82,7 @@ func (s *DNSSniffer) HandlePacket(packet gopacket.Packet) {
 func (s *DNSSniffer) RefreshHostsMapping() error {
 	err := s.resolver.Refresh()
 	if err != nil {
-		return err
+		return errors.Wrap(err)
 	}
 
 	for _, p := range s.pending {

--- a/src/sniffer/pkg/ipresolver/process_monitor.go
+++ b/src/sniffer/pkg/ipresolver/process_monitor.go
@@ -1,6 +1,7 @@
 package ipresolver
 
 import (
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -59,7 +60,7 @@ func (pm *ProcessMonitor) Poll() error {
 		// Shouldn't handle again
 		pm.processes.Insert(pid)
 	}); err != nil {
-		return err
+		return errors.Wrap(err)
 	}
 
 	exitedProcesses := processesSeenLastTime.Difference(pm.processes)

--- a/src/sniffer/pkg/ipresolver/procfs_resolver.go
+++ b/src/sniffer/pkg/ipresolver/procfs_resolver.go
@@ -1,7 +1,7 @@
 package ipresolver
 
 import (
-	"errors"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
@@ -45,13 +45,13 @@ func (r *ProcFSIPResolver) onProcessNew(pid int64, pDir string) (err error) {
 	hostname, err = utils.ExtractProcessHostname(pDir)
 	if err != nil {
 		logrus.Debugf("Failed to extract hostname for process %d: %v", pid, err)
-		return err
+		return errors.Wrap(err)
 	}
 
 	ipaddr, err = utils.ExtractProcessIPAddr(pDir)
 	if err != nil {
 		logrus.Debugf("Failed to extract IP address for process %d: %v", pid, err)
-		return err
+		return errors.Wrap(err)
 	}
 
 	if entry, ok := r.byAddr[ipaddr]; ok {

--- a/src/sniffer/pkg/mapperclient/client.go
+++ b/src/sniffer/pkg/mapperclient/client.go
@@ -3,6 +3,7 @@ package mapperclient
 import (
 	"context"
 	"github.com/Khan/genqlient/graphql"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"net/http"
 )
 
@@ -20,17 +21,17 @@ func NewMapperClient(mapperAddress string) MapperClient {
 
 func (c *MapperClientImpl) ReportCaptureResults(ctx context.Context, results CaptureResults) error {
 	_, err := reportCaptureResults(ctx, c.gqlClient, results)
-	return err
+	return errors.Wrap(err)
 }
 
 func (c *MapperClientImpl) ReportSocketScanResults(ctx context.Context, results SocketScanResults) error {
 	_, err := reportSocketScanResults(ctx, c.gqlClient, results)
-	return err
+	return errors.Wrap(err)
 }
 
 func (c *MapperClientImpl) Health(ctx context.Context) error {
 	_, err := Health(ctx, c.gqlClient)
-	return err
+	return errors.Wrap(err)
 }
 
 type MapperClient interface {

--- a/src/sniffer/pkg/sniffer/sniffer.go
+++ b/src/sniffer/pkg/sniffer/sniffer.go
@@ -2,6 +2,7 @@ package sniffer
 
 import (
 	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/prometheus"
 	"time"
 
@@ -86,7 +87,7 @@ func (s *Sniffer) getTimeTilNextReport() time.Duration {
 func (s *Sniffer) RunForever(ctx context.Context) error {
 	packetsChan, err := s.dnsSniffer.CreateDNSPacketStream()
 	if err != nil {
-		return err
+		return errors.Wrap(err)
 	}
 
 	for {

--- a/src/sniffer/pkg/utils/procfs.go
+++ b/src/sniffer/pkg/utils/procfs.go
@@ -1,9 +1,9 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"github.com/mpvl/unique"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/sirupsen/logrus"
 	"os"
 	"regexp"
@@ -21,7 +21,7 @@ func ScanProcDirProcesses(callback ProcessScanCallback) error {
 	hostProcDir := viper.GetString(config.HostProcDirKey)
 	files, err := os.ReadDir(hostProcDir)
 	if err != nil {
-		return err
+		return errors.Wrap(err)
 	}
 
 	for _, f := range files {
@@ -39,7 +39,7 @@ func ExtractProcessHostname(pDir string) (string, error) {
 	// Read the environment variables from the proc filesystem
 	data, err := os.ReadFile(fmt.Sprintf("%s/environ", pDir))
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err)
 	}
 
 	// Split the environment variables by null byte
@@ -57,14 +57,14 @@ func ExtractProcessHostname(pDir string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("couldn't find hostname in %s/environ", pDir)
+	return "", errors.Errorf("couldn't find hostname in %s/environ", pDir)
 
 }
 
 func ExtractProcessIPAddr(pDir string) (string, error) {
 	contentBytes, err := os.ReadFile(fmt.Sprintf("%s/net/fib_trie", pDir))
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err)
 	}
 
 	content := string(contentBytes)


### PR DESCRIPTION
This PR wraps most errors returned in the intents-operator so that they include the stack.