### PR TITLE
Fix a bug where the source hostnames weren't enforced on TCP capture results for AWS; Add a configuration key to define the time a server-pod has to live for us to trust it's IP 

### DIFF
--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -39,15 +39,17 @@ const (
 	ServiceCacheSizeKey                   = "service-cache-size"
 	ServiceCacheSizeDefault               = 10000
 
-	EnableIstioCollectionKey           = "enable-istio-collection"
-	EnableIstioCollectionDefault       = false
-	IstioRestrictCollectionToNamespace = "istio-restrict-collection-to-namespace"
-	IstioReportIntervalKey             = "istio-report-interval"
-	IstioReportIntervalDefault         = 30 * time.Second
-	IstioCooldownIntervalKey           = "istio-cooldown-interval"
-	IstioCooldownIntervalDefault       = 15 * time.Second
-	MetricFetchTimeoutKey              = "istio-metric-fetch-timeout"
-	MetricFetchTimeoutDefault          = 10 * time.Second
+	EnableIstioCollectionKey                  = "enable-istio-collection"
+	EnableIstioCollectionDefault              = false
+	IstioRestrictCollectionToNamespace        = "istio-restrict-collection-to-namespace"
+	IstioReportIntervalKey                    = "istio-report-interval"
+	IstioReportIntervalDefault                = 30 * time.Second
+	IstioCooldownIntervalKey                  = "istio-cooldown-interval"
+	IstioCooldownIntervalDefault              = 15 * time.Second
+	MetricFetchTimeoutKey                     = "istio-metric-fetch-timeout"
+	MetricFetchTimeoutDefault                 = 10 * time.Second
+	TimeServerHasToLiveBeforeWeTrustItKey     = "time-server-has-to-live-before-we-trust-it"
+	TimeServerHasToLiveBeforeWeTrustItDefault = 5 * time.Minute
 )
 
 var excludedNamespaces *goset.Set[string]
@@ -77,5 +79,6 @@ func init() {
 	viper.SetDefault(EnableIstioCollectionKey, EnableIstioCollectionDefault)
 	viper.SetDefault(ServiceCacheTTLDurationKey, ServiceCacheTTLDurationDefault)
 	viper.SetDefault(ServiceCacheSizeKey, ServiceCacheSizeDefault)
+	viper.SetDefault(TimeServerHasToLiveBeforeWeTrustItKey, TimeServerHasToLiveBeforeWeTrustItDefault)
 	excludedNamespaces = goset.FromSlice(viper.GetStringSlice(ExcludedNamespacesKey))
 }

--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -40,6 +40,8 @@ func (r *Resolver) discoverSrcIdentity(ctx context.Context, src model.RecordedDe
 		}
 		return model.OtterizeServiceIdentity{}, errors.Errorf("could not resolve %s to pod: %w", src.SrcIP, err)
 	}
+	// When running on AWS - we must validate the hostname because the IP may be reused by a new pod (AWS VPC CNI)
+	// When not running on AWS - source hostname resolution in the sniffer might be disabled
 	if (src.SrcHostname != "" || r.isRunningOnAws) && srcPod.Name != src.SrcHostname {
 		// This could mean a new pod is reusing the same IP
 		// TODO: Use the captured hostname to actually find the relevant pod (instead of the IP that might no longer exist or be reused)

--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -40,7 +40,7 @@ func (r *Resolver) discoverSrcIdentity(ctx context.Context, src model.RecordedDe
 		}
 		return model.OtterizeServiceIdentity{}, errors.Errorf("could not resolve %s to pod: %w", src.SrcIP, err)
 	}
