### PR TITLE
Fixed case where mapper could fail to initialize when domain name Internet intents were enabled

### DIFF
--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/metadata"
 	"net/http"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -110,6 +109,10 @@ func main() {
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
 
 	dnsCache := dnscache.NewDNSCache()
+	dnsPublisher, dnsPublisherEnabled, err := dnsintentspublisher.InitWithManager(errGroupCtx, mgr, dnsCache)
+	if err != nil {
+		logrus.WithError(err).Panic("Failed to initialize DNS publisher")
+	}
 
 	mapperServer := echo.New()
 	mapperServer.HideBanner = true
@@ -258,9 +261,12 @@ func main() {
 		intentsHolder.RegisterNotifyIntents(otelExporter.NotifyIntents)
 	}
 
-	err = StartDNSClientIntentsPublisher(mgr, dnsCache, errGroupCtx, errgrp)
-	if err != nil {
-		logrus.WithError(err).Panic("failed to initialize DNS client intents publisher")
+	if dnsPublisherEnabled {
+		errgrp.Go(func() error {
+			defer errorreporter.AutoNotify()
+			dnsPublisher.RunForever(errGroupCtx)
+			return nil
+		})
 	}
 
 	errgrp.Go(func() error {
@@ -308,31 +314,6 @@ func main() {
 			logrus.WithError(err).Error("failed to shutdown server")
 		}
 	}
-}
-
-func StartDNSClientIntentsPublisher(mgr manager.Manager, dnsCache *dnscache.DNSCache, errGroupCtx context.Context, errgrp *errgroup.Group) error {
-	if viper.GetBool(config.DNSClientIntentsUpdateEnabledKey) {
-		dnsPublisher := dnsintentspublisher.NewPublisher(mgr.GetClient(), dnsCache)
-		err := dnsPublisher.InitIndices(errGroupCtx, mgr)
-		if err != nil {
-			if discoveryErr := (&apiutil.ErrResourceDiscoveryFailed{}); errors.As(err, &discoveryErr) {
-				for gvk := range *discoveryErr {
-					if gvk.Group == "k8s.otterize.com" {
-						logrus.Debugf("DNS client intents publishing is not enabled due to missing CRD %v", gvk)
-						// This can happen if the network mapper is deployed without the intents operator, which is normal.
-						return nil
-					}
-				}
-			}
-			return errors.Wrap(err)
-		}
-		errgrp.Go(func() error {
-			defer errorreporter.AutoNotify()
-			dnsPublisher.RunForever(errGroupCtx)
-			return nil
-		})
-	}
-	return nil
 }
 
 func shutdownGracefullyOnCancel(errGroupCtx context.Context, server *echo.Echo) {

--- a/src/mapper/pkg/dnsintentspublisher/init.go
+++ b/src/mapper/pkg/dnsintentspublisher/init.go
@@ -1,0 +1,36 @@
+package dnsintentspublisher
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
+	"github.com/otterize/network-mapper/src/mapper/pkg/dnscache"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func InitWithManager(ctx context.Context, mgr manager.Manager, dnsCache *dnscache.DNSCache) (*Publisher, bool, error) {
+	if !viper.GetBool(config.DNSClientIntentsUpdateEnabledKey) {
+		return nil, false, nil
+	}
+
+	dnsPublisher := NewPublisher(mgr.GetClient(), dnsCache)
+	err := dnsPublisher.InitIndices(ctx, mgr)
+	if err != nil {
+		discoveryErr := (&apiutil.ErrResourceDiscoveryFailed{})
+		if errors.As(err, &discoveryErr) {
+			for gvk := range *discoveryErr {
+				if gvk.Group == "k8s.otterize.com" {
+					// This can happen if the network mapper is deployed without the intents operator, which is normal.
+					logrus.Debugf("DNS client intents publishing is not enabled due to missing CRD %v", gvk)
+					return nil, false, nil
+				}
+			}
+		}
+		return nil, false, errors.Wrap(err)
+	}
+
+	return dnsPublisher, true, nil
+}

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"testing"
 	"time"
@@ -267,7 +268,7 @@ func (s *ResolverTestSuite) TestReportCaptureResultsPodDeletion() {
 	err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, &podToUpdate)
 	s.Require().NoError(err)
 	s.Require().True(controllerutil.AddFinalizer(&podToUpdate, "intents.otterize.com/finalizer-so-that-object-cant-be-deleted-for-this-test"))
-	err = s.Mgr.GetClient().Update(context.Background(), &podToUpdate)
+	err = s.Mgr.GetClient().Patch(context.Background(), &podToUpdate, client.MergeFrom(pod))
 	s.Require().NoError(err)
 
 	interval := 1 * time.Second


### PR DESCRIPTION
### Description

This PR initialized the DNS publisher index before the manager start, since otherwise it cause panic.


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
