### PR TITLE
Enable DNS intents support by default

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -44,6 +44,7 @@ require (
 	gotest.tools/v3 v3.0.3
 	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a
 	k8s.io/api v0.29.0
+	k8s.io/apiextensions-apiserver v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
 	sigs.k8s.io/controller-runtime v0.17.2
@@ -146,7 +147,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.29.0 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/pod_webhook"
 	"github.com/otterize/network-mapper/src/shared/echologrus"
 	"golang.org/x/sync/errgroup"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"net/http"
@@ -61,6 +62,7 @@ var (
 )
 
 func init() {
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(otterizev1alpha2.AddToScheme(scheme))
 	utilruntime.Must(otterizev1alpha3.AddToScheme(scheme))

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -33,7 +33,7 @@ const (
 	DNSClientIntentsUpdateIntervalKey     = "dns-client-intents-update-interval"
 	DNSClientIntentsUpdateIntervalDefault = 1 * time.Second
 	DNSClientIntentsUpdateEnabledKey      = "dns-client-intents-update-enabled"
-	DNSClientIntentsUpdateEnabledDefault  = false
+	DNSClientIntentsUpdateEnabledDefault  = true
 
 	EnableIstioCollectionKey           = "enable-istio-collection"
 	EnableIstioCollectionDefault       = false

--- a/src/mapper/pkg/dnsintentspublisher/init.go
+++ b/src/mapper/pkg/dnsintentspublisher/init.go
@@ -7,8 +7,15 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/dnscache"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	clientIntentsCRDName = "clientintents.k8s.otterize.com"
 )
 
 func InitWithManager(ctx context.Context, mgr manager.Manager, dnsCache *dnscache.DNSCache) (*Publisher, bool, error) {
@@ -16,21 +23,35 @@ func InitWithManager(ctx context.Context, mgr manager.Manager, dnsCache *dnscach
 		return nil, false, nil
 	}
 
-	dnsPublisher := NewPublisher(mgr.GetClient(), dnsCache)
-	err := dnsPublisher.InitIndices(ctx, mgr)
+	installed, err := IsClientIntentsInstalled(ctx, mgr.GetClient())
 	if err != nil {
-		discoveryErr := (&apiutil.ErrResourceDiscoveryFailed{})
-		if errors.As(err, &discoveryErr) {
-			for gvk := range *discoveryErr {
-				if gvk.Group == "k8s.otterize.com" {
-					// This can happen if the network mapper is deployed without the intents operator, which is normal.
-					logrus.Debugf("DNS client intents publishing is not enabled due to missing CRD %v", gvk)
-					return nil, false, nil
-				}
-			}
-		}
+		return nil, false, errors.Wrap(err)
+	}
+
+	if !installed {
+		logrus.Debugf("DNS client intents publishing is not enabled due to missing CRD %s", clientIntentsCRDName)
+		return nil, false, nil
+	}
+
+	dnsPublisher := NewPublisher(mgr.GetClient(), dnsCache)
+	err = dnsPublisher.InitIndices(ctx, mgr)
+	if err != nil {
 		return nil, false, errors.Wrap(err)
 	}
 
 	return dnsPublisher, true, nil
+}
+
+func IsClientIntentsInstalled(ctx context.Context, client client.Client) (bool, error) {
+	crd := apiextensionsv1.CustomResourceDefinition{}
+	err := client.Get(ctx, types.NamespacedName{Name: clientIntentsCRDName}, &crd)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return false, errors.Wrap(err)
+	}
+
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
### Description

The mapper should by default update client intents with DNS resolution data to support intents to domain names server. It was only disabled by default until the full support of egress feature.

This PR also make the part where we check if `ClientIntents` CRD installed a little bit more clear & explicit. 


[The relevant Helm chart PR](https://github.com/otterize/helm-charts/pull/206)


### Testing

There is no logic changes, and the CRD check can only be tested manually

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
