### PR TITLE
FIx bug where `hostNetwork` pods could be falsely detected as incoming traffic from outside of the cluster; Support resolution of `LoadBalancer` typed services using their node ports

### DIFF
--- a/src/mapper/pkg/kubefinder/kubefinder.go
+++ b/src/mapper/pkg/kubefinder/kubefinder.go
@@ -21,15 +21,16 @@ import (
 )
 
 const (
-	podIPIndexField            = "ip"
-	endpointIPPortIndexField   = "ipPort"
-	serviceIPIndexField        = "spec.ip"
-	externalIPIndexField       = "spec.externalIPs"
-	portNumberIndexField       = "service.spec.ports.nodePort"
-	nodeIPIndexField           = "node.status.Addresses.ExternalIP"
-	IstioCanonicalNameLabelKey = "service.istio.io/canonical-name"
-	apiServerName              = "kubernetes"
-	apiServerNamespace         = "default"
+	podIPIndexField                     = "ip"
+	podIPIncludingHostNetworkIndexField = "ipAndHostNetwork"
+	endpointIPPortIndexField            = "ipPort"
+	serviceIPIndexField                 = "spec.ip"
+	externalIPIndexField                = "spec.externalIPs"
+	portNumberIndexField                = "service.spec.ports.nodePort"
+	nodeIPIndexField                    = "node.status.Addresses.ExternalIP"
+	IstioCanonicalNameLabelKey          = "service.istio.io/canonical-name"
+	apiServerName                       = "kubernetes"
+	apiServerNamespace                  = "default"
 )
 
 type KubeFinder struct {
@@ -61,6 +62,24 @@ func (k *KubeFinder) initIndexes(ctx context.Context) error {
 		if pod.Spec.HostNetwork || pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
 			return res
 		}
+		for _, ip := range pod.Status.PodIPs {
+			res = append(res, ip.IP)
+		}
+		return res
+	})
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	err = k.mgr.GetCache().IndexField(ctx, &corev1.Pod{}, podIPIncludingHostNetworkIndexField, func(object client.Object) []string {
+		res := make([]string, 0)
+		pod := object.(*corev1.Pod)
+
+		// TODO: SHOULD I REMOVE IT??
+		if pod.DeletionTimestamp != nil {
+			return res
+		}
+
 		for _, ip := range pod.Status.PodIPs {
 			res = append(res, ip.IP)
 		}
@@ -105,7 +124,9 @@ func (k *KubeFinder) initIndexes(ctx context.Context) error {
 		if svc.DeletionTimestamp != nil {
 			return nil
 		}
-		if svc.Spec.Type != corev1.ServiceTypeNodePort {
+
+		// Node ports are unique regardless of the service type
+		if svc.Spec.Type != corev1.ServiceTypeNodePort && svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 			return nil
 		}
 
@@ -252,7 +273,7 @@ func (k *KubeFinder) ResolveIPToControlPlane(ctx context.Context, ip string) (*c
 }
 
 func (k *KubeFinder) ResolveIPToExternalAccessService(ctx context.Context, ip string, port int) (*corev1.Service, bool, error) {
-	nodePortService, ok, err := k.resolveNodePortService(ctx, ip, port)
+	nodePortService, ok, err := k.resolveServiceByNodeIPAndPort(ctx, ip, port)
 	if err != nil {
 		return nil, false, errors.Wrap(err)
 	}
@@ -260,14 +281,14 @@ func (k *KubeFinder) ResolveIPToExternalAccessService(ctx context.Context, ip st
 		return nodePortService, true, nil
 	}
 
-	loadBalancerService, ok, err := k.resolveLoadBalancerService(ctx, ip, port)
+	loadBalancerService, ok, err := k.resolveLoadBalancerServiceByExternalIP(ctx, ip, port)
 	if err != nil {
 		return nil, false, errors.Wrap(err)
 	}
 	return loadBalancerService, ok, nil
 }
 
-func (k *KubeFinder) resolveLoadBalancerService(ctx context.Context, ip string, port int) (*corev1.Service, bool, error) {
+func (k *KubeFinder) resolveLoadBalancerServiceByExternalIP(ctx context.Context, ip string, port int) (*corev1.Service, bool, error) {
 	var services corev1.ServiceList
 	err := k.client.List(ctx, &services, client.MatchingFields{externalIPIndexField: ip})
 	if err != nil {
@@ -288,7 +309,7 @@ func (k *KubeFinder) resolveLoadBalancerService(ctx context.Context, ip string, 
 	return &service, true, nil
 }
 
-func (k *KubeFinder) resolveNodePortService(ctx context.Context, ip string, port int) (*corev1.Service, bool, error) {
+func (k *KubeFinder) resolveServiceByNodeIPAndPort(ctx context.Context, ip string, port int) (*corev1.Service, bool, error) {
 	var nodes corev1.NodeList
 	err := k.client.List(ctx, &nodes, client.MatchingFields{nodeIPIndexField: ip})
 	if err != nil {
@@ -441,4 +462,54 @@ func (k *KubeFinder) ResolveOtterizeIdentityForService(ctx context.Context, svc 
 	}
 	dstSvcIdentity.KubernetesService = lo.ToPtr(svc.Name)
 	return dstSvcIdentity, true, nil
+}
+
+func (k *KubeFinder) IsSrcIpLocal(ctx context.Context, ip string) (bool, error) {
+	isNode, err := k.IsNodeIP(ctx, ip)
+	if err != nil {
+		return false, errors.Wrap(err)
+	}
+	if isNode {
+		return true, nil
+	}
+
+	isPod, err := k.IsPodIp(ctx, ip)
+	if err != nil {
+		return false, errors.Wrap(err)
+	}
+	if isPod {
+		return true, nil
+	}
+
+	_, isControlPlane, err := k.ResolveIPToControlPlane(ctx, ip)
+	if err != nil {
+		return false, errors.Wrap(err)
+	}
+	if isControlPlane {
+		return true, nil
+	}
+
+	//TODO: Should we check for services/endpoints as well?
+	//TODO: Should we check PodCIDR
+	//TODO: Should we have cache for pod ips and node ips?
+
+	return false, nil
+}
+
+func (k *KubeFinder) IsPodIp(ctx context.Context, ip string) (bool, error) {
+	var pods corev1.PodList
+	err := k.client.List(ctx, &pods, client.MatchingFields{podIPIncludingHostNetworkIndexField: ip})
+	if err != nil {
+		return false, errors.Wrap(err)
+	}
+	return len(pods.Items) > 0, nil
+}
+
+func (k *KubeFinder) IsNodeIP(ctx context.Context, ip string) (bool, error) {
+	var nodes corev1.NodeList
+	err := k.client.List(ctx, &nodes, client.MatchingFields{nodeIPIndexField: ip})
+	if err != nil {
+		return false, errors.Wrap(err)
+	}
+	return len(nodes.Items) > 0, nil
 }

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -376,31 +376,37 @@ func (r *Resolver) handleReportTCPCaptureResults(ctx context.Context, results mo
 	}
 
 	for _, captureItem := range results.Results {
-		logrus.Debugf("Handling TCP capture result from %s to %s:%d", captureItem.SrcIP, captureItem.Destinations[0].Destination, lo.FromPtr(captureItem.Destinations[0].DestinationPort))
-
-		isLocal, err := r.kubeFinder.IsSrcIpLocal(ctx, captureItem.SrcIP)
+		err := r.handleTCPCaptureResult(ctx, captureItem)
 		if err != nil {
-			logrus.WithError(err).WithField("ip", captureItem.SrcIP).Error("could not determine if source IP is local")
-			continue
-		}
-		if !isLocal {
-			err := r.reportIncomingInternetTraffic(ctx, captureItem.SrcIP, captureItem.Destinations)
-			if err != nil {
-				logrus.WithError(err).Error("could not report incoming internet traffic")
-			}
-			continue
-		}
-		srcSvcIdentity, err := r.discoverInternalSrcIdentity(ctx, captureItem)
-		if err != nil {
-			logrus.WithError(err).Debugf("could not discover src identity for '%s'", captureItem.SrcIP)
-			continue
-		}
-		for _, dest := range captureItem.Destinations {
-			r.handleInternalTrafficTCPResult(ctx, srcSvcIdentity, dest)
+			logrus.WithError(err).
+				WithField("srcIp", captureItem.SrcIP).
+				WithField("srcHostname", captureItem.SrcHostname).
+				Error("could not handle TCP capture result")
 		}
 	}
 	telemetrysender.SendNetworkMapper(telemetriesgql.EventTypeIntentsDiscoveredCapture, len(results.Results))
 	r.gotResultsSignal()
+	return nil
+}
+
+func (r *Resolver) handleTCPCaptureResult(ctx context.Context, captureItem model.RecordedDestinationsForSrc) error {
+	logrus.Debugf("Handling TCP capture result from %s to %s:%d", captureItem.SrcIP, captureItem.Destinations[0].Destination, lo.FromPtr(captureItem.Destinations[0].DestinationPort))
+	isSrcInCluster, err := r.kubeFinder.IsSrcIpClusterInternal(ctx, captureItem.SrcIP)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	if !isSrcInCluster {
+		return errors.Wrap(r.reportIncomingInternetTraffic(ctx, captureItem.SrcIP, captureItem.Destinations))
+	}
+
+	srcSvcIdentity, err := r.discoverInternalSrcIdentity(ctx, captureItem)
+	if err != nil {
+		logrus.WithError(err).Debugf("could not discover src identity for '%s'", captureItem.SrcIP)
+		return nil
+	}
+	for _, dest := range captureItem.Destinations {
+		r.handleInternalTrafficTCPResult(ctx, srcSvcIdentity, dest)
+	}
 	return nil
 }
 

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -69,6 +69,7 @@ func (s *ControllerManagerTestSuiteBase) SetupTest() {
 		ObjectMeta: metav1.ObjectMeta{Name: "node1"},
 		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.168.1.1"}}},
 	}, metav1.CreateOptions{})
+	s.Require().NoError(err)
 }
 
 // BeforeTest happens AFTER the SetupTest()

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -54,12 +54,21 @@ func (s *ControllerManagerTestSuiteBase) SetupTest() {
 	s.Mgr, err = manager.New(s.cfg, manager.Options{Metrics: server.Options{BindAddress: "0"}})
 	s.Require().NoError(err)
 	testName := s.T().Name()[strings.LastIndex(s.T().Name(), "/")+1:]
+	maxLen := 63 - len("-20060102150405")
+	if len(testName) > maxLen {
+		sliceStart := len(testName) - maxLen
+		testName = testName[sliceStart:]
+	}
 	s.TestNamespace = strings.ToLower(fmt.Sprintf("%s-%s", testName, time.Now().Format("20060102150405")))
 	testNamespaceObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: s.TestNamespace},
 	}
 	_, err = s.K8sDirectClient.CoreV1().Namespaces().Create(context.Background(), testNamespaceObj, metav1.CreateOptions{})
 	s.Require().NoError(err)
+	_, err = s.K8sDirectClient.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+		Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.168.1.1"}}},
+	}, metav1.CreateOptions{})
 }
 
 // BeforeTest happens AFTER the SetupTest()
@@ -195,12 +204,20 @@ func (s *ControllerManagerTestSuiteBase) AddEndpoints(name string, pods []*corev
 	return endpoints
 }
 
-func (s *ControllerManagerTestSuiteBase) AddService(name string, selector map[string]string, serviceIp string, pods []*corev1.Pod) *corev1.Service {
+func (s *ControllerManagerTestSuiteBase) AddClusterIPService(name string, selector map[string]string, serviceIp string, pods []*corev1.Pod) *corev1.Service {
+	return s.AddService(name, selector, serviceIp, pods, corev1.ServiceTypeClusterIP)
+}
+
+func (s *ControllerManagerTestSuiteBase) AddLoadBalancerService(name string, selector map[string]string, serviceIp string, pods []*corev1.Pod) *corev1.Service {
+	return s.AddService(name, selector, serviceIp, pods, corev1.ServiceTypeLoadBalancer)
+}
+
+func (s *ControllerManagerTestSuiteBase) AddService(name string, selector map[string]string, serviceIp string, pods []*corev1.Pod, serviceType corev1.ServiceType) *corev1.Service {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("svc-%s", name), Namespace: s.TestNamespace},
 		Spec: corev1.ServiceSpec{Selector: selector,
 			Ports:      []corev1.ServicePort{{Name: "someport", Port: 8080, Protocol: corev1.ProtocolTCP}},
-			Type:       corev1.ServiceTypeClusterIP,
+			Type:       serviceType,
 			ClusterIP:  serviceIp,
 			ClusterIPs: []string{serviceIp},
 		},
@@ -389,7 +406,7 @@ func (s *ControllerManagerTestSuiteBase) AddDeployment(name string, podIps []str
 
 func (s *ControllerManagerTestSuiteBase) AddDeploymentWithService(name string, podIps []string, podLabels map[string]string, serviceIp string) (*appsv1.Deployment, *corev1.Service, []*corev1.Pod) {
 	deployment, pods := s.AddDeployment(name, podIps, podLabels)
-	service := s.AddService(name, podLabels, serviceIp, pods)
+	service := s.AddClusterIPService(name, podLabels, serviceIp, pods)
 	return deployment, service, pods
 }
 
@@ -442,6 +459,6 @@ func (s *ControllerManagerTestSuiteBase) AddDaemonSet(name string, podIps []stri
 
 func (s *ControllerManagerTestSuiteBase) AddDaemonSetWithService(name string, podIps []string, podLabels map[string]string, serviceIp string) (*appsv1.DaemonSet, *corev1.Service) {
 	daemonSet, pods := s.AddDaemonSet(name, podIps, podLabels)
-	service := s.AddService(name, podLabels, serviceIp, pods)
+	service := s.AddClusterIPService(name, podLabels, serviceIp, pods)
 	return daemonSet, service
 }


### PR DESCRIPTION
### Description
_FIx bug where `hostNetwork` pods could be falsely detected as incoming traffic from outside the cluster:_  
- It was done by adding an index for pod Ips that includes host network pods.
- Added a test

_Support resolution of `LoadBalancer` typed services using their node ports_
- Added load balancer services to the "node ports index" that used to ignore them.
- Added a test

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