-	if src.SrcHostname != "" && srcPod.Name != src.SrcHostname {
+	if (src.SrcHostname != "" || r.isRunningOnAws) && srcPod.Name != src.SrcHostname {
 		// This could mean a new pod is reusing the same IP
 		// TODO: Use the captured hostname to actually find the relevant pod (instead of the IP that might no longer exist or be reused)
 		return model.OtterizeServiceIdentity{}, errors.Errorf("found pod %s (by ip %s) doesn't match captured hostname %s, ignoring", srcPod.Name, src.SrcIP, src.SrcHostname)

--- a/src/mapper/pkg/resolvers/resolver.go
+++ b/src/mapper/pkg/resolvers/resolver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/incomingtrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/intentsstore"
 	"github.com/otterize/network-mapper/src/mapper/pkg/kubefinder"
+	"github.com/otterize/network-mapper/src/shared/isrunningonaws"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -38,6 +39,7 @@ type Resolver struct {
 	awsOperations                chan model.AWSOperationResults
 	gotResultsCtx                context.Context
 	gotResultsSignal             context.CancelFunc
+	isRunningOnAws               bool
 }
 
 func NewResolver(
@@ -63,6 +65,7 @@ func NewResolver(
 		awsOperations:                make(chan model.AWSOperationResults, 200),
 		awsIntentsHolder:             awsIntentsHolder,
 		dnsCache:                     dnsCache,
+		isRunningOnAws:               isrunningonaws.Check(),
 	}
 	r.gotResultsCtx, r.gotResultsSignal = context.WithCancel(context.Background())
 

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -156,7 +156,7 @@ func (r *Resolver) addSocketScanPodIntent(ctx context.Context, srcSvcIdentity mo
 		return nil
 	}
 
-	if destPod.CreationTimestamp.After(dest.LastSeen) {
+	if destPod.CreationTimestamp.After(dest.LastSeen.Add(-viper.GetDuration(config.TimeServerHasToLiveBeforeWeTrustItKey))) {
 		logrus.Debugf("Pod %s was created after scan time %s, ignoring", destPod.Name, dest.LastSeen)
 		return nil
 	}
@@ -287,6 +287,7 @@ func (r *Resolver) resolveOtterizeIdentityForDestinationAddress(ctx context.Cont
 		logrus.Debugf("Service address %s is currently not backed by any pod, ignoring", destAddress)
 		return nil, false, nil
 	}
+	// Resolving the IP of the service's endpoints!
 	destPod, err := r.kubeFinder.ResolveIPToPod(ctx, ips[0])
 	if err != nil {
 		if errors.Is(err, kubefinder.ErrFoundMoreThanOnePod) {

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -30,8 +30,6 @@ const (
 	SourceTypeSocketScan  SourceType = "SocketScan"
 	SourceTypeKafkaMapper SourceType = "KafkaMapper"
 	SourceTypeIstio       SourceType = "Istio"
-	apiServerName                    = "kubernetes"
-	apiServerNamespace               = "default"
 )
 
 func updateTelemetriesCounters(sourceType SourceType, intent model.Intent) {
@@ -156,8 +154,9 @@ func (r *Resolver) addSocketScanPodIntent(ctx context.Context, srcSvcIdentity mo
 		return nil
 	}
 
-	if destPod.CreationTimestamp.After(dest.LastSeen.Add(-viper.GetDuration(config.TimeServerHasToLiveBeforeWeTrustItKey))) {
-		logrus.Debugf("Pod %s was created after scan time %s, ignoring", destPod.Name, dest.LastSeen)
+	minTimeForPodCreationTime := dest.LastSeen.Add(-viper.GetDuration(config.TimeServerHasToLiveBeforeWeTrustItKey))
+	if destPod.CreationTimestamp.After(minTimeForPodCreationTime) {
+		logrus.Debugf("Pod %s was created after scan time %s, ignoring", destPod.Name, minTimeForPodCreationTime)
 		return nil
 	}
 

--- a/src/shared/isrunningonaws/check.go
+++ b/src/shared/isrunningonaws/check.go
@@ -1,0 +1,32 @@
+package isrunningonaws
+
+import (
+	"context"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/smithy-go/logging"
+	"github.com/sirupsen/logrus"
+	"time"
+)
+
+func Check() bool {
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cfg, err := awsconfig.LoadDefaultConfig(ctxTimeout)
+	if err != nil {
+		logrus.Debug("Autodetect AWS (an error here is fine): Failed to load AWS config")
+		return false
+	}
+	cfg.Logger = logging.Nop{}
+
+	client := imds.NewFromConfig(cfg)
+
+	result, err := client.GetInstanceIdentityDocument(ctxTimeout, &imds.GetInstanceIdentityDocumentInput{})
+	if err != nil {
+		logrus.Debug("Autodetect AWS (an error here is fine): Failed to get instance identity document")
+		return false
+	}
+
+	logrus.WithField("region", result.Region).Debug("Autodetect AWS: Running on AWS")
+	return true
+}

--- a/src/sniffer/pkg/collectors/tcpsniffer.go
+++ b/src/sniffer/pkg/collectors/tcpsniffer.go
@@ -108,6 +108,7 @@ func (s *TCPSniffer) HandlePacket(packet gopacket.Packet) {
 	localHostname, err := s.resolver.ResolveIP(srcIP)
 	if err != nil {
 		logrus.Debugf("Can't resolve IP addr %s, sending IP only", srcIP)
+		// This is still reported because might be ingress traffic, mapper would drop non-ingress captures with no src hostname
 		s.addCapturedRequest(srcIP, "", dstIP, dstIP, captureTime, nilable.FromPtr[int](nil), &dstPort)
 		return
 	}


### PR DESCRIPTION

### Description

This PR contains:
- Fix a bug where the source hostnames weren't enforced on TCP capture results for AWS. 
- Add a configuration key to define the minimum time server-pod has to live for us to trust its IP. Set its default to 5 minutes

