### PR TITLE
Treat pod not found as external source traffic, only use node podCIDRs if possible.

### DIFF
--- a/src/mapper/pkg/kubefinder/kubefinder.go
+++ b/src/mapper/pkg/kubefinder/kubefinder.go
@@ -196,7 +196,7 @@ func (k *KubeFinder) ResolveServiceToPods(ctx context.Context, svc *corev1.Servi
 	return pods, nil
 }
 
-func (k *KubeFinder) IsExternalIP(ctx context.Context, ip string) (bool, error) {
+func (k *KubeFinder) IsIPNotInNodePodCIDR(ctx context.Context, ip string) (bool, error) {
 	var nodes corev1.NodeList
 	err := k.client.List(ctx, &nodes)
 	if err != nil {

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -411,12 +411,21 @@ func (r *Resolver) handleReportTCPCaptureResults(ctx context.Context, results mo
 	logrus.Infof("Handling TCP capture results len: %d", len(results.Results))
 	for _, captureItem := range results.Results {
 		logrus.Debugf("Handling TCP capture result from %s to %s:%d", captureItem.SrcIP, captureItem.Destinations[0].Destination, lo.FromPtr(captureItem.Destinations[0].DestinationPort))
-		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, captureItem)
+		isExternal, err := r.isExternalOrAssumeExternalIfError(ctx, captureItem.SrcIP)
 		if err != nil {
-			if errors.Is(err, kubefinder.ErrNoPodFound) {
-				r.tryReportIncomingInternetTraffic(ctx, captureItem.SrcIP, captureItem.Destinations)
+			logrus.WithError(err).Error("could not determine if IP is external")
+			continue
+		}
+		if isExternal {
+			err := r.reportIncomingInternetTraffic(ctx, captureItem.SrcIP, captureItem.Destinations)
+			if err != nil {
+				logrus.WithError(err).Error("could not report incoming internet traffic")
 				continue
 			}
+		}
+
+		srcSvcIdentity, err := r.discoverSrcIdentity(ctx, captureItem)
+		if err != nil {
 			logrus.WithError(err).Debugf("could not discover src identity for '%s'", captureItem.SrcIP)
 			continue
 		}
@@ -430,17 +439,7 @@ func (r *Resolver) handleReportTCPCaptureResults(ctx context.Context, results mo
 	return nil
 }
 
-func (r *Resolver) tryReportIncomingInternetTraffic(ctx context.Context, srcIP string, destinations []model.Destination) {
-	isExternal, err := r.kubeFinder.IsExternalIP(ctx, srcIP)
-	if err != nil {
-		logrus.WithError(err).Errorf("could not determine if IP %s is external", srcIP)
-		return
-	}
-	if !isExternal {
-		logrus.Debugf("IP %s is not external, ignoring", srcIP)
-		return
-	}
-
+func (r *Resolver) reportIncomingInternetTraffic(ctx context.Context, srcIP string, destinations []model.Destination) error {
 	for _, dest := range destinations {
 		destSvcIdentity, ok, err := r.resolveOtterizeIdentityForExternalAccessDestination(ctx, dest)
 		if err != nil {
@@ -459,6 +458,7 @@ func (r *Resolver) tryReportIncomingInternetTraffic(ctx context.Context, srcIP s
 		}
 		r.incomingTrafficHolder.AddIntent(intent)
 	}
+	return nil
 }
 
 func (r *Resolver) handleTCPResult(ctx context.Context, srcIdentity model.OtterizeServiceIdentity, dest model.Destination) {


### PR DESCRIPTION
### Description

Prior to this PR, node PodCIDRs were always used to determine if an IP is considered external. However, sometimes the node CIDR can be unpopulated (or not populated yet?). Now we will treat those cases as if the IP is external, only checking the pod CIDRs if available, otherwise assuming that any pod not found means external traffic.