### PR TITLE
Improve the way we resolve services DNS to identities by going directly from the `targetRef` of `endpoints` instead of going through IP addresses

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,10 @@ permissions:
   # pull-requests: read
 
 jobs:
-  golangci:
-    name: golangci-lint
-    runs-on: ubuntu-20.04
+  vet:
+    # run vet in a separate job to avoid conflicts with golangci-lint pkg-cache
+    name: vet
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -31,6 +32,16 @@ jobs:
         working-directory: src/
       - name: check git diff
         run: git diff --exit-code
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.21.3'
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install libpcap-dev # required for the linter to be able to lint github.com/google/gopacket
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -41,7 +52,7 @@ jobs:
           working-directory: src
 
           # Optional: golangci-lint command line arguments.
-          args: --timeout 5m
+          args: --timeout 5m --out-format github-actions
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -56,13 +56,13 @@ func (s *KubeFinderTestSuite) TestResolveServiceAddressToIps() {
 	pods, service, err := s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("svc-service1.%s.svc.cluster.local", s.TestNamespace))
 	s.Require().NoError(err)
 	s.Require().Equal("svc-service1", service.Name)
-	s.Require().ElementsMatch(pods, lo.Map(retPods, func(p *corev1.Pod, _ int) corev1.Pod { return *p }))
+	s.Require().ElementsMatch(lo.Map(pods, func(p corev1.Pod, _ int) string { return p.Status.PodIP }), lo.Map(retPods, func(p *corev1.Pod, _ int) string { return p.Status.PodIP }))
 
 	// make sure we don't fail on the longer forms of k8s service addresses, listed on this page: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service
 	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.svc-service1.%s.svc.cluster.local", s.TestNamespace))
 	s.Require().Equal("svc-service1", service.Name)
 	s.Require().NoError(err)
-	s.Require().ElementsMatch(pods, lo.Map(retPods, func(p *corev1.Pod, _ int) corev1.Pod { return *p }))
+	s.Require().ElementsMatch(lo.Map(pods, func(p corev1.Pod, _ int) string { return p.Status.PodIP }), lo.Map(retPods, func(p *corev1.Pod, _ int) string { return p.Status.PodIP }))
 
 	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
 	s.Require().Error(err)
@@ -71,7 +71,7 @@ func (s *KubeFinderTestSuite) TestResolveServiceAddressToIps() {
 	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
 	s.Require().Error(err)
 	s.Require().Empty(service)
-	s.Require().ElementsMatch(pods, lo.Map(pods4444, func(p *corev1.Pod, _ int) corev1.Pod { return *p }))
+	s.Require().ElementsMatch(lo.Map(pods, func(p corev1.Pod, _ int) string { return p.Status.PodIP }), lo.Map(pods4444, func(p *corev1.Pod, _ int) string { return p.Status.PodIP }))
 }
 
 func TestKubeFinderTestSuite(t *testing.T) {

--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/otterize/network-mapper/src/shared/testbase"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
 	"testing"
@@ -38,10 +39,10 @@ func (s *KubeFinderTestSuite) TestResolveIpToPod() {
 }
 
 func (s *KubeFinderTestSuite) TestResolveServiceAddressToIps() {
-	_, _, err := s.kubeFinder.ResolveServiceAddressToIps(context.Background(), "www.google.com")
+	_, _, err := s.kubeFinder.ResolveServiceAddressToPods(context.Background(), "www.google.com")
 	s.Require().Error(err)
 
-	_, _, err = s.kubeFinder.ResolveServiceAddressToIps(context.Background(), fmt.Sprintf("svc-service1.%s.svc.cluster.local", s.TestNamespace))
+	_, _, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("svc-service1.%s.svc.cluster.local", s.TestNamespace))
 	s.Require().Error(err)
 
 	podIp0 := "1.1.1.1"
@@ -49,24 +50,28 @@ func (s *KubeFinderTestSuite) TestResolveServiceAddressToIps() {
 	podIp2 := "1.1.1.3"
 	s.Require().NoError(s.Mgr.GetClient().List(context.Background(), &corev1.EndpointsList{})) // Workaround: make then client start caching Endpoints, so when we do "WaitForCacheSync" it will actually sync cache"
 	s.AddDeploymentWithService("service0", []string{podIp0}, map[string]string{"app": "service0"}, "10.0.0.10")
-	s.AddDeploymentWithService("service1", []string{podIp1, podIp2}, map[string]string{"app": "service1"}, "10.0.0.11")
+	_, _, retPods := s.AddDeploymentWithService("service1", []string{podIp1, podIp2}, map[string]string{"app": "service1"}, "10.0.0.11")
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
-	ips, service, err := s.kubeFinder.ResolveServiceAddressToIps(context.Background(), fmt.Sprintf("svc-service1.%s.svc.cluster.local", s.TestNamespace))
+	pods, service, err := s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("svc-service1.%s.svc.cluster.local", s.TestNamespace))
 	s.Require().NoError(err)
 	s.Require().Equal("svc-service1", service.Name)
-	s.Require().ElementsMatch(ips, []string{podIp1, podIp2})
+	s.Require().ElementsMatch(pods, lo.Map(retPods, func(p *corev1.Pod, _ int) corev1.Pod { return *p }))
 
 	// make sure we don't fail on the longer forms of k8s service addresses, listed on this page: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service
-	ips, service, err = s.kubeFinder.ResolveServiceAddressToIps(context.Background(), fmt.Sprintf("4-4-4-4.svc-service1.%s.svc.cluster.local", s.TestNamespace))
+	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.svc-service1.%s.svc.cluster.local", s.TestNamespace))
 	s.Require().Equal("svc-service1", service.Name)
 	s.Require().NoError(err)
-	s.Require().ElementsMatch(ips, []string{podIp1, podIp2})
+	s.Require().ElementsMatch(pods, lo.Map(retPods, func(p *corev1.Pod, _ int) corev1.Pod { return *p }))
 
-	ips, service, err = s.kubeFinder.ResolveServiceAddressToIps(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
-	s.Require().NoError(err)
+	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
+	s.Require().Error(err)
+
+	_, pods4444 := s.AddDeployment("depl", []string{"4.4.4.4"}, map[string]string{"app": "4444"})
+	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
+	s.Require().Error(err)
 	s.Require().Empty(service)
-	s.Require().ElementsMatch(ips, []string{"4.4.4.4"})
+	s.Require().ElementsMatch(pods, lo.Map(pods4444, func(p *corev1.Pod, _ int) corev1.Pod { return *p }))
 }
 
 func TestKubeFinderTestSuite(t *testing.T) {

--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -66,6 +66,7 @@ func (s *KubeFinderTestSuite) TestResolveServiceAddressToIps() {
 
 	_, _, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
 	s.Require().Error(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	_, pods4444 := s.AddDeployment("depl", []string{"4.4.4.4"}, map[string]string{"app": "4444"})
 	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))

--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -64,12 +64,12 @@ func (s *KubeFinderTestSuite) TestResolveServiceAddressToIps() {
 	s.Require().NoError(err)
 	s.Require().ElementsMatch(lo.Map(pods, func(p corev1.Pod, _ int) string { return p.Status.PodIP }), lo.Map(retPods, func(p *corev1.Pod, _ int) string { return p.Status.PodIP }))
 
-	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
+	_, _, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
 	s.Require().Error(err)
 
 	_, pods4444 := s.AddDeployment("depl", []string{"4.4.4.4"}, map[string]string{"app": "4444"})
 	pods, service, err = s.kubeFinder.ResolveServiceAddressToPods(context.Background(), fmt.Sprintf("4-4-4-4.%s.pod.cluster.local", s.TestNamespace))
-	s.Require().Error(err)
+	s.Require().NoError(err)
 	s.Require().Empty(service)
 	s.Require().ElementsMatch(lo.Map(pods, func(p corev1.Pod, _ int) string { return p.Status.PodIP }), lo.Map(pods4444, func(p *corev1.Pod, _ int) string { return p.Status.PodIP }))
 }

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -283,16 +283,16 @@ func (r *Resolver) resolveOtterizeIdentityForDestinationAddress(ctx context.Cont
 	}
 
 	filteredPods := lo.Filter(pods, func(pod corev1.Pod, _ int) bool {
-		LastCreationTimeForUsToTrustIt := dest.LastSeen
+		lastCreationTimeForUsToTrustIt := dest.LastSeen
 		if lo.IsEmpty(serviceName) {
-			// In this case the DNS was a "pod" DNS - which contains IP - ad therefore less reliable.
-			LastCreationTimeForUsToTrustIt = LastCreationTimeForUsToTrustIt.Add(viper.GetDuration(config.TimeServerHasToLiveBeforeWeTrustItKey))
+			// In this case the DNS was a "pod" DNS - which contains IP - and therefore less reliable.
+			lastCreationTimeForUsToTrustIt = lastCreationTimeForUsToTrustIt.Add(viper.GetDuration(config.TimeServerHasToLiveBeforeWeTrustItKey))
 		}
-		return LastCreationTimeForUsToTrustIt.After(pod.CreationTimestamp.Time) && pod.DeletionTimestamp == nil
+		return lastCreationTimeForUsToTrustIt.After(pod.CreationTimestamp.Time) && pod.DeletionTimestamp == nil
 	})
 
 	if len(filteredPods) == 0 {
-		logrus.Debugf("Service address %s is currently not backed by any valoid pod, ignoring", destAddress)
+		logrus.Debugf("Service address %s is currently not backed by any valid pod, ignoring", destAddress)
 		return nil, false, nil
 	}
 


### PR DESCRIPTION

### Description

Improve the way we resolve services DNS to identities by going directly from the `targetRef` of `endpoints` instead of going through IP addresses


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
