### PR TITLE
Fix bug where discovered traffic from a pod wasn't filtered properly by its creation timestamp

### DIFF
--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -1019,6 +1019,7 @@ func (s *ResolverTestSuite) TestIntentsToApiServerDNS() {
 				Destinations: []test_gql_client.Destination{
 					{
 						Destination: fmt.Sprintf("%s.%s.svc.cluster.local", service.GetName(), service.GetNamespace()),
+						LastSeen:    time.Now().Add(time.Minute),
 					},
 				},
 			},
@@ -1070,7 +1071,7 @@ func (s *ResolverTestSuite) TestIntentsToApiServerSocketScan() {
 				Destinations: []test_gql_client.Destination{
 					{
 						Destination: service.Spec.ClusterIP,
-						LastSeen:    time.Now(),
+						LastSeen:    time.Now().Add(time.Minute),
 					},
 				},
 			},

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -1365,6 +1365,60 @@ func (s *ResolverTestSuite) TestTCPResultsFromExternalToLoadBalancerServiceUsing
 	s.Require().Equal("8.8.8.8", intents[0].Intent.IP)
 }
 
+func (s *ResolverTestSuite) TestResolveOtterizeIdentityFilterSrcDestinationsByCreationTimestamp() {
+	podIP := "1.1.1.3"
+	pod := s.AddPod("pod3", podIP, nil, nil)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+	recorededDestinationForSrc := &model.RecordedDestinationsForSrc{
+		SrcIP: podIP,
+		Destinations: []model.Destination{
+			{
+				Destination: "target-on-time",
+				LastSeen:    pod.CreationTimestamp.Add(time.Minute),
+			},
+			{
+				Destination: "target-before-time",
+				LastSeen:    pod.CreationTimestamp.Add(-time.Minute),
+			},
+		},
+	}
+	srcIdentity, err := s.resolver.discoverInternalSrcIdentity(context.Background(), recorededDestinationForSrc)
+	s.Require().NoError(err)
+	s.Require().Equal("pod3", srcIdentity.Name)
+
+	s.Require().Len(recorededDestinationForSrc.Destinations, 1)
+	s.Require().Equal("target-on-time", recorededDestinationForSrc.Destinations[0].Destination)
+
+}
+
+func (s *ResolverTestSuite) TestPoop() {
+	//serviceIP := "10.0.0.10"
+	podIP := "1.1.1.3"
+
+	pod3 := s.AddPod("pod3", podIP, nil, nil)
+	//s.AddService(serviceName, map[string]string{"app": "test"}, serviceIP, []*v1.Pod{pod3})
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	pod := &v1.Pod{}
+	err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Name: pod3.Name, Namespace: pod3.Namespace}, pod)
+	s.Require().NoError(err)
+	podlist1 := &v1.PodList{}
+	err = s.Mgr.GetClient().List(context.Background(), podlist1, client.MatchingFields{"ip": pod.Status.PodIP})
+	s.Require().NoError(err)
+	s.Require().Len(podlist1.Items, 1)
+
+	err = s.Mgr.GetClient().Delete(context.Background(), pod)
+	s.Require().NoError(err)
+
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	podlist := &v1.PodList{}
+	err = s.Mgr.GetClient().List(context.Background(), podlist, client.MatchingFields{"ip": pod.Status.PodIP})
+	s.Require().NoError(err)
+	s.Require().Empty(podlist.Items)
+
+}
+
 func TestRunSuite(t *testing.T) {
 	suite.Run(t, new(ResolverTestSuite))
 }

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -399,7 +399,7 @@ func (r *Resolver) handleTCPCaptureResult(ctx context.Context, captureItem model
 		return errors.Wrap(r.reportIncomingInternetTraffic(ctx, captureItem.SrcIP, captureItem.Destinations))
 	}
 
-	srcSvcIdentity, err := r.discoverInternalSrcIdentity(ctx, captureItem)
+	srcSvcIdentity, err := r.discoverInternalSrcIdentity(ctx, &captureItem)
 	if err != nil {
 		logrus.WithError(err).Debugf("could not discover src identity for '%s'", captureItem.SrcIP)
 		return nil
@@ -462,7 +462,7 @@ func (r *Resolver) handleReportCaptureResults(ctx context.Context, results model
 
 	var newResults int
 	for _, captureItem := range results.Results {
-		srcSvcIdentity, err := r.discoverInternalSrcIdentity(ctx, captureItem)
+		srcSvcIdentity, err := r.discoverInternalSrcIdentity(ctx, &captureItem)
 		if err != nil {
 			logrus.WithError(err).Debugf("could not discover src identity for '%s'", captureItem.SrcIP)
 			continue
@@ -499,7 +499,7 @@ func (r *Resolver) handleReportSocketScanResults(ctx context.Context, results mo
 		return nil
 	}
 	for _, socketScanItem := range results.Results {
-		srcSvcIdentity, err := r.discoverInternalSrcIdentity(ctx, socketScanItem)
+		srcSvcIdentity, err := r.discoverInternalSrcIdentity(ctx, &socketScanItem)
 		if err != nil {
 			logrus.WithError(err).Debugf("could not discover src identity for '%s'", socketScanItem.SrcIP)
 			continue


### PR DESCRIPTION


### Description

Fix bug where traffic from a pod wasn't filtered properly by its creation timestamp. It happened because the filtering function didn't get a pointer - so the filter operation did not affect the calling scope.


### Testing


- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
