### PR TITLE
Improve load balancer service resolution - support shared external ip address

### DIFF
--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -202,8 +202,12 @@ func (s *ResolverTestSuite) TestReportCaptureResults() {
 
 func (s *ResolverTestSuite) TestReportIncomingTraffic() {
 	serviceIp := "10.0.0.16"
+	service2Ip := "10.0.0.17"
 	serviceExternalIP := "34.10.0.12"
 	s.AddDeploymentWithIngressService("service1", []string{"1.1.1.1"}, map[string]string{"app": "service1"}, serviceIp, serviceExternalIP, 9090)
+
+	// Add service2 to make sure our resolution handles the case where the load-balancer services share the same external IP
+	s.AddDeploymentWithIngressService("service2", []string{"1.1.1.2"}, map[string]string{"app": "service1"}, service2Ip, serviceExternalIP, 1337)
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 	externalInternetServerIP := "142.198.10.38"
 


### PR DESCRIPTION
### Description

Ip addresses can be shared between multiple services if they use different ports. Until this PR we didn't support resolution in those cases


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
