### PR TITLE
Group S3 object operations as wildcard

### DIFF
--- a/build/mapper.Dockerfile
+++ b/build/mapper.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.21-alpine as buildenv
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine as buildenv
 RUN apk add --no-cache ca-certificates git protoc
 RUN apk add build-base libpcap-dev
 WORKDIR /src

--- a/src/go.mod
+++ b/src/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.31
 	github.com/Khan/genqlient v0.6.0
 	github.com/amit7itz/goset v1.2.1
+	github.com/aws/aws-sdk-go-v2 v1.23.0
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/golang/mock v1.6.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -58,6 +58,8 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/aws/aws-sdk-go-v2 v1.23.0 h1:PiHAzmiQQr6JULBUdvR8fKlA+UPKLT/8KbiqpFBWiAo=
+github.com/aws/aws-sdk-go-v2 v1.23.0/go.mod h1:i1XDttT4rnf6vxc9AuskLc6s7XBee8rlLilKlc03uAA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=

--- a/src/mapper/pkg/awsintentsholder/holder.go
+++ b/src/mapper/pkg/awsintentsholder/holder.go
@@ -50,7 +50,7 @@ func (h *AWSIntentsHolder) AddIntent(intent AWSIntent) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	logrus.Warnf("Adding intent: %+v", intent)
+	logrus.Debugf("Adding intent: %+v", intent)
 
 	key := AWSIntentKey{
 		ClientName:      intent.Client.Name,
@@ -100,11 +100,10 @@ func (h *AWSIntentsHolder) getNewIntentsSinceLastGet() []AWSIntent {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	intents := make([]AWSIntent, 0, len(h.intents))
+	transformers := AWSIntentRootTransformer{}
+	intents := lo.MapToSlice(h.intents, func(key AWSIntentKey, value TimestampedAWSIntent) AWSIntent {
+		return value.AWSIntent
+	})
 
-	for _, intent := range h.intents {
-		intents = append(intents, intent.AWSIntent)
-	}
-
-	return intents
+	return transformers.Transform(intents)
 }

--- a/src/mapper/pkg/awsintentsholder/transformers.go
+++ b/src/mapper/pkg/awsintentsholder/transformers.go
@@ -1,0 +1,106 @@
+package awsintentsholder
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+type AWSIntentsTransformer interface {
+	Transform(intents []AWSIntent) []AWSIntent
+}
+
+type AWSIntentRootTransformer struct{}
+type AWSIntentFlattenTransformer struct{}
+type S3ObjectTransformer struct{}
+
+func (g *AWSIntentRootTransformer) Transform(intents []AWSIntent) []AWSIntent {
+	transformers := []AWSIntentsTransformer{
+		&AWSIntentFlattenTransformer{},
+		&S3ObjectTransformer{},
+	}
+
+	for _, transformer := range transformers {
+		intents = transformer.Transform(intents)
+	}
+
+	return intents
+
+}
+func (g *AWSIntentFlattenTransformer) Transform(intents []AWSIntent) []AWSIntent {
+	result := make([]AWSIntent, 0)
+
+	for _, intent := range intents {
+		for _, action := range intent.Actions {
+			result = append(result, AWSIntent{
+				Client:  intent.Client,
+				Actions: []string{action},
+				ARN:     intent.ARN,
+			})
+		}
+	}
+
+	return result
+}
+
+func (g *S3ObjectTransformer) Transform(intents []AWSIntent) []AWSIntent {
+	result := make([]AWSIntent, 0)
+
+	for _, intent := range intents {
+		arnId, err := arn.Parse(intent.ARN)
+
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to parse ARN: %s", intent.ARN)
+			continue
+		}
+
+		isS3Object, bucketWildCardArn := g.isS3Object(arnId)
+
+		if isS3Object {
+			intent.ARN = bucketWildCardArn.String()
+		}
+
+		result = append(result, intent)
+	}
+
+	return result
+}
+
+func (g *S3ObjectTransformer) isS3Object(arnId arn.ARN) (bool, *arn.ARN) {
+	if arnId.Service != "s3" {
+		return false, nil
+	}
+
+	resource := arnId.Resource
+
+	if resource == "" {
+		return false, nil
+	}
+
+	before, _, found := strings.Cut(resource, "/")
+
+	if !found {
+		return false, nil
+	}
+
+	reservedNames := []string{
+		"accesspoint",
+		"job",
+		"storage-lens",
+		"storage-lens-group",
+		"async-request",
+		"access-grants",
+	}
+
+	// skip non-object resources
+	if lo.Contains(reservedNames, before) {
+		return false, nil
+	}
+
+	bucketName := before
+	bucketWildCardArn := arnId
+	bucketWildCardArn.Resource = fmt.Sprintf("%s/*", bucketName)
+	return true, &bucketWildCardArn
+}

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -223,7 +223,7 @@ func (r *mutationResolver) ReportIstioConnectionResults(ctx context.Context, res
 
 func (r *mutationResolver) ReportAWSOperation(ctx context.Context, operation []model.AWSOperation) (bool, error) {
 	for _, op := range operation {
-		logrus.Infof("Received AWS operation: %+v", op)
+		logrus.Debugf("Received AWS operation: %+v", op)
 		srcPod, err := r.kubeFinder.ResolveIPToPod(ctx, op.SrcIP)
 
 		if err != nil {


### PR DESCRIPTION
### Description
Merge discovered intents to S3 object (files) into a wildcard intent.

Example:
a `GetObject` operation to two files:
```
s3://some-bucket/file-0.txt
s3://some-bucket/file-1.txt
```

will create an intent for
`s3://some-bucket/*`

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
