### PR TITLE
Fix a bug where detected TCP traffic from pods short time before their deletion time could be labeled as incoming traffic from the internet

### DIFF
--- a/src/mapper/pkg/kubefinder/kubefinder.go
+++ b/src/mapper/pkg/kubefinder/kubefinder.go
@@ -3,6 +3,7 @@ package kubefinder
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/network-mapper/src/mapper/pkg/config"
@@ -37,20 +38,28 @@ type KubeFinder struct {
 	mgr               manager.Manager
 	client            client.Client
 	serviceIdResolver *serviceidresolver.Resolver
+	SeenIPsTTLCache   *expirable.LRU[string, struct{}]
 }
 
-var ErrNoPodFound = errors.NewSentinelError("no pod found")
-var ErrFoundMoreThanOnePod = errors.NewSentinelError("ip belongs to more than one pod")
-var ErrFoundMoreThanOneService = errors.NewSentinelError("ip belongs to more than one service")
-var ErrServiceNotFound = errors.NewSentinelError("service not found")
+var (
+	ErrNoPodFound              = errors.NewSentinelError("no pod found")
+	ErrFoundMoreThanOnePod     = errors.NewSentinelError("ip belongs to more than one pod")
+	ErrFoundMoreThanOneService = errors.NewSentinelError("ip belongs to more than one service")
+	ErrServiceNotFound         = errors.NewSentinelError("service not found")
+)
 
 func NewKubeFinder(ctx context.Context, mgr manager.Manager) (*KubeFinder, error) {
 	indexer := &KubeFinder{client: mgr.GetClient(), mgr: mgr, serviceIdResolver: serviceidresolver.NewResolver(mgr.GetClient())}
+	indexer.initCache()
 	err := indexer.initIndexes(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
 	return indexer, nil
+}
+
+func (k *KubeFinder) initCache() {
+	k.SeenIPsTTLCache = expirable.NewLRU[string, struct{}](2000, nil, time.Minute*10)
 }
 
 func (k *KubeFinder) initIndexes(ctx context.Context) error {
@@ -80,6 +89,7 @@ func (k *KubeFinder) initIndexes(ctx context.Context) error {
 		}
 
 		for _, ip := range pod.Status.PodIPs {
+			k.SeenIPsTTLCache.Add(ip.IP, struct{}{})
 			res = append(res, ip.IP)
 		}
 		return res
@@ -464,7 +474,12 @@ func (k *KubeFinder) ResolveOtterizeIdentityForService(ctx context.Context, svc 
 }
 
 func (k *KubeFinder) IsSrcIpClusterInternal(ctx context.Context, ip string) (bool, error) {
-	// Known issue: this function is currently missing support for services/endpoints, node.PodCIDR, and pods that were deleted.
+	// Known issue: this function is currently missing support for services/endpoints, node.PodCIDR
+
+	wasPodIp := k.WasPodIP(ip)
+	if wasPodIp {
+		return true, nil
+	}
 
 	isNode, err := k.IsNodeIP(ctx, ip)
 	if err != nil {
@@ -500,6 +515,10 @@ func (k *KubeFinder) IsPodIp(ctx context.Context, ip string) (bool, error) {
 		return false, errors.Wrap(err)
 	}
 	return len(pods.Items) > 0, nil
+}
+
+func (k *KubeFinder) WasPodIP(ip string) bool {
+	return k.SeenIPsTTLCache.Contains(ip)
 }
 
 func (k *KubeFinder) IsNodeIP(ctx context.Context, ip string) (bool, error) {

--- a/src/mapper/pkg/kubefinder/kubefinder.go
+++ b/src/mapper/pkg/kubefinder/kubefinder.go
@@ -32,6 +32,8 @@ const (
 	IstioCanonicalNameLabelKey          = "service.istio.io/canonical-name"
 	apiServerName                       = "kubernetes"
 	apiServerNamespace                  = "default"
+	seenIPsCacheSize                    = 2000
+	seenIPsCacheTTL                     = time.Minute * 10
 )
 
 type KubeFinder struct {
@@ -59,7 +61,7 @@ func NewKubeFinder(ctx context.Context, mgr manager.Manager) (*KubeFinder, error
 }
 
 func (k *KubeFinder) initSeenIPsCache() {
-	k.seenIPsTTLCache = expirable.NewLRU[string, struct{}](2000, nil, time.Minute*10)
+	k.seenIPsTTLCache = expirable.NewLRU[string, struct{}](seenIPsCacheSize, nil, seenIPsCacheTTL)
 }
 
 func (k *KubeFinder) initIndexes(ctx context.Context) error {

--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -104,7 +104,7 @@ func (s *KubeFinderTestSuite) TestIsSrcIpClusterInternal() {
 	s.Require().True(isInternal)
 
 	// Reset the cache
-	s.kubeFinder.initCache()
+	s.kubeFinder.initSeenIPsCache()
 
 	// Check isInternal with the deleted pod's ip after cache reset
 	isInternal, err = s.kubeFinder.IsSrcIpClusterInternal(context.Background(), "1.1.1.1")

--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -75,6 +75,43 @@ func (s *KubeFinderTestSuite) TestResolveServiceAddressToIps() {
 	s.Require().ElementsMatch(lo.Map(pods, func(p corev1.Pod, _ int) string { return p.Status.PodIP }), lo.Map(pods4444, func(p *corev1.Pod, _ int) string { return p.Status.PodIP }))
 }
 
+func (s *KubeFinderTestSuite) TestIsSrcIpClusterInternal() {
+	pod := s.AddPod("test-pod", "1.1.1.1", nil, nil)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	// Check with existing pod's ip
+	isInternal, err := s.kubeFinder.IsSrcIpClusterInternal(context.Background(), "1.1.1.1")
+	s.Require().NoError(err)
+	s.Require().True(isInternal)
+
+	// Check with non-existing pod's ip
+	isInternal, err = s.kubeFinder.IsSrcIpClusterInternal(context.Background(), "8.8.8.8")
+	s.Require().NoError(err)
+	s.Require().False(isInternal)
+
+	err = s.Mgr.GetClient().Delete(context.Background(), pod)
+	s.Require().NoError(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	// Check pod doesn't exist in the manager's cache
+	pod, err = s.kubeFinder.ResolveIPToPod(context.Background(), "1.1.1.1")
+	s.Require().Nil(pod)
+	s.Require().Error(err)
+
+	// Check isInternal with the deleted pod's ip
+	isInternal, err = s.kubeFinder.IsSrcIpClusterInternal(context.Background(), "1.1.1.1")
+	s.Require().NoError(err)
+	s.Require().True(isInternal)
+
+	// Reset the cache
+	s.kubeFinder.initCache()
+
+	// Check isInternal with the deleted pod's ip after cache reset
+	isInternal, err = s.kubeFinder.IsSrcIpClusterInternal(context.Background(), "1.1.1.1")
+	s.Require().NoError(err)
+	s.Require().False(isInternal)
+}
+
 func TestKubeFinderTestSuite(t *testing.T) {
 	suite.Run(t, new(KubeFinderTestSuite))
 }


### PR DESCRIPTION


### Description

We fixed this bug by creating a TTL cache for pod IPs with an expiry time of 10 minutes.


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
