### PR TITLE
Add TCP based intents discovery

### DIFF
--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -9,6 +9,27 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+type AzureKeyVaultPolicyInput struct {
+	CertificatePermissions []*string `json:"certificatePermissions"`
+	KeyPermissions         []*string `json:"keyPermissions"`
+	SecretPermissions      []*string `json:"secretPermissions"`
+	StoragePermissions     []*string `json:"storagePermissions"`
+}
+
+// GetCertificatePermissions returns AzureKeyVaultPolicyInput.CertificatePermissions, and is useful for accessing the field via an interface.
+func (v *AzureKeyVaultPolicyInput) GetCertificatePermissions() []*string {
+	return v.CertificatePermissions
+}
+
+// GetKeyPermissions returns AzureKeyVaultPolicyInput.KeyPermissions, and is useful for accessing the field via an interface.
+func (v *AzureKeyVaultPolicyInput) GetKeyPermissions() []*string { return v.KeyPermissions }
+
+// GetSecretPermissions returns AzureKeyVaultPolicyInput.SecretPermissions, and is useful for accessing the field via an interface.
+func (v *AzureKeyVaultPolicyInput) GetSecretPermissions() []*string { return v.SecretPermissions }
+
+// GetStoragePermissions returns AzureKeyVaultPolicyInput.StoragePermissions, and is useful for accessing the field via an interface.
+func (v *AzureKeyVaultPolicyInput) GetStoragePermissions() []*string { return v.StoragePermissions }
+
 type ComponentType string
 
 const (
@@ -118,19 +139,20 @@ const (
 )
 
 type IntentInput struct {
-	Namespace         *string                `json:"namespace"`
-	ClientName        *string                `json:"clientName"`
-	ServerName        *string                `json:"serverName"`
-	ServerNamespace   *string                `json:"serverNamespace"`
-	Type              *IntentType            `json:"type"`
-	Topics            []*KafkaConfigInput    `json:"topics"`
-	Resources         []*HTTPConfigInput     `json:"resources"`
-	DatabaseResources []*DatabaseConfigInput `json:"databaseResources"`
-	AwsActions        []*string              `json:"awsActions"`
-	AzureRoles        []*string              `json:"azureRoles"`
-	GcpPermissions    []*string              `json:"gcpPermissions"`
-	Internet          *InternetConfigInput   `json:"internet"`
-	Status            *IntentStatusInput     `json:"status"`
+	Namespace           *string                   `json:"namespace"`
+	ClientName          *string                   `json:"clientName"`
+	ServerName          *string                   `json:"serverName"`
+	ServerNamespace     *string                   `json:"serverNamespace"`
+	Type                *IntentType               `json:"type"`
+	Topics              []*KafkaConfigInput       `json:"topics"`
+	Resources           []*HTTPConfigInput        `json:"resources"`
+	DatabaseResources   []*DatabaseConfigInput    `json:"databaseResources"`
+	AwsActions          []*string                 `json:"awsActions"`
+	AzureRoles          []*string                 `json:"azureRoles"`
+	AzureKeyVaultPolicy *AzureKeyVaultPolicyInput `json:"azureKeyVaultPolicy"`
+	GcpPermissions      []*string                 `json:"gcpPermissions"`
+	Internet            *InternetConfigInput      `json:"internet"`
+	Status              *IntentStatusInput        `json:"status"`
 }
 
 // GetNamespace returns IntentInput.Namespace, and is useful for accessing the field via an interface.
@@ -162,6 +184,11 @@ func (v *IntentInput) GetAwsActions() []*string { return v.AwsActions }
 
 // GetAzureRoles returns IntentInput.AzureRoles, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetAzureRoles() []*string { return v.AzureRoles }
+
+// GetAzureKeyVaultPolicy returns IntentInput.AzureKeyVaultPolicy, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetAzureKeyVaultPolicy() *AzureKeyVaultPolicyInput {
+	return v.AzureKeyVaultPolicy
+}
 
 // GetGcpPermissions returns IntentInput.GcpPermissions, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetGcpPermissions() []*string { return v.GcpPermissions }

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -175,6 +175,20 @@ input AzureInfoInput {
 	namespace: String!
 }
 
+type AzureKeyVaultPolicy {
+	certificatePermissions: [String!]
+	keyPermissions: [String!]
+	secretPermissions: [String!]
+	storagePermissions: [String!]
+}
+
+input AzureKeyVaultPolicyInput {
+	certificatePermissions: [String!]
+	keyPermissions: [String!]
+	secretPermissions: [String!]
+	storagePermissions: [String!]
+}
+
 type AzureResource {
 	resource: String!
 }
@@ -516,6 +530,13 @@ input ExternalTrafficIntentInput {
 	target: DNSIPPairInput!
 }
 
