### PR TITLE
Catch errors from all goroutines in network-mapper

### DIFF
--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -272,7 +272,7 @@ func shutdownGracefullyOnCancel(errGroupCtx context.Context, server *echo.Echo) 
 
 	if shutdownErr != nil {
 		logrus.WithError(shutdownErr).Error("failed to shutdown server")
-	}
+		_ = server.Close()
 
-	_ = server.Close()
+	}
 }


### PR DESCRIPTION
The `echo` framework used for serving webhooks and metrics
did not use the context used in other parts of the mapper.
Thus, the process did not exit when a critical part of it
did not start properly, preventing a restart and error
reporting.

This commit shuts down echo cleanly when the main context is Done.