### PR TITLE
Use ClientName[space] as service identity name instead of as pod name

### DIFF
--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -254,25 +254,9 @@ func (r *Resolver) handleAWSOperationReport(ctx context.Context, operation model
 
 func (r *Resolver) handleAzureOperationReport(ctx context.Context, operation model.AzureOperationResults) error {
 	for _, op := range operation {
-		pod, err := r.kubeFinder.ResolvePodByName(ctx, op.ClientName, op.ClientNamespace)
-
-		if err != nil {
-			logrus.Errorf("could not resolve name %s/%s to Pod: %s",
-				op.ClientName, op.ClientNamespace, err.Error())
-			continue
-		}
-
-		identity, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, pod)
-
-		if err != nil {
-			logrus.Errorf("could not resolve pod %s/%s to OtterizeServiceIdentity: %s",
-				pod.Name, pod.Namespace, err.Error())
-			continue
-		}
-
 		r.azureIntentsHolder.AddOperation(model.OtterizeServiceIdentity{
-			Name:      identity.Name,
-			Namespace: identity.Namespace,
+			Name:      op.ClientName,
+			Namespace: op.ClientNamespace,
 		}, op)
 	}
 


### PR DESCRIPTION
### Description

Fix azure handling to use incoming operation client name and namespace as ServiceIdentity to match other handlers.



### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
