### PR TITLE
Reduce the risk of misidentification of incoming traffic by verifying destination hostname when resolving incoming internet traffic; Use `/proc/<pid>/root/etc/hostname` for IP to hostname resolution as an alternative to `/proc/<pid>/environ`

### DIFF
--- a/src/mapper/pkg/dnsintentspublisher/dns_intents_publisher.go
+++ b/src/mapper/pkg/dnsintentspublisher/dns_intents_publisher.go
@@ -113,9 +113,11 @@ func (p *Publisher) updateResolvedIPs(ctx context.Context, clientIntents otteriz
 
 	updatedResolvedIPs := make([]otterizev2alpha1.ResolvedIPs, 0, len(resolvedIPsMap))
 	for dnsName, ips := range resolvedIPsMap {
+		ipSlice := lo.MapToSlice(ips, func(ip string, _ struct{}) string { return ip })
+		slices.Sort(ipSlice)
 		updatedResolvedIPs = append(updatedResolvedIPs, otterizev2alpha1.ResolvedIPs{
 			DNS: dnsName,
-			IPs: lo.MapToSlice(ips, func(ip string, _ struct{}) string { return ip }),
+			IPs: ipSlice,
 		})
 	}
 

--- a/src/mapper/pkg/dnsintentspublisher/dns_intents_publisher_test.go
+++ b/src/mapper/pkg/dnsintentspublisher/dns_intents_publisher_test.go
@@ -298,8 +298,8 @@ func (s *PublisherTestSuite) TestAppendToOldIP() {
 		{
 			DNS: "my-blog.de",
 			IPs: []string{
-				oldIP,
 				IP1,
+				oldIP,
 			},
 		},
 	}

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -362,6 +362,12 @@ func (r *Resolver) resolveOtterizeIdentityForExternalAccessDestination(ctx conte
 			logrus.WithError(err).Debugf("Could not resolve %s to pod", destIP)
 			return model.OtterizeServiceIdentity{}, false, errors.Wrap(err)
 		}
+		if dest.Destination != "" && dest.Destination != destIP && dest.Destination != pod.Name {
+			logrus.Infof("Destination %s is not a service, but a pod %s", dest.Destination, pod.Name)
+			return model.OtterizeServiceIdentity{}, false, nil
+		}
+		logrus.Infof("Destination %s %s is a pod %s", destIP, dest.Destination, pod.Name)
+
 		dstSvcIdentity, err := r.resolveInClusterIdentity(ctx, pod)
 		if err != nil {
 			return model.OtterizeServiceIdentity{}, false, errors.Wrap(err)

--- a/src/sniffer/pkg/collectors/dnssniffer.go
+++ b/src/sniffer/pkg/collectors/dnssniffer.go
@@ -146,8 +146,8 @@ func (s *DNSSniffer) HandlePacket(packet gopacket.Packet) {
 					s.addCapturedRequest(ip.DstIP.String(), "", hostName, answer.IP.String(), captureTime, nilable.From(int(answer.TTL)), nil)
 					continue
 				}
-				hostname, err := s.resolver.ResolveIP(ip.DstIP.String())
-				if err != nil {
+				hostname, ok := s.resolver.ResolveIP(ip.DstIP.String())
+				if !ok {
 					logrus.Debugf("Can't resolve IP addr %s, skipping", ip.DstIP.String())
 				} else {
 					// Resolver cache could be outdated, verify same resolving result after next poll
@@ -194,8 +194,8 @@ func (s *DNSSniffer) RefreshHostsMapping() error {
 	}
 
 	for _, p := range s.pending {
-		hostname, err := s.resolver.ResolveIP(p.srcIp)
-		if err != nil {
+		hostname, ok := s.resolver.ResolveIP(p.srcIp)
+		if !ok {
 			logrus.WithError(err).Debugf("Could not to resolve %s, skipping packet", p.srcIp)
 			continue
 		}

--- a/src/sniffer/pkg/collectors/tcpsniffer.go
+++ b/src/sniffer/pkg/collectors/tcpsniffer.go
@@ -107,7 +107,6 @@ func (s *TCPSniffer) HandlePacket(packet gopacket.Packet) {
 
 	localHostname, ok := s.resolver.ResolveIP(srcIP)
 	if !ok {
-		logrus.Debugf("Can't resolve IP addr %s, sending IP only", srcIP)
 		// This is still reported because might be ingress traffic, mapper would drop non-ingress captures with no src hostname
 		destNameOrIP := dstIP
 		destHostname, ok := s.resolver.ResolveIP(dstIP)

--- a/src/sniffer/pkg/collectors/tcpsniffer.go
+++ b/src/sniffer/pkg/collectors/tcpsniffer.go
@@ -105,11 +105,16 @@ func (s *TCPSniffer) HandlePacket(packet gopacket.Packet) {
 		return
 	}
 
-	localHostname, err := s.resolver.ResolveIP(srcIP)
-	if err != nil {
+	localHostname, ok := s.resolver.ResolveIP(srcIP)
+	if !ok {
 		logrus.Debugf("Can't resolve IP addr %s, sending IP only", srcIP)
 		// This is still reported because might be ingress traffic, mapper would drop non-ingress captures with no src hostname
-		s.addCapturedRequest(srcIP, "", dstIP, dstIP, captureTime, nilable.FromPtr[int](nil), &dstPort)
+		destNameOrIP := dstIP
+		destHostname, ok := s.resolver.ResolveIP(dstIP)
+		if ok {
+			destNameOrIP = destHostname
+		}
+		s.addCapturedRequest(srcIP, "", destNameOrIP, dstIP, captureTime, nilable.FromPtr[int](nil), &dstPort)
 		return
 	}
 
@@ -161,8 +166,8 @@ func (s *TCPSniffer) RefreshHostsMapping() error {
 	}
 
 	for _, p := range s.pending {
-		hostname, err := s.resolver.ResolveIP(p.srcIp)
-		if err != nil {
+		hostname, ok := s.resolver.ResolveIP(p.srcIp)
+		if !ok {
 			logrus.WithError(err).Debugf("Could not to resolve %s, skipping packet", p.srcIp)
 			continue
 		}

--- a/src/sniffer/pkg/collectors/tcpsniffer_test.go
+++ b/src/sniffer/pkg/collectors/tcpsniffer_test.go
@@ -17,7 +17,7 @@ import (
 func TestTCPSniffer_TestHandlePacketAWS(t *testing.T) {
 	controller := gomock.NewController(t)
 	mockResolver := ipresolver.NewMockIPResolver(controller)
-	mockResolver.EXPECT().ResolveIP("10.0.2.48").Return("client-1", nil).Times(2) // once for the initial check, and then another for verification
+	mockResolver.EXPECT().ResolveIP("10.0.2.48").Return("client-1", true).Times(2) // once for the initial check, and then another for verification
 	mockResolver.EXPECT().Refresh().Return(nil).Times(1)
 
 	sniffer := NewTCPSniffer(mockResolver, true)

--- a/src/sniffer/pkg/config/config.go
+++ b/src/sniffer/pkg/config/config.go
@@ -16,6 +16,8 @@ const (
 	PacketsBufferLengthDefault         = 4096
 	HostsMappingRefreshIntervalKey     = "hosts-mapping-refresh-interval"
 	HostsMappingRefreshIntervalDefault = 500 * time.Millisecond
+	UseExtendedProcfsResolutionKey     = "use-extended-procfs-resolution"
+	UseExtendedProcfsResolutionDefault = false
 )
 
 func init() {
@@ -24,4 +26,5 @@ func init() {
 	viper.SetDefault(CallsTimeoutKey, CallsTimeoutDefault)
 	viper.SetDefault(HostProcDirKey, HostProcDirDefault)
 	viper.SetDefault(HostsMappingRefreshIntervalKey, HostsMappingRefreshIntervalDefault)
+	viper.SetDefault(UseExtendedProcfsResolutionKey, UseExtendedProcfsResolutionDefault)
 }

--- a/src/sniffer/pkg/ipresolver/ipresolver.go
+++ b/src/sniffer/pkg/ipresolver/ipresolver.go
@@ -7,7 +7,7 @@ import (
 
 type IPResolver interface {
 	Refresh() error
-	ResolveIP(ipaddr string) (hostname string, err error)
+	ResolveIP(ipaddr string) (hostname string, ok bool)
 }
 
 // NewMockIPResolver creates a new mock instance.
@@ -48,11 +48,11 @@ func (mr *MockIPResolverMockRecorder) Refresh() *gomock.Call {
 }
 
 // ResolveIP mocks base method.
-func (m *MockIPResolver) ResolveIP(ipaddr string) (string, error) {
+func (m *MockIPResolver) ResolveIP(ipaddr string) (string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveIP", ipaddr)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
+	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 

--- a/src/sniffer/pkg/ipresolver/procfs_resolver.go
+++ b/src/sniffer/pkg/ipresolver/procfs_resolver.go
@@ -29,11 +29,11 @@ func NewProcFSIPResolver() *ProcFSIPResolver {
 	return &r
 }
 
-func (r *ProcFSIPResolver) ResolveIP(ipaddr string) (hostname string, err error) {
+func (r *ProcFSIPResolver) ResolveIP(ipaddr string) (hostname string, ok bool) {
 	if hostInfo, ok := r.byAddr[ipaddr]; ok {
-		return hostInfo.Hostname, nil
+		return hostInfo.Hostname, true
 	}
-	return "", errors.New("ip not found")
+	return "", false
 }
 
 func (r *ProcFSIPResolver) Refresh() error {

--- a/src/sniffer/pkg/utils/procfs.go
+++ b/src/sniffer/pkg/utils/procfs.go
@@ -36,12 +36,14 @@ func ScanProcDirProcesses(callback ProcessScanCallback) error {
 }
 
 func ExtractProcessHostname(pDir string) (string, error) {
-	hostname, found, err := extractProcessHostnameUsingEtcHostname(pDir)
-	if err != nil {
-		return "", errors.Wrap(err)
-	}
-	if found {
-		return hostname, nil
+	if viper.GetBool(config.UseExtendedProcfsResolutionKey) {
+		hostname, found, err := extractProcessHostnameUsingEtcHostname(pDir)
+		if err != nil {
+			return "", errors.Wrap(err)
+		}
+		if found {
+			return hostname, nil
+		}
 	}
 	return extractProcessHostnameUsingEnviron(pDir)
 


### PR DESCRIPTION
### Description

1. Reduce the risk of misidentification of incoming traffic by verifying destination hostname when resolving incoming internet traffic.

2. Improve IP to hostname procfs resolver by using `/proc/<pid>/root/etc/hostname` as an alternative to `/proc/<pid>/environ`

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
