### PR TITLE
Use $BUILDPLATFORM in Dockerfile

### DIFF
--- a/build/kafka-watcher.Dockerfile
+++ b/build/kafka-watcher.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.21-alpine as buildenv
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine as buildenv
 RUN apk add --no-cache ca-certificates git protoc
 RUN apk add build-base libpcap-dev
 WORKDIR /src

--- a/build/mapper.Dockerfile
+++ b/build/mapper.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.21-alpine as buildenv
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine as buildenv
 RUN apk add --no-cache ca-certificates git protoc
 RUN apk add build-base libpcap-dev
 WORKDIR /src


### PR DESCRIPTION
### Description

User $BUILDPLATFORM in build stage in Dockerfile: This will cause the builder image to be arm64 on Macs, and amd64 on CI and other environments.

Not cross-compiling arm64->amd64 on macs is significantly faster. The resulting images are without change.

### References

https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/