### PR TITLE
Upgrade error reporter version, fix cases where errors would not be reported or would be reported with wrong stack

### DIFF
--- a/build/kafka-watcher.Dockerfile
+++ b/build/kafka-watcher.Dockerfile
@@ -15,7 +15,7 @@ RUN go test ./kafka-watcher/...
 FROM test as builder
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /main ./kafka-watcher/cmd
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /main ./kafka-watcher/cmd
 
 # add version file
 ARG VERSION

--- a/build/mapper.Dockerfile
+++ b/build/mapper.Dockerfile
@@ -20,7 +20,7 @@ RUN go test ./mapper/...
 FROM test as builder
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /main ./mapper/cmd
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /main ./mapper/cmd
 
 # add version file
 ARG VERSION

--- a/build/sniffer.Dockerfile
+++ b/build/sniffer.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /src
 # restore dependencies
 COPY . .
 RUN go mod download
-RUN go build -o /main ./sniffer/cmd
+RUN go build -trimpath -o /main ./sniffer/cmd
 
 # add version file
 ARG VERSION

--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -36,6 +36,7 @@ func main() {
 		TimestampFormat: time.RFC3339,
 	})
 	errorreporter.Init("kafka-watcher", version.Version(), viper.GetString(sharedconfig.TelemetryErrorsAPIKeyKey))
+	defer errorreporter.AutoNotify()
 	ctrl.SetLogger(logrusr.New(logrus.StandardLogger()))
 	componentutils.SetCloudClientId()
 	componentinfo.SetGlobalComponentInstanceId()

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -88,6 +88,7 @@ func main() {
 		TimestampFormat: time.RFC3339,
 	})
 	errorreporter.Init("network-mapper", version.Version(), viper.GetString(sharedconfig.TelemetryErrorsAPIKeyKey))
+	defer errorreporter.AutoNotify()
 	if !viper.IsSet(config.ClusterDomainKey) || viper.GetString(config.ClusterDomainKey) == "" {
 		clusterDomain := getClusterDomainOrDefault()
 		viper.Set(config.ClusterDomainKey, clusterDomain)

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -33,9 +33,7 @@ func main() {
 		TimestampFormat: time.RFC3339,
 	})
 	errorreporter.Init("sniffer", version.Version(), viper.GetString(sharedconfig.TelemetryErrorsAPIKeyKey))
-	if viper.GetBool(sharedconfig.DebugKey) {
-		logrus.SetLevel(logrus.DebugLevel)
-	}
+	defer errorreporter.AutoNotify()
 	ctrl.SetLogger(logrusr.New(logrus.StandardLogger()))
 	componentutils.SetCloudClientId()
 	componentinfo.SetGlobalComponentInstanceId()


### PR DESCRIPTION
Depends on: https://github.com/otterize/intents-operator/pull/406

Now built using `-trimpath` so the stack traces are independent of build path.