### PR TITLE
Fix a case where the watchers (istio/kafka) tried to access logs of non-running pods

### DIFF
--- a/src/istio-watcher/pkg/watcher/watcher.go
+++ b/src/istio-watcher/pkg/watcher/watcher.go
@@ -150,6 +150,10 @@ func (m *IstioWatcher) CollectIstioConnectionMetrics(ctx context.Context, namesp
 	}
 
 	for _, pod := range podList.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			logrus.Debugf("Skipping pod %s as it is not running", pod.Name)
+			continue
+		}
 		// Known for loop gotcha with goroutines
 		curr := pod
 		sendersErrGroup.Go(func() error {

--- a/src/kafka-watcher/pkg/logwatcher/kubeneteslogwatcher.go
+++ b/src/kafka-watcher/pkg/logwatcher/kubeneteslogwatcher.go
@@ -86,7 +86,7 @@ func (w *KubernetesLogWatcher) watchOnce(ctx context.Context, kafkaServer types.
 		return errors.Wrap(err)
 	}
 	if pod.Status.Phase != corev1.PodRunning {
-		logrus.Debugf("Kafka server %s is not running, skipping logs for this itteration", kafkaServer.String())
+		logrus.Debugf("Kafka server %s is not running, skipping logs for this iteration", kafkaServer.String())
 		return nil
 	}
 	podLogOpts := corev1.PodLogOptions{

--- a/src/kafka-watcher/pkg/logwatcher/kubeneteslogwatcher.go
+++ b/src/kafka-watcher/pkg/logwatcher/kubeneteslogwatcher.go
@@ -81,6 +81,14 @@ func (w *KubernetesLogWatcher) RunForever(ctx context.Context) error {
 }
 
 func (w *KubernetesLogWatcher) watchOnce(ctx context.Context, kafkaServer types.NamespacedName, startTime time.Time) error {
+	pod, err := w.clientset.CoreV1().Pods(kafkaServer.Namespace).Get(ctx, kafkaServer.Name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		logrus.Debugf("Kafka server %s is not running, skipping logs for this itteration", kafkaServer.String())
+		return nil
+	}
 	podLogOpts := corev1.PodLogOptions{
 		SinceTime: &metav1.Time{Time: startTime},
 	}


### PR DESCRIPTION
### Description

Fix a case where the watchers (istio/kafka) tried to access logs of non-running pods


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
