### PR TITLE
Report AWS operations with service identity

### DIFF
--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -519,6 +519,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputIstioConnectionResults,
 		ec.unmarshalInputKafkaMapperResult,
 		ec.unmarshalInputKafkaMapperResults,
+		ec.unmarshalInputNamespacedName,
 		ec.unmarshalInputRecordedDestinationsForSrc,
 		ec.unmarshalInputServerFilter,
 		ec.unmarshalInputSocketScanResults,
@@ -773,10 +774,16 @@ input IstioConnectionResults {
     results: [IstioConnection!]!
 }
 
+input NamespacedName {
+    name: String!
+    namespace: String!
+}
+
 input AWSOperation {
     resource: String!
     actions: [String!]!
-    srcIp: String!
+    srcIp: String
+    client: NamespacedName
 }
 
 input ServerFilter {
@@ -5041,7 +5048,7 @@ func (ec *executionContext) unmarshalInputAWSOperation(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"resource", "actions", "srcIp"}
+	fieldsInOrder := [...]string{"resource", "actions", "srcIp", "client"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -5064,11 +5071,18 @@ func (ec *executionContext) unmarshalInputAWSOperation(ctx context.Context, obj 
 			it.Actions = data
 		case "srcIp":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("srcIp"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.SrcIP = data
+		case "client":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("client"))
+			data, err := ec.unmarshalONamespacedName2ᚖgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐNamespacedName(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Client = data
 		}
 	}
 
@@ -5425,6 +5439,40 @@ func (ec *executionContext) unmarshalInputKafkaMapperResults(ctx context.Context
 				return it, err
 			}
 			it.Results = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputNamespacedName(ctx context.Context, obj interface{}) (model.NamespacedName, error) {
+	var it model.NamespacedName
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"name", "namespace"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "namespace":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("namespace"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Namespace = data
 		}
 	}
 
@@ -7485,6 +7533,14 @@ func (ec *executionContext) marshalOKafkaOperation2ᚕgithubᚗcomᚋotterizeᚋ
 	}
 
 	return ret
+}
+
+func (ec *executionContext) unmarshalONamespacedName2ᚖgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐNamespacedName(ctx context.Context, v interface{}) (*model.NamespacedName, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputNamespacedName(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOPodLabel2ᚕgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐPodLabelᚄ(ctx context.Context, sel ast.SelectionSet, v []model.PodLabel) graphql.Marshaler {

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -10,9 +10,10 @@ import (
 )
 
 type AWSOperation struct {
-	Resource string   `json:"resource"`
-	Actions  []string `json:"actions"`
-	SrcIP    string   `json:"srcIp"`
+	Resource string          `json:"resource"`
+	Actions  []string        `json:"actions"`
+	SrcIP    *string         `json:"srcIp,omitempty"`
+	Client   *NamespacedName `json:"client,omitempty"`
 }
 
 type AzureOperation struct {
@@ -105,6 +106,11 @@ type KafkaMapperResults struct {
 }
 
 type Mutation struct {
+}
+
+type NamespacedName struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }
 
 type OtterizeServiceIdentity struct {

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -257,7 +257,7 @@ func (r *Resolver) handleAWSOperationReport(ctx context.Context, operation model
 			srcPod, err := r.kubeFinder.ResolveIPToPod(ctx, *op.SrcIP)
 
 			if err != nil {
-				logrus.Errorf("could not resolve %s to pod: %s", op.SrcIP, err.Error())
+				logrus.Errorf("could not resolve IP %s to pod: %s", *op.SrcIP, err.Error())
 				continue
 			}
 

--- a/src/mapperclient/generated.go
+++ b/src/mapperclient/generated.go
@@ -11,9 +11,10 @@ import (
 )
 
 type AWSOperation struct {
-	Resource string   `json:"resource"`
-	Actions  []string `json:"actions"`
-	SrcIp    string   `json:"srcIp"`
+	Resource string                          `json:"resource"`
+	Actions  []string                        `json:"actions"`
+	SrcIp    nilable.Nilable[string]         `json:"srcIp"`
+	Client   nilable.Nilable[NamespacedName] `json:"client"`
 }
 
 // GetResource returns AWSOperation.Resource, and is useful for accessing the field via an interface.
@@ -23,7 +24,10 @@ func (v *AWSOperation) GetResource() string { return v.Resource }
 func (v *AWSOperation) GetActions() []string { return v.Actions }
 
 // GetSrcIp returns AWSOperation.SrcIp, and is useful for accessing the field via an interface.
-func (v *AWSOperation) GetSrcIp() string { return v.SrcIp }
+func (v *AWSOperation) GetSrcIp() nilable.Nilable[string] { return v.SrcIp }
+
+// GetClient returns AWSOperation.Client, and is useful for accessing the field via an interface.
+func (v *AWSOperation) GetClient() nilable.Nilable[NamespacedName] { return v.Client }
 
 type AzureOperation struct {
 	Scope           string   `json:"scope"`
@@ -126,6 +130,17 @@ type KafkaMapperResults struct {
 
 // GetResults returns KafkaMapperResults.Results, and is useful for accessing the field via an interface.
 func (v *KafkaMapperResults) GetResults() []KafkaMapperResult { return v.Results }
+
+type NamespacedName struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// GetName returns NamespacedName.Name, and is useful for accessing the field via an interface.
+func (v *NamespacedName) GetName() string { return v.Name }
+
+// GetNamespace returns NamespacedName.Namespace, and is useful for accessing the field via an interface.
+func (v *NamespacedName) GetNamespace() string { return v.Namespace }
 
 type RecordedDestinationsForSrc struct {
 	SrcIp        string        `json:"srcIp"`

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -152,10 +152,16 @@ input IstioConnectionResults {
     results: [IstioConnection!]!
 }
 
+input NamespacedName {
+    name: String!
+    namespace: String!
+}
+
 input AWSOperation {
     resource: String!
     actions: [String!]!
-    srcIp: String!
+    srcIp: String
+    client: NamespacedName
 }
 
 input ServerFilter {


### PR DESCRIPTION
### Description
ReportAWSOperation accepted a SrcIp parameter to link between a reported AWS operation and its pod. This has caused issues in cases where the source pod didn't exist by the time network-mapper received the report.
This PR adds a new parameter to the mutation, so that reporting clients can specify the service identity directly.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