+input ExternallyAccessibleServiceInput {
+	namespace: String!
+	serverName: String!
+	referredByIngress: Boolean!
+	serviceType: KubernetesServiceType!
+}
+
 """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""
 scalar Float
 
@@ -646,6 +667,7 @@ type Integration {
 	azureInfo: AzureInfo
 	githubSettings: GitHubSettings
 	organizationId: String!
+	status: IntegrationStatus
 }
 
 type IntegrationComponents {
@@ -657,6 +679,17 @@ type IntegrationComponents {
 type IntegrationCredentials {
 	clientId: String!
 	clientSecret: String!
+}
+
+enum IntegrationState {
+	SUCCESS
+	FAILURE
+	PENDING
+}
+
+type IntegrationStatus {
+	state: IntegrationState!
+	errorMessage: String
 }
 
 enum IntegrationType {
@@ -679,6 +712,7 @@ type Intent {
 	databaseResources: [DatabaseConfig!]
 	awsActions: [String!]
 	azureRoles: [String!]
+	azureKeyVaultPolicy: AzureKeyVaultPolicy
 	gcpPermissions: [String!]
 	internet: InternetConfig
 	status: IntentStatus
@@ -695,6 +729,7 @@ input IntentInput {
 	databaseResources: [DatabaseConfigInput!]
 	awsActions: [String!]
 	azureRoles: [String!]
+	azureKeyVaultPolicy: AzureKeyVaultPolicyInput
 	gcpPermissions: [String!]
 	internet: InternetConfigInput
 	status: IntentStatusInput
@@ -756,6 +791,7 @@ input IntentsOperatorConfigurationInput {
 }
 
 type InternetConfig {
+	appliedDomains: [String!]
 	dnsName: String!
 	ips: [String!]
 	ports: [Int!]
@@ -850,6 +886,13 @@ type KeyPair {
 	certPEM: String!
 	rootCAPEM: String!
 	expiresAt: Int!
+}
+
+enum KubernetesServiceType {
+	LOAD_BALANCER
+	NODE_PORT
+	CLUSTER_IP
+	EXTERNAL_NAME
 }
 
 type Label {
@@ -1048,6 +1091,10 @@ type Mutation {
 	reportNetworkPolicies(
 		namespace: String!
 		policies: [NetworkPolicyInput!]!
+	): Boolean!
+	reportExternallyAccessibleServices(
+		namespace: String!
+		services: [ExternallyAccessibleServiceInput!]!
 	): Boolean!
 """Create user invite"""
 	createInvite(
@@ -1467,6 +1514,8 @@ enum TutorialEvent {
 enum TutorialName {
 	NETWORK_POLICIES
 	AWS_IAM
+	GCP_IAM
+	AZURE_IAM
 	POSTGRESQL
 	ISTIO_AUTH_POLICY_AUTOMATION
 	KAFKA_ACCESS_AUTOMATE_OTTERIZE_CLOUD

--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -78,6 +78,7 @@ type ComplexityRoot struct {
 		ReportIstioConnectionResults func(childComplexity int, results model.IstioConnectionResults) int
 		ReportKafkaMapperResults     func(childComplexity int, results model.KafkaMapperResults) int
 		ReportSocketScanResults      func(childComplexity int, results model.SocketScanResults) int
+		ReportTCPCaptureResults      func(childComplexity int, results model.CaptureTCPResults) int
 		ResetCapture                 func(childComplexity int) int
 	}
 
@@ -109,6 +110,7 @@ type ComplexityRoot struct {
 type MutationResolver interface {
 	ResetCapture(ctx context.Context) (bool, error)
 	ReportCaptureResults(ctx context.Context, results model.CaptureResults) (bool, error)
+	ReportTCPCaptureResults(ctx context.Context, results model.CaptureTCPResults) (bool, error)
 	ReportSocketScanResults(ctx context.Context, results model.SocketScanResults) (bool, error)
 	ReportKafkaMapperResults(ctx context.Context, results model.KafkaMapperResults) (bool, error)
 	ReportIstioConnectionResults(ctx context.Context, results model.IstioConnectionResults) (bool, error)
@@ -290,6 +292,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.ReportSocketScanResults(childComplexity, args["results"].(model.SocketScanResults)), true
 
+	case "Mutation.reportTCPCaptureResults":
+		if e.complexity.Mutation.ReportTCPCaptureResults == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_reportTCPCaptureResults_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.ReportTCPCaptureResults(childComplexity, args["results"].(model.CaptureTCPResults)), true
+
 	case "Mutation.resetCapture":
 		if e.complexity.Mutation.ResetCapture == nil {
 			break
@@ -401,6 +415,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputAWSOperation,
 		ec.unmarshalInputCaptureResults,
+		ec.unmarshalInputCaptureTCPResults,
 		ec.unmarshalInputDestination,
 		ec.unmarshalInputIstioConnection,
 		ec.unmarshalInputIstioConnectionResults,
@@ -524,6 +539,10 @@ input RecordedDestinationsForSrc {
 }
 
 input CaptureResults {
+    results: [RecordedDestinationsForSrc!]!
+}
+
+input CaptureTCPResults {
     results: [RecordedDestinationsForSrc!]!
 }
 
@@ -683,6 +702,7 @@ type Query {
 type Mutation {
     resetCapture: Boolean!
     reportCaptureResults(results: CaptureResults!): Boolean!
+    reportTCPCaptureResults(results: CaptureTCPResults!): Boolean!
     reportSocketScanResults(results: SocketScanResults!): Boolean!
     reportKafkaMapperResults(results: KafkaMapperResults!): Boolean!
     reportIstioConnectionResults(results: IstioConnectionResults!): Boolean!
@@ -762,6 +782,21 @@ func (ec *executionContext) field_Mutation_reportSocketScanResults_args(ctx cont
 	if tmp, ok := rawArgs["results"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("results"))
 		arg0, err = ec.unmarshalNSocketScanResults2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐSocketScanResults(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["results"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_reportTCPCaptureResults_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.CaptureTCPResults
+	if tmp, ok := rawArgs["results"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("results"))
+		arg0, err = ec.unmarshalNCaptureTCPResults2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐCaptureTCPResults(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -1587,6 +1622,61 @@ func (ec *executionContext) fieldContext_Mutation_reportCaptureResults(ctx conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_reportCaptureResults_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_reportTCPCaptureResults(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_reportTCPCaptureResults(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().ReportTCPCaptureResults(rctx, fc.Args["results"].(model.CaptureTCPResults))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_reportTCPCaptureResults(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_reportTCPCaptureResults_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -4382,6 +4472,33 @@ func (ec *executionContext) unmarshalInputCaptureResults(ctx context.Context, ob
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCaptureTCPResults(ctx context.Context, obj interface{}) (model.CaptureTCPResults, error) {
+	var it model.CaptureTCPResults
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"results"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "results":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("results"))
+			data, err := ec.unmarshalNRecordedDestinationsForSrc2ᚕgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐRecordedDestinationsForSrcᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Results = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDestination(ctx context.Context, obj interface{}) (model.Destination, error) {
 	var it model.Destination
 	asMap := map[string]interface{}{}
@@ -4934,6 +5051,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "reportCaptureResults":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_reportCaptureResults(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "reportTCPCaptureResults":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_reportTCPCaptureResults(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -5608,6 +5732,11 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 
 func (ec *executionContext) unmarshalNCaptureResults2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐCaptureResults(ctx context.Context, v interface{}) (model.CaptureResults, error) {
 	res, err := ec.unmarshalInputCaptureResults(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNCaptureTCPResults2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐCaptureTCPResults(ctx context.Context, v interface{}) (model.CaptureTCPResults, error) {
+	res, err := ec.unmarshalInputCaptureTCPResults(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -19,6 +19,10 @@ type CaptureResults struct {
 	Results []RecordedDestinationsForSrc `json:"results"`
 }
 
+type CaptureTCPResults struct {
+	Results []RecordedDestinationsForSrc `json:"results"`
+}
+
 type Destination struct {
 	Destination   string    `json:"destination"`
 	DestinationIP *string   `json:"destinationIP,omitempty"`

--- a/src/mapper/pkg/graph/model/results_length.go
+++ b/src/mapper/pkg/graph/model/results_length.go
@@ -21,3 +21,7 @@ type AWSOperationResults []AWSOperation
 func (c AWSOperationResults) Length() int {
 	return len(c)
 }
+
+func (c CaptureTCPResults) Length() int {
+	return len(c.Results)
+}

--- a/src/mapper/pkg/prometheus/metrics.go
+++ b/src/mapper/pkg/prometheus/metrics.go
@@ -14,6 +14,10 @@ var (
 		Name: "dns_reported_connections",
 		Help: "The total number of DNS-sourced reported connections",
 	})
+	tcpCaptureReports = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tcp_reported_connections",
+		Help: "The total number of TCP-sourced reported connections",
+	})
 	kafkaReports = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "kafka_reported_topics",
 		Help: "The total number of Kafka-sourced topics",
@@ -34,6 +38,10 @@ var (
 		Name: "dns_dropped_connections",
 		Help: "The total number of DNS-sourced reported connections that were dropped for performance",
 	})
+	tcpCaptureDrops = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "tcp_dropped_connections",
+		Help: "The total number of TCP-sourced reported connections that were dropped for performance",
+	})
 	kafkaReportsDrops = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "kafka_dropped_topics",
 		Help: "The total number of Kafka-sourced reported topics that were dropped for performance",
@@ -48,6 +56,14 @@ var (
 		Help: "The total number of AWS operations reported that were dropped for performance",
 	})
 )
+
+func IncrementTCPCaptureReports(count int) {
+	tcpCaptureReports.Add(float64(count))
+}
+
+func IncrementTCPCaptureDrops(count int) {
+	tcpCaptureDrops.Add(float64(count))
+}
 
 func IncrementSocketScanReports(count int) {
 	socketScanReports.Add(float64(count))

--- a/src/mapper/pkg/resolvers/resolver.go
+++ b/src/mapper/pkg/resolvers/resolver.go
@@ -29,6 +29,7 @@ type Resolver struct {
 	awsIntentsHolder             *awsintentsholder.AWSIntentsHolder
 	dnsCache                     *dnscache.DNSCache
 	dnsCaptureResults            chan model.CaptureResults
+	tcpCaptureResults            chan model.CaptureTCPResults
 	socketScanResults            chan model.SocketScanResults
 	kafkaMapperResults           chan model.KafkaMapperResults
 	istioConnectionResults       chan model.IstioConnectionResults
@@ -51,6 +52,7 @@ func NewResolver(
 		intentsHolder:                intentsHolder,
 		externalTrafficIntentsHolder: externalTrafficHolder,
 		dnsCaptureResults:            make(chan model.CaptureResults, 200),
+		tcpCaptureResults:            make(chan model.CaptureTCPResults, 200),
 		socketScanResults:            make(chan model.SocketScanResults, 200),
 		kafkaMapperResults:           make(chan model.KafkaMapperResults, 200),
 		istioConnectionResults:       make(chan model.IstioConnectionResults, 200),
@@ -77,6 +79,10 @@ func (r *Resolver) RunForever(ctx context.Context) error {
 	errgrp.Go(func() error {
 		defer bugsnag.AutoNotify(errGrpCtx)
 		return runHandleLoop(errGrpCtx, r.dnsCaptureResults, r.handleReportCaptureResults)
+	})
+	errgrp.Go(func() error {
+		defer bugsnag.AutoNotify(errGrpCtx)
+		return runHandleLoop(errGrpCtx, r.tcpCaptureResults, r.handleReportTCPCaptureResults)
 	})
 	errgrp.Go(func() error {
 		defer bugsnag.AutoNotify(errGrpCtx)

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -37,6 +37,20 @@ func (r *mutationResolver) ReportCaptureResults(ctx context.Context, results mod
 	}
 }
 
+// ReportTCPCaptureResults is the resolver for the reportTCPCaptureResults field.
+func (r *mutationResolver) ReportTCPCaptureResults(ctx context.Context, results model.CaptureTCPResults) (bool, error) {
+	select {
+	case r.tcpCaptureResults <- results:
+		prometheus.IncrementTCPCaptureReports(len(results.Results))
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+		prometheus.IncrementTCPCaptureDrops(len(results.Results))
+		return false, nil
+	}
+}
+
 // ReportSocketScanResults is the resolver for the reportSocketScanResults field.
 func (r *mutationResolver) ReportSocketScanResults(ctx context.Context, results model.SocketScanResults) (bool, error) {
 	select {

--- a/src/mapper/pkg/resolvers/test_gql_client/generated.go
+++ b/src/mapper/pkg/resolvers/test_gql_client/generated.go
@@ -17,6 +17,13 @@ type CaptureResults struct {
 // GetResults returns CaptureResults.Results, and is useful for accessing the field via an interface.
 func (v *CaptureResults) GetResults() []RecordedDestinationsForSrc { return v.Results }
 
+type CaptureTCPResults struct {
+	Results []RecordedDestinationsForSrc `json:"results"`
+}
+
+// GetResults returns CaptureTCPResults.Results, and is useful for accessing the field via an interface.
+func (v *CaptureTCPResults) GetResults() []RecordedDestinationsForSrc { return v.Results }
+
 type Destination struct {
 	Destination   string                  `json:"destination"`
 	DestinationIP nilable.Nilable[string] `json:"destinationIP"`
@@ -187,6 +194,16 @@ func (v *ReportSocketScanResultsResponse) GetReportSocketScanResults() bool {
 	return v.ReportSocketScanResults
 }
 
+// ReportTCPCaptureResultsResponse is returned by ReportTCPCaptureResults on success.
+type ReportTCPCaptureResultsResponse struct {
+	ReportTCPCaptureResults bool `json:"reportTCPCaptureResults"`
+}
+
+// GetReportTCPCaptureResults returns ReportTCPCaptureResultsResponse.ReportTCPCaptureResults, and is useful for accessing the field via an interface.
+func (v *ReportTCPCaptureResultsResponse) GetReportTCPCaptureResults() bool {
+	return v.ReportTCPCaptureResults
+}
+
 type ServerFilter struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
@@ -340,6 +357,14 @@ type __ReportSocketScanResultsInput struct {
 // GetResults returns __ReportSocketScanResultsInput.Results, and is useful for accessing the field via an interface.
 func (v *__ReportSocketScanResultsInput) GetResults() SocketScanResults { return v.Results }
 
+// __ReportTCPCaptureResultsInput is used internally by genqlient
+type __ReportTCPCaptureResultsInput struct {
+	Results CaptureTCPResults `json:"results"`
+}
+
+// GetResults returns __ReportTCPCaptureResultsInput.Results, and is useful for accessing the field via an interface.
+func (v *__ReportTCPCaptureResultsInput) GetResults() CaptureTCPResults { return v.Results }
+
 // __ServiceIntentsInput is used internally by genqlient
 type __ServiceIntentsInput struct {
 	Namespaces []string `json:"namespaces"`
@@ -464,6 +489,39 @@ func ReportSocketScanResults(
 	var err_ error
 
 	var data_ ReportSocketScanResultsResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by ReportTCPCaptureResults.
+const ReportTCPCaptureResults_Operation = `
+mutation ReportTCPCaptureResults ($results: CaptureTCPResults!) {
+	reportTCPCaptureResults(results: $results)
+}
+`
+
+func ReportTCPCaptureResults(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	results CaptureTCPResults,
+) (*ReportTCPCaptureResultsResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportTCPCaptureResults",
+		Query:  ReportTCPCaptureResults_Operation,
+		Variables: &__ReportTCPCaptureResultsInput{
+			Results: results,
+		},
+	}
+	var err_ error
+
+	var data_ ReportTCPCaptureResultsResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/mapper/pkg/resolvers/test_gql_client/genqlient.graphql
+++ b/src/mapper/pkg/resolvers/test_gql_client/genqlient.graphql
@@ -62,3 +62,7 @@ mutation ReportCaptureResults($results: CaptureResults!) {
 mutation ReportSocketScanResults($results: SocketScanResults!) {
     reportSocketScanResults(results: $results)
 }
+
+mutation ReportTCPCaptureResults($results: CaptureTCPResults!) {
+    reportTCPCaptureResults(results: $results)
+}

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -19,6 +19,10 @@ input CaptureResults {
     results: [RecordedDestinationsForSrc!]!
 }
 
+input CaptureTCPResults {
+    results: [RecordedDestinationsForSrc!]!
+}
+
 input SocketScanResults {
     results: [RecordedDestinationsForSrc!]!
 }
@@ -175,6 +179,7 @@ type Query {
 type Mutation {
     resetCapture: Boolean!
     reportCaptureResults(results: CaptureResults!): Boolean!
+    reportTCPCaptureResults(results: CaptureTCPResults!): Boolean!
     reportSocketScanResults(results: SocketScanResults!): Boolean!
     reportKafkaMapperResults(results: KafkaMapperResults!): Boolean!
     reportIstioConnectionResults(results: IstioConnectionResults!): Boolean!

--- a/src/shared/config/config.go
+++ b/src/shared/config/config.go
@@ -19,6 +19,12 @@ const (
 	PrometheusMetricsPortDefault = 2112
 	TelemetryErrorsAPIKeyKey     = "telemetry-errors-api-key"
 	TelemetryErrorsAPIKeyDefault = "d86195588a41fa03aa6711993bb1c765"
+	EnableTCPKey                 = "enable-tcp"
+	EnableTCPSnifferDefault      = true
+	EnableSocketScannerKey       = "enable-socket-scanner"
+	EnableSocketScannerDefault   = true
+	EnableDNSKey                 = "enable-dns"
+	EnableDNSSnifferDefault      = true
 
 	EnvPodKey       = "pod"
 	EnvNamespaceKey = "namespace"
@@ -37,6 +43,9 @@ func init() {
 	viper.SetDefault(DebugKey, DebugDefault)
 	viper.SetDefault(PrometheusMetricsPortKey, PrometheusMetricsPortDefault)
 	viper.SetDefault(TelemetryErrorsAPIKeyKey, TelemetryErrorsAPIKeyDefault)
+	viper.SetDefault(EnableTCPKey, EnableTCPSnifferDefault)
+	viper.SetDefault(EnableSocketScannerKey, EnableSocketScannerDefault)
+	viper.SetDefault(EnableDNSKey, EnableDNSSnifferDefault)
 	viper.SetEnvPrefix(envPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/src/sniffer/pkg/collectors/dnssniffer.go
+++ b/src/sniffer/pkg/collectors/dnssniffer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/otterize/intents-operator/src/shared/errors"
+	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/config"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/ipresolver"
 	"github.com/otterize/nilable"
@@ -128,6 +129,10 @@ func (s *DNSSniffer) CreateDNSPacketStream() (chan gopacket.Packet, error) {
 }
 
 func (s *DNSSniffer) HandlePacket(packet gopacket.Packet) {
+	if !viper.GetBool(sharedconfig.EnableDNSKey) {
+		return
+	}
+
 	captureTime := detectCaptureTime(packet)
 	ipLayer := packet.Layer(layers.LayerTypeIPv4)
 	dnsLayer := packet.Layer(layers.LayerTypeDNS)

--- a/src/sniffer/pkg/collectors/socketscanner.go
+++ b/src/sniffer/pkg/collectors/socketscanner.go
@@ -3,8 +3,10 @@ package collectors
 import (
 	"fmt"
 	"github.com/otterize/go-procnet/procnet"
+	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/utils"
 	"github.com/otterize/nilable"
+	"github.com/spf13/viper"
 
 	"time"
 )
@@ -22,6 +24,9 @@ func NewSocketScanner() *SocketScanner {
 }
 
 func (s *SocketScanner) scanTcpFile(hostname string, path string) {
+	if !viper.GetBool(sharedconfig.EnableSocketScannerKey) {
+		return
+	}
 	socks, err := procnet.SocksFromPath(path)
 	if err != nil {
 		// it's likely that some files will be deleted during our iteration, so we ignore errors reading the file.

--- a/src/sniffer/pkg/collectors/tcpsniffer.go
+++ b/src/sniffer/pkg/collectors/tcpsniffer.go
@@ -74,7 +74,12 @@ func (s *TCPSniffer) HandlePacket(packet gopacket.Packet) {
 	captureTime := detectCaptureTime(packet)
 	ipLayer := packet.Layer(layers.LayerTypeIPv4)
 	if ipLayer != nil {
-		ip, _ := ipLayer.(*layers.IPv4)
+		ip, ok := ipLayer.(*layers.IPv4)
+		if !ok {
+			logrus.Debugf("Failed to parse IP layer")
+			return
+		}
+
 		srcIP := ip.SrcIP.String()
 		dstIP := ip.DstIP.String()
 		localHostname, err := s.resolver.ResolveIP(srcIP)

--- a/src/sniffer/pkg/collectors/tcpsniffer.go
+++ b/src/sniffer/pkg/collectors/tcpsniffer.go
@@ -1,0 +1,120 @@
+package collectors
+
+import (
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
+	"github.com/otterize/network-mapper/src/sniffer/pkg/config"
+	"github.com/otterize/network-mapper/src/sniffer/pkg/ipresolver"
+	"github.com/otterize/nilable"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"time"
+)
+
+type TCPSniffer struct {
+	NetworkCollector
+	resolver    ipresolver.IPResolver
+	pending     []pendingTCPCapture
+	lastRefresh time.Time
+}
+
+type pendingTCPCapture struct {
+	srcIp       string
+	srcHostname string
+	destIp      string
+	time        time.Time
+	ttl         nilable.Nilable[int]
+}
+
+func NewTCPSniffer(resolver ipresolver.IPResolver) *TCPSniffer {
+	s := TCPSniffer{
+		NetworkCollector: NetworkCollector{},
+		resolver:         resolver,
+		pending:          make([]pendingTCPCapture, 0),
+		lastRefresh:      time.Now().Add(-viper.GetDuration(config.HostsMappingRefreshIntervalKey)), // Should refresh immediately
+	}
+	s.resetData()
+	return &s
+}
+
+func setCaptureIncomingTCPSYN(handle *pcap.Handle) error {
+	err := handle.SetDirection(pcap.DirectionIn)
+	if err != nil {
+		return err
+	}
+	err = handle.SetBPFFilter("tcp and tcp[tcpflags] == tcp-syn")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *TCPSniffer) CreateTCPPacketStream() (chan gopacket.Packet, error) {
+	handle, err := pcap.OpenLive("any", 0, true, pcap.BlockForever)
+	if err != nil {
+		return nil, err
+	}
+
+	err = setCaptureIncomingTCPSYN(handle)
+	if err != nil {
+		return nil, err
+	}
+
+	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+	return packetSource.Packets(), nil
+}
+
+func (s *TCPSniffer) HandlePacket(packet gopacket.Packet) {
+	if !viper.GetBool(sharedconfig.EnableTCPKey) {
+		return
+	}
+	captureTime := detectCaptureTime(packet)
+	ipLayer := packet.Layer(layers.LayerTypeIPv4)
+	if ipLayer != nil {
+		ip, _ := ipLayer.(*layers.IPv4)
+		srcIP := ip.SrcIP.String()
+		dstIP := ip.DstIP.String()
+		localHostname, err := s.resolver.ResolveIP(srcIP)
+		if err != nil {
+			logrus.Debugf("Can't resolve IP addr %s, skipping", srcIP)
+		} else {
+			logrus.Debugf("Captured TCP SYN from %s to %s", srcIP, dstIP)
+
+			// Resolver cache could be outdated, verify same resolving result after next poll
+			s.pending = append(s.pending, pendingTCPCapture{
+				srcIp: srcIP, srcHostname: localHostname, destIp: dstIP, time: captureTime,
+			})
+		}
+	}
+}
+
+func (s *TCPSniffer) RefreshHostsMapping() error {
+	err := s.resolver.Refresh()
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	for _, p := range s.pending {
+		hostname, err := s.resolver.ResolveIP(p.srcIp)
+		if err != nil {
+			logrus.WithError(err).Debugf("Could not to resolve %s, skipping packet", p.srcIp)
+			continue
+		}
+		if p.srcHostname != hostname {
+			logrus.Debugf("IP %s was resolved to %s, but now resolves to %s. skipping packet", p.srcIp, p.srcHostname, hostname)
+			continue
+		}
+		s.addCapturedRequest(p.srcIp, hostname, p.destIp, p.destIp, p.time, p.ttl)
+	}
+	s.pending = make([]pendingTCPCapture, 0)
+	return nil
+}
+
+func (s *TCPSniffer) GetTimeTilNextRefresh() time.Duration {
+	nextRefreshTime := s.lastRefresh.Add(viper.GetDuration(config.HostsMappingRefreshIntervalKey))
+	s.lastRefresh = time.Now()
+	return time.Until(nextRefreshTime)
+}

--- a/src/sniffer/pkg/collectors/tcpsniffer_test.go
+++ b/src/sniffer/pkg/collectors/tcpsniffer_test.go
@@ -1,0 +1,48 @@
+package collectors
+
+import (
+	"encoding/hex"
+	"github.com/golang/mock/gomock"
+	"github.com/otterize/network-mapper/src/sniffer/pkg/ipresolver"
+	"github.com/otterize/nilable"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/otterize/network-mapper/src/sniffer/pkg/mapperclient"
+)
+
+func TestTCPSniffer_TestHandlePacket(t *testing.T) {
+	controller := gomock.NewController(t)
+	mockResolver := ipresolver.NewMockIPResolver(controller)
+	mockResolver.EXPECT().ResolveIP("10.0.2.48").Return("client-1", nil).Times(2) // once for the initial check, and then another for verification
+	mockResolver.EXPECT().Refresh().Return(nil).Times(1)
+
+	sniffer := NewTCPSniffer(mockResolver)
+
+	tcpSYN, err := hex.DecodeString("4500004000004000400600000a0002300af4784ed93d1f40a16450e500000000b002fffffe34000002043fd8010303060101080ab6a645bc0000000004020000")
+	if err != nil {
+		require.NoError(t, err)
+	}
+	packet := gopacket.NewPacket(tcpSYN, layers.LayerTypeIPv4, gopacket.Default)
+	timestamp := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	packet.Metadata().CaptureInfo.Timestamp = timestamp
+	sniffer.HandlePacket(packet)
+	require.NoError(t, sniffer.RefreshHostsMapping())
+
+	require.Equal(t, []mapperclient.RecordedDestinationsForSrc{
+		{
+			SrcIp:       "10.0.2.48",
+			SrcHostname: "client-1",
+			Destinations: []mapperclient.Destination{
+				{
+					Destination:   "10.244.120.78",
+					DestinationIP: nilable.From("10.244.120.78"),
+					LastSeen:      timestamp,
+				},
+			},
+		},
+	}, sniffer.CollectResults())
+}

--- a/src/sniffer/pkg/ipresolver/ipresolver.go
+++ b/src/sniffer/pkg/ipresolver/ipresolver.go
@@ -1,13 +1,63 @@
 package ipresolver
 
+import (
+	"github.com/golang/mock/gomock"
+	"reflect"
+)
+
 type IPResolver interface {
 	Refresh() error
 	ResolveIP(ipaddr string) (hostname string, err error)
 }
 
-type MockIPResolver struct{}
+// NewMockIPResolver creates a new mock instance.
+func NewMockIPResolver(ctrl *gomock.Controller) *MockIPResolver {
+	mock := &MockIPResolver{ctrl: ctrl}
+	mock.recorder = &MockIPResolverMockRecorder{mock}
+	return mock
+}
 
-func (r *MockIPResolver) Refresh() error { return nil }
-func (r *MockIPResolver) ResolveIP(_ string) (hostname string, err error) {
-	return "", nil
+// MockMapperClient is a mock of IPResolver interface.
+type MockIPResolver struct {
+	ctrl     *gomock.Controller
+	recorder *MockIPResolverMockRecorder
+}
+
+// MockMapperClientMockRecorder is the mock recorder for MockMapperClient.
+type MockIPResolverMockRecorder struct {
+	mock *MockIPResolver
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIPResolver) EXPECT() *MockIPResolverMockRecorder {
+	return m.recorder
+}
+
+// Refresh mocks base method.
+func (m *MockIPResolver) Refresh() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Refresh")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReportCaptureResults indicates an expected call of ReportCaptureResults.
+func (mr *MockIPResolverMockRecorder) Refresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockIPResolver)(nil).Refresh))
+}
+
+// ResolveIP mocks base method.
+func (m *MockIPResolver) ResolveIP(ipaddr string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveIP", ipaddr)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveIP indicates an expected call of ResolveIP.
+func (mr *MockIPResolverMockRecorder) ResolveIP(ipaddr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIP", reflect.TypeOf((*MockIPResolver)(nil).ResolveIP), ipaddr)
 }

--- a/src/sniffer/pkg/mapperclient/client.go
+++ b/src/sniffer/pkg/mapperclient/client.go
@@ -24,6 +24,11 @@ func (c *MapperClientImpl) ReportCaptureResults(ctx context.Context, results Cap
 	return errors.Wrap(err)
 }
 
+func (c *MapperClientImpl) ReportTCPCaptureResults(ctx context.Context, results CaptureTCPResults) error {
+	_, err := reportTCPCaptureResults(ctx, c.gqlClient, results)
+	return err
+}
+
 func (c *MapperClientImpl) ReportSocketScanResults(ctx context.Context, results SocketScanResults) error {
 	_, err := reportSocketScanResults(ctx, c.gqlClient, results)
 	return errors.Wrap(err)
@@ -36,6 +41,7 @@ func (c *MapperClientImpl) Health(ctx context.Context) error {
 
 type MapperClient interface {
 	ReportCaptureResults(ctx context.Context, results CaptureResults) error
+	ReportTCPCaptureResults(ctx context.Context, results CaptureTCPResults) error
 	ReportSocketScanResults(ctx context.Context, results SocketScanResults) error
 	Health(ctx context.Context) error
 }

--- a/src/sniffer/pkg/mapperclient/generated.go
+++ b/src/sniffer/pkg/mapperclient/generated.go
@@ -17,6 +17,13 @@ type CaptureResults struct {
 // GetResults returns CaptureResults.Results, and is useful for accessing the field via an interface.
 func (v *CaptureResults) GetResults() []RecordedDestinationsForSrc { return v.Results }
 
+type CaptureTCPResults struct {
+	Results []RecordedDestinationsForSrc `json:"results"`
+}
+
+// GetResults returns CaptureTCPResults.Results, and is useful for accessing the field via an interface.
+func (v *CaptureTCPResults) GetResults() []RecordedDestinationsForSrc { return v.Results }
+
 type Destination struct {
 	Destination   string                  `json:"destination"`
 	DestinationIP nilable.Nilable[string] `json:"destinationIP"`
@@ -82,6 +89,14 @@ type __reportSocketScanResultsInput struct {
 // GetResults returns __reportSocketScanResultsInput.Results, and is useful for accessing the field via an interface.
 func (v *__reportSocketScanResultsInput) GetResults() SocketScanResults { return v.Results }
 
+// __reportTCPCaptureResultsInput is used internally by genqlient
+type __reportTCPCaptureResultsInput struct {
+	Results CaptureTCPResults `json:"results"`
+}
+
+// GetResults returns __reportTCPCaptureResultsInput.Results, and is useful for accessing the field via an interface.
+func (v *__reportTCPCaptureResultsInput) GetResults() CaptureTCPResults { return v.Results }
+
 // reportCaptureResultsResponse is returned by reportCaptureResults on success.
 type reportCaptureResultsResponse struct {
 	ReportCaptureResults bool `json:"reportCaptureResults"`
@@ -98,6 +113,16 @@ type reportSocketScanResultsResponse struct {
 // GetReportSocketScanResults returns reportSocketScanResultsResponse.ReportSocketScanResults, and is useful for accessing the field via an interface.
 func (v *reportSocketScanResultsResponse) GetReportSocketScanResults() bool {
 	return v.ReportSocketScanResults
+}
+
+// reportTCPCaptureResultsResponse is returned by reportTCPCaptureResults on success.
+type reportTCPCaptureResultsResponse struct {
+	ReportTCPCaptureResults bool `json:"reportTCPCaptureResults"`
+}
+
+// GetReportTCPCaptureResults returns reportTCPCaptureResultsResponse.ReportTCPCaptureResults, and is useful for accessing the field via an interface.
+func (v *reportTCPCaptureResultsResponse) GetReportTCPCaptureResults() bool {
+	return v.ReportTCPCaptureResults
 }
 
 // The query or mutation executed by Health.
@@ -184,6 +209,39 @@ func reportSocketScanResults(
 	var err_ error
 
 	var data_ reportSocketScanResultsResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by reportTCPCaptureResults.
+const reportTCPCaptureResults_Operation = `
+mutation reportTCPCaptureResults ($results: CaptureTCPResults!) {
+	reportTCPCaptureResults(results: $results)
+}
+`
+
+func reportTCPCaptureResults(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	results CaptureTCPResults,
+) (*reportTCPCaptureResultsResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "reportTCPCaptureResults",
+		Query:  reportTCPCaptureResults_Operation,
+		Variables: &__reportTCPCaptureResultsInput{
+			Results: results,
+		},
+	}
+	var err_ error
+
+	var data_ reportTCPCaptureResultsResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/sniffer/pkg/mapperclient/genqlient.graphql
+++ b/src/sniffer/pkg/mapperclient/genqlient.graphql
@@ -3,6 +3,10 @@ mutation reportCaptureResults($results: CaptureResults!) {
     reportCaptureResults(results: $results)
 }
 
+mutation reportTCPCaptureResults($results: CaptureTCPResults!) {
+    reportTCPCaptureResults(results: $results)
+}
+
 mutation reportSocketScanResults($results: SocketScanResults!) {
     reportSocketScanResults(results: $results)
 }

--- a/src/sniffer/pkg/mapperclient/mockclient/mocks.go
+++ b/src/sniffer/pkg/mapperclient/mockclient/mocks.go
@@ -76,3 +76,17 @@ func (mr *MockMapperClientMockRecorder) ReportSocketScanResults(ctx, results int
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportSocketScanResults", reflect.TypeOf((*MockMapperClient)(nil).ReportSocketScanResults), ctx, results)
 }
+
+// ReportTCPCaptureResults mocks base method.
+func (m *MockMapperClient) ReportTCPCaptureResults(ctx context.Context, results mapperclient.CaptureResults) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReportTCPCaptureResults", ctx, results)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReportTCPCaptureResults indicates an expected call of ReportTCPCaptureResults.
+func (mr *MockMapperClientMockRecorder) ReportTCPCaptureResults(ctx, results interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportTCPCaptureResults", reflect.TypeOf((*MockMapperClient)(nil).ReportTCPCaptureResults), ctx, results)
+}

--- a/src/sniffer/pkg/mapperclient/mockclient/mocks.go
+++ b/src/sniffer/pkg/mapperclient/mockclient/mocks.go
@@ -78,7 +78,7 @@ func (mr *MockMapperClientMockRecorder) ReportSocketScanResults(ctx, results int
 }
 
 // ReportTCPCaptureResults mocks base method.
-func (m *MockMapperClient) ReportTCPCaptureResults(ctx context.Context, results mapperclient.CaptureResults) error {
+func (m *MockMapperClient) ReportTCPCaptureResults(ctx context.Context, results mapperclient.CaptureTCPResults) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReportTCPCaptureResults", ctx, results)
 	ret0, _ := ret[0].(error)

--- a/src/sniffer/pkg/sniffer/sniffer.go
+++ b/src/sniffer/pkg/sniffer/sniffer.go
@@ -60,13 +60,13 @@ func (s *Sniffer) reportTCPCaptureResults(ctx context.Context) {
 		logrus.Debugf("No TCP captured sniffed requests to report")
 		return
 	}
-	logrus.Infof("Reporting TCP captured requests of %d clients to Mapper", len(results))
+	logrus.Debugf("Reporting TCP captured requests of %d clients to Mapper", len(results))
 
 	go func() {
 		timeoutCtx, cancelFunc := context.WithTimeout(ctx, viper.GetDuration(config.CallsTimeoutKey))
 		defer cancelFunc()
 
-		logrus.Infof("Reporting TCP captured requests of %d clients to Mapper", len(results))
+		logrus.Debugf("Reporting TCP captured requests of %d clients to Mapper", len(results))
 		err := s.mapperClient.ReportTCPCaptureResults(timeoutCtx, mapperclient.CaptureTCPResults{Results: results})
 		if err != nil {
 			logrus.WithError(err).Error("Failed to report capture results")

--- a/src/sniffer/pkg/sniffer/sniffer.go
+++ b/src/sniffer/pkg/sniffer/sniffer.go
@@ -17,13 +17,16 @@ import (
 type Sniffer struct {
 	dnsSniffer     *collectors.DNSSniffer
 	socketScanner  *collectors.SocketScanner
+	tcpSniffer     *collectors.TCPSniffer
 	lastReportTime time.Time
 	mapperClient   mapperclient.MapperClient
 }
 
 func NewSniffer(mapperClient mapperclient.MapperClient) *Sniffer {
+	procFSIPResolver := ipresolver.NewProcFSIPResolver()
 	return &Sniffer{
-		dnsSniffer:    collectors.NewDNSSniffer(ipresolver.NewProcFSIPResolver()),
+		dnsSniffer:    collectors.NewDNSSniffer(procFSIPResolver),
+		tcpSniffer:    collectors.NewTCPSniffer(procFSIPResolver),
 		socketScanner: collectors.NewSocketScanner(),
 		mapperClient:  mapperClient,
 	}
@@ -51,10 +54,30 @@ func (s *Sniffer) reportCaptureResults(ctx context.Context) {
 	}()
 }
 
+func (s *Sniffer) reportTCPCaptureResults(ctx context.Context) {
+	results := s.tcpSniffer.CollectResults()
+	if len(results) == 0 {
+		logrus.Debugf("No TCP captured sniffed requests to report")
+		return
+	}
+	logrus.Infof("Reporting TCP captured requests of %d clients to Mapper", len(results))
+
+	go func() {
+		timeoutCtx, cancelFunc := context.WithTimeout(ctx, viper.GetDuration(config.CallsTimeoutKey))
+		defer cancelFunc()
+
+		logrus.Infof("Reporting TCP captured requests of %d clients to Mapper", len(results))
+		err := s.mapperClient.ReportTCPCaptureResults(timeoutCtx, mapperclient.CaptureTCPResults{Results: results})
+		if err != nil {
+			logrus.WithError(err).Error("Failed to report capture results")
+		}
+	}()
+}
+
 func (s *Sniffer) reportSocketScanResults(ctx context.Context) {
 	results := s.socketScanner.CollectResults()
 	if len(results) == 0 {
-		logrus.Debugf("No scanned tcp connections to report")
+		logrus.Debugf("No socket scanned connections to report")
 		return
 	}
 	logrus.Debugf("Reporting scanned requests of %d clients to Mapper", len(results))
@@ -76,6 +99,7 @@ func (s *Sniffer) reportSocketScanResults(ctx context.Context) {
 func (s *Sniffer) report(ctx context.Context) {
 	s.reportSocketScanResults(ctx)
 	s.reportCaptureResults(ctx)
+	s.reportTCPCaptureResults(ctx)
 	s.lastReportTime = time.Now()
 }
 
@@ -85,18 +109,29 @@ func (s *Sniffer) getTimeTilNextReport() time.Duration {
 }
 
 func (s *Sniffer) RunForever(ctx context.Context) error {
-	packetsChan, err := s.dnsSniffer.CreateDNSPacketStream()
+	dnsPacketsChan, err := s.dnsSniffer.CreateDNSPacketStream()
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	tcpPacketsChan, err := s.tcpSniffer.CreateTCPPacketStream()
 	if err != nil {
 		return errors.Wrap(err)
 	}
 
 	for {
 		select {
-		case packet := <-packetsChan:
+		case packet := <-dnsPacketsChan:
 			s.dnsSniffer.HandlePacket(packet)
+		case packet := <-tcpPacketsChan:
+			s.tcpSniffer.HandlePacket(packet)
 		case <-time.After(s.dnsSniffer.GetTimeTilNextRefresh()):
 			if err := s.dnsSniffer.RefreshHostsMapping(); err != nil {
-				logrus.WithError(err).Error("Failed to refresh ip->host resolving map")
+				logrus.WithError(err).Error("Failed to refresh ip->host resolving map for DNS")
+			}
+		case <-time.After(s.tcpSniffer.GetTimeTilNextRefresh()):
+			if err := s.tcpSniffer.RefreshHostsMapping(); err != nil {
+				logrus.WithError(err).Error("Failed to refresh ip->host resolving map for TCP")
 			}
 		case <-time.After(s.getTimeTilNextReport()):
 			if err := s.socketScanner.ScanProcDir(); err != nil {
@@ -104,7 +139,10 @@ func (s *Sniffer) RunForever(ctx context.Context) error {
 			}
 			// Flush pending packets before reporting
 			if err := s.dnsSniffer.RefreshHostsMapping(); err != nil {
-				logrus.WithError(err).Error("Failed to refresh ip->host resolving map")
+				logrus.WithError(err).Error("Failed to refresh ip->host resolving map for DNS")
+			}
+			if err := s.tcpSniffer.RefreshHostsMapping(); err != nil {
+				logrus.WithError(err).Error("Failed to refresh ip->host resolving map for TCP")
 			}
 			// Actual server request is async, won't block packet handling
 			s.report(ctx)


### PR DESCRIPTION
### Description

Add TCP-SYN packet sniffing to allow discovery of intents from pure TCP communication.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
