### PR TITLE
Update Otterize CRD versions following changes to the intents operator

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263
 	github.com/otterize/go-procnet v0.1.1
-	github.com/otterize/intents-operator/src v0.0.0-20240703130757-e9aa6677263f
+	github.com/otterize/intents-operator/src v0.0.0-20240715125001-7c068d1a15a6
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f
 	github.com/prometheus/client_golang v1.18.0
 	github.com/samber/lo v1.33.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -340,8 +340,7 @@ github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263 h1:Qd1Ml+uEhpesT8Og
 github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263/go.mod h1:odkMeLkWS8G6+WP2z3Pn2vkzhPSvBtFhAUYTKXAtZMQ=
 github.com/otterize/go-procnet v0.1.1 h1:5vRwX35VrsWcy2uP05sA4PmwpRoAu2L4vMJou4og8Kk=
 github.com/otterize/go-procnet v0.1.1/go.mod h1:WEm282HzrSVBZg6DX2fNB4dpVHBPTCjzHWvqOfauV+Q=
-github.com/otterize/intents-operator/src v0.0.0-20240703130757-e9aa6677263f h1:N8gftUYHwIFwGKCLNfANDfpo+G/qiFKwtuada5ATkB8=
-github.com/otterize/intents-operator/src v0.0.0-20240703130757-e9aa6677263f/go.mod h1:nfX02iyk0wXTWYtW/dYiK+MEXD6ZM84fxXBZy7Jy370=
+github.com/otterize/intents-operator/src v0.0.0-20240715125001-7c068d1a15a6 h1:aOfcU5bblejvmjD/igACvohCFYu3ZqFIT5mNxn5Vn1A=
 github.com/otterize/intents-operator/src v0.0.0-20240715125001-7c068d1a15a6/go.mod h1:R4tfDkJToFDE931Qk7gi47KhXX5WJ3bBYIfskQ1l3Wg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=

--- a/src/go.sum
+++ b/src/go.sum
@@ -342,6 +342,7 @@ github.com/otterize/go-procnet v0.1.1 h1:5vRwX35VrsWcy2uP05sA4PmwpRoAu2L4vMJou4o
 github.com/otterize/go-procnet v0.1.1/go.mod h1:WEm282HzrSVBZg6DX2fNB4dpVHBPTCjzHWvqOfauV+Q=
 github.com/otterize/intents-operator/src v0.0.0-20240703130757-e9aa6677263f h1:N8gftUYHwIFwGKCLNfANDfpo+G/qiFKwtuada5ATkB8=
 github.com/otterize/intents-operator/src v0.0.0-20240703130757-e9aa6677263f/go.mod h1:nfX02iyk0wXTWYtW/dYiK+MEXD6ZM84fxXBZy7Jy370=
+github.com/otterize/intents-operator/src v0.0.0-20240715125001-7c068d1a15a6/go.mod h1:R4tfDkJToFDE931Qk7gi47KhXX5WJ3bBYIfskQ1l3Wg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -37,10 +37,7 @@ func main() {
 		TimestampFormat: time.RFC3339,
 	})
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
-	clusterUID, err := clusterutils.GetOrCreateClusterUID(errGroupCtx)
-	if err != nil {
-		logrus.WithError(err).Panic("Failed fetching cluster UID")
-	}
+	clusterUID := clusterutils.GetOrCreateClusterUID(errGroupCtx)
 	componentinfo.SetGlobalContextId(telemetrysender.Anonymize(clusterUID))
 	errorreporter.Init("kafka-watcher", version.Version())
 	defer errorreporter.AutoNotify()
@@ -53,6 +50,7 @@ func main() {
 	mode := viper.GetString(config.KafkaLogReadModeKey)
 
 	var watcher logwatcher2.Watcher
+	var err error
 
 	switch mode {
 	case config.FileReadMode:

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -36,9 +36,9 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	otterizev1 "github.com/otterize/intents-operator/src/operator/api/v1"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	otterizev1beta1 "github.com/otterize/intents-operator/src/operator/api/v1beta1"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
@@ -69,7 +69,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(otterizev1alpha2.AddToScheme(scheme))
 	utilruntime.Must(otterizev1alpha3.AddToScheme(scheme))
-	utilruntime.Must(otterizev1.AddToScheme(scheme))
+	utilruntime.Must(otterizev1beta1.AddToScheme(scheme))
 	utilruntime.Must(otterizev2alpha1.AddToScheme(scheme))
 }
 
@@ -94,10 +94,7 @@ func main() {
 	})
 	signalHandlerCtx := ctrl.SetupSignalHandler()
 
-	clusterUID, err := clusterutils.GetOrCreateClusterUID(signalHandlerCtx)
-	if err != nil {
-		logrus.WithError(err).Panic("Failed fetching cluster UID")
-	}
+	clusterUID := clusterutils.GetOrCreateClusterUID(signalHandlerCtx)
 
 	componentinfo.SetGlobalContextId(telemetrysender.Anonymize(clusterUID))
 

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -35,10 +35,7 @@ func main() {
 		TimestampFormat: time.RFC3339,
 	})
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
-	clusterUID, err := clusterutils.GetOrCreateClusterUID(errGroupCtx)
-	if err != nil {
-		logrus.WithError(err).Panic("Failed fetching cluster UID")
-	}
+	clusterUID := clusterutils.GetOrCreateClusterUID(errGroupCtx)
 	componentinfo.SetGlobalContextId(telemetrysender.Anonymize(clusterUID))
 	errorreporter.Init("sniffer", version.Version())
 	defer errorreporter.AutoNotify()
@@ -87,7 +84,7 @@ func main() {
 		return snifferInstance.RunForever(errGroupCtx)
 	})
 
-	err = errgrp.Wait()
+	err := errgrp.Wait()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logrus.WithError(err).Panic("Error when running server or HTTP server")
 	}


### PR DESCRIPTION
### Description

After reconsidering Kubernetes custom resources versioning conventions, we have decided to upgrade `v1alpha3` to `v1beta1` instead of `v1`

### References

https://github.com/otterize/intents-operator/pull/454/

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
