### PR TITLE
Update iamlive repo url

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout IAMLive fork
         uses: actions/checkout@v2
         with:
-          repository: orishavit/iamlive
+          repository: otterize/iamlive
           path: iamlive
           ref: main
 


### PR DESCRIPTION
### Description

Update the IAMLive repo path in CI. It pointed to the wrong github user. Since the repository was transferred, the old URL redirected to the correct one.