### PR TITLE
Fix bug where external ingress traffic detection would fail if more than one pod was found with the IP in cluster when determining if traffic is external

### DIFF
--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -24,6 +24,10 @@ func podLabelsToOtterizeLabels(pod *corev1.Pod) []model.PodLabel {
 // isExternalOrAssumeExternalIfError returns true if the IP is external or if an error occurred while determining if the IP is external.
 func (r *Resolver) isExternalOrAssumeExternalIfError(ctx context.Context, srcIP string) (bool, error) {
 	_, err := r.kubeFinder.ResolveIPToPod(ctx, srcIP)
+	if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {
+		return false, nil
+	}
+
 	// If the IP is not found, it may be external
 	if err != nil && !errors.Is(err, kubefinder.ErrNoPodFound) {
 		return false, errors.Wrap(err)


### PR DESCRIPTION
### Description

Fix bug where external ingress traffic detection would fail if more than one pod was found with the IP in cluster when determining if traffic is external.

This could happen in the case of multiple hostNetwork pods which share the node's IP address.