### PR TITLE
Fix error reporting - use the enum graphql type

### DIFF
--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
 	"github.com/otterize/network-mapper/src/kafka-watcher/pkg/config"
 	logwatcher2 "github.com/otterize/network-mapper/src/kafka-watcher/pkg/logwatcher"
@@ -39,7 +40,7 @@ func main() {
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
 	clusterUID := clusterutils.GetOrCreateClusterUID(errGroupCtx)
 	componentinfo.SetGlobalContextId(telemetrysender.Anonymize(clusterUID))
-	errorreporter.Init("kafka-watcher", version.Version())
+	errorreporter.Init(telemetriesgql.TelemetryComponentTypeNetworkMapper, version.Version())
 	defer errorreporter.AutoNotify()
 	shared.RegisterPanicHandlers()
 

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -98,7 +98,7 @@ func main() {
 
 	componentinfo.SetGlobalContextId(telemetrysender.Anonymize(clusterUID))
 
-	errorreporter.Init("network-mapper", version.Version())
+	errorreporter.Init(telemetriesgql.TelemetryComponentTypeNetworkMapper, version.Version())
 	defer errorreporter.AutoNotify()
 	shared.RegisterPanicHandlers()
 

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/intents-operator/src/shared/telemetries/errorreporter"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
 	"github.com/otterize/network-mapper/src/shared/version"
 	"golang.org/x/sync/errgroup"
@@ -37,7 +38,7 @@ func main() {
 	errgrp, errGroupCtx := errgroup.WithContext(signals.SetupSignalHandler())
 	clusterUID := clusterutils.GetOrCreateClusterUID(errGroupCtx)
 	componentinfo.SetGlobalContextId(telemetrysender.Anonymize(clusterUID))
-	errorreporter.Init("sniffer", version.Version())
+	errorreporter.Init(telemetriesgql.TelemetryComponentTypeNetworkMapper, version.Version())
 	defer errorreporter.AutoNotify()
 	shared.RegisterPanicHandlers()
 


### PR DESCRIPTION
### Description

Use graphql enum type instead of string

