### PR TITLE
Fix bug: internet intents discovered with CNAME instead of the actual domain name

### DIFF
--- a/src/sniffer/pkg/collectors/dnssniffer_test.go
+++ b/src/sniffer/pkg/collectors/dnssniffer_test.go
@@ -48,6 +48,34 @@ func (s *SnifferTestSuite) TestHandlePacket() {
 	}, sniffer.CollectResults())
 }
 
+func (s *SnifferTestSuite) TestHandlePacketWithCNAME() {
+	sniffer := NewDNSSniffer(&ipresolver.MockIPResolver{}, false)
+
+	rawDnsResponse, err := hex.DecodeString("92e72b05f87b02af9e5f513c0800450000b1443940004011e0100af400020af4000900359c2b009d16a123e085800001000200000001036170690c6f74746572697a652d64657603636f6d0000010001036170690c6f74746572697a652d64657603636f6d000005000100000006001b08696e7465726e616c0c6f74746572697a652d64657603636f6d0008696e7465726e616c0c6f74746572697a652d64657603636f6d00000100010000000600040bdc020000002904d0000000000000")
+	if err != nil {
+		s.Require().NoError(err)
+	}
+	packet := gopacket.NewPacket(rawDnsResponse, layers.LayerTypeEthernet, gopacket.Default)
+	timestamp := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	packet.Metadata().CaptureInfo.Timestamp = timestamp
+	sniffer.HandlePacket(packet)
+	_ = sniffer.RefreshHostsMapping()
+
+	s.Require().Equal([]mapperclient.RecordedDestinationsForSrc{
+		{
+			SrcIp: "10.244.0.9",
+			Destinations: []mapperclient.Destination{
+				{
+					Destination:   "api.otterize-dev.com",
+					DestinationIP: nilable.From("11.220.2.0"),
+					LastSeen:      timestamp,
+					TTL:           nilable.From(6),
+				},
+			},
+		},
+	}, sniffer.CollectResults())
+}
+
 func TestDNSSnifferSuite(t *testing.T) {
 	suite.Run(t, new(SnifferTestSuite))
 }


### PR DESCRIPTION
### Description

When discovering intents to the internet, the mapper exports them using the CNAME as domain, instead of the actual domain name used. This PR check the CNAME section to get the domain name.
