### PR TITLE
Add cache to services reporting

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gopacket v1.1.19
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jellydator/ttlcache/v3 v3.1.1
 	github.com/labstack/echo-contrib v0.15.0
 	github.com/labstack/echo/v4 v4.11.3
@@ -85,7 +86,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-3 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -34,6 +34,10 @@ const (
 	DNSClientIntentsUpdateIntervalDefault = 1 * time.Second
 	DNSClientIntentsUpdateEnabledKey      = "dns-client-intents-update-enabled"
 	DNSClientIntentsUpdateEnabledDefault  = true
+	ServiceCacheTTLDurationKey            = "service-cache-ttl-duration"
+	ServiceCacheTTLDurationDefault        = 1 * time.Minute
+	ServiceCacheSizeKey                   = "service-cache-size"
+	ServiceCacheSizeDefault               = 10000
 
 	EnableIstioCollectionKey           = "enable-istio-collection"
 	EnableIstioCollectionDefault       = false
@@ -71,5 +75,7 @@ func init() {
 	viper.SetDefault(IstioCooldownIntervalKey, IstioCooldownIntervalDefault)
 	viper.SetDefault(IstioRestrictCollectionToNamespace, "")
 	viper.SetDefault(EnableIstioCollectionKey, EnableIstioCollectionDefault)
+	viper.SetDefault(ServiceCacheTTLDurationKey, ServiceCacheTTLDurationDefault)
+	viper.SetDefault(ServiceCacheSizeKey, ServiceCacheSizeDefault)
 	excludedNamespaces = goset.FromSlice(viper.GetStringSlice(ExcludedNamespacesKey))
 }

--- a/src/mapper/pkg/resourcevisibility/svc_reconciler.go
+++ b/src/mapper/pkg/resourcevisibility/svc_reconciler.go
@@ -1,36 +1,53 @@
 package resourcevisibility
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"hash/crc32"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"slices"
 	"time"
 )
 
 type ServiceReconciler struct {
 	client.Client
 	injectablerecorder.InjectableRecorder
-	otterizeCloud cloudclient.CloudClient
-	kubeFinder    KubeFinder
+	otterizeCloud                    cloudclient.CloudClient
+	kubeFinder                       KubeFinder
+	namespaceToReportedServicesCache *expirable.LRU[string, []byte]
 }
 
 type KubeFinder interface {
 	ResolveOtterizeIdentityForService(ctx context.Context, service *corev1.Service, now time.Time) (model.OtterizeServiceIdentity, bool, error)
 }
 
+func OnEvict(key string, _ []byte) {
+	logrus.Debugf("Namespace %s evicted from cache, you may change configuration to increase cache size or TTL", key)
+}
+
 func NewServiceReconciler(client client.Client, otterizeCloudClient cloudclient.CloudClient, kubeFinder KubeFinder) *ServiceReconciler {
+	size := viper.GetInt(config.ServiceCacheSizeKey)
+	ttl := viper.GetDuration(config.ServiceCacheTTLDurationKey)
+	cache := expirable.NewLRU[string, []byte](size, OnEvict, ttl)
 	return &ServiceReconciler{
-		Client:        client,
-		otterizeCloud: otterizeCloudClient,
-		kubeFinder:    kubeFinder,
+		Client:                           client,
+		otterizeCloud:                    otterizeCloudClient,
+		kubeFinder:                       kubeFinder,
+		namespaceToReportedServicesCache: cache,
 	}
 }
 
@@ -63,12 +80,47 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, errors.Wrap(err)
 	}
 
+	hashSum, err := r.getCachedValue(servicesToReport)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	val, found := r.namespaceToReportedServicesCache.Get(namespace)
+	if found && bytes.Equal(val, hashSum) {
+		logrus.Debugf("Skipping reporting of services in namespace %s", namespace)
+		return ctrl.Result{}, nil
+	}
+
 	err = r.otterizeCloud.ReportK8sServices(ctx, namespace, servicesToReport)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err)
 	}
 
+	r.namespaceToReportedServicesCache.Add(namespace, hashSum)
+
 	return ctrl.Result{}, nil
+}
+
+func (r *ServiceReconciler) getCachedValue(servicesToReport []cloudclient.K8sServiceInput) ([]byte, error) {
+	values := lo.Map(servicesToReport, func(service cloudclient.K8sServiceInput, _ int) string {
+		return reportedServicesCacheValuePart(service)
+	})
+
+	slices.Sort(values)
+
+	hash := crc32.NewIEEE()
+	for _, value := range values {
+		_, err := hash.Write([]byte(value))
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+	}
+	hashSum := hash.Sum(nil)
+	return hashSum, nil
+}
+
+func reportedServicesCacheValuePart(service cloudclient.K8sServiceInput) string {
+	return fmt.Sprintf("%s-%s-%s", service.ResourceName, service.OtterizeServer, service.Service.Spec.Type.Item)
 }
 
 func (r *ServiceReconciler) convertToCloudServices(ctx context.Context, services []corev1.Service) ([]cloudclient.K8sServiceInput, error) {

--- a/src/mapper/pkg/resourcevisibility/svc_reconciler.go
+++ b/src/mapper/pkg/resourcevisibility/svc_reconciler.go
@@ -36,7 +36,7 @@ type KubeFinder interface {
 }
 
 func OnEvict(key string, _ []byte) {
-	logrus.Debugf("Namespace %s evicted from cache, you may change configuration to increase cache size or TTL", key)
+	logrus.WithField("namespace", key).Debug("key evicted from cache, you may change configuration to increase cache size or TTL")
 }
 
 func NewServiceReconciler(client client.Client, otterizeCloudClient cloudclient.CloudClient, kubeFinder KubeFinder) *ServiceReconciler {
@@ -87,7 +87,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	val, found := r.namespaceToReportedServicesCache.Get(namespace)
 	if found && bytes.Equal(val, hashSum) {
-		logrus.Debugf("Skipping reporting of services in namespace %s", namespace)
+		logrus.WithField("namespace", namespace).Debug("Skipping reporting of services in namespace due to cache")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
### Description

Services may change in high frequency. This PR reduce the reporting level to once per minute (configurable) or based on meaningful changes to the services: deletion, change of resolved identity and type.  


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
