### PR TITLE
Fix a bug where host networking traffic could be misclassified as control plane traffic on Minikube

### DIFF
--- a/src/mapper/pkg/kubefinder/kubefinder.go
+++ b/src/mapper/pkg/kubefinder/kubefinder.go
@@ -238,6 +238,16 @@ func (k *KubeFinder) ResolveServiceToPods(ctx context.Context, svc *corev1.Servi
 	return pods, nil
 }
 
+func (k *KubeFinder) IsIpHostNetworkIp(ctx context.Context, ip string) (bool, error) {
+	var podsWithHostNetwork corev1.PodList
+	err := k.client.List(ctx, &podsWithHostNetwork, client.MatchingFields{podIPIncludingHostNetworkIndexField: ip})
+	if err != nil {
+		return false, errors.Wrap(err)
+	}
+
+	return lo.SomeBy(podsWithHostNetwork.Items, func(pod corev1.Pod) bool { return pod.Spec.HostNetwork }), nil
+}
+
 func (k *KubeFinder) ResolveIPToPod(ctx context.Context, ip string) (*corev1.Pod, error) {
 	var pods corev1.PodList
 	err := k.client.List(ctx, &pods, client.MatchingFields{podIPIndexField: ip})

--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -22,6 +22,15 @@ func (r *Resolver) discoverInternalSrcIdentity(ctx context.Context, src *model.R
 			Host:        lo.ToPtr(src.SrcIP),
 			PodHostname: lo.ToPtr(src.SrcHostname),
 		}
+		pods, err := r.kubeFinder.ResolveServiceToPods(ctx, svc)
+		if err != nil && !errors.Is(err, kubefinder.ErrNoPodFound) {
+			return model.OtterizeServiceIdentity{}, errors.Errorf("could not resolve service %s to pods: %w", svc.Name, err)
+		}
+		// ignore services backed by host networking pods because it might as well be unrelated traffic (not from the control plane)
+		if len(pods) > 0 && lo.SomeBy(pods, func(pod corev1.Pod) bool { return pod.Spec.HostNetwork }) {
+			logrus.Debugf("control plane service is backed by a host networking pod, ignoring")
+			return model.OtterizeServiceIdentity{}, nil
+		}
 		return model.OtterizeServiceIdentity{Name: svc.Name, Namespace: svc.Namespace, KubernetesService: &svc.Name, ResolutionData: &resolutionData}, nil
 	}
 

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -1484,6 +1484,7 @@ func (s *ResolverTestSuite) TestDiscoverInternalSrcIdentityIgnoreControlPlaneIfB
 	// get endpoints for control plane service
 	endpointsTest := &v1.Endpoints{}
 	err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Name: "kubernetes", Namespace: "default"}, endpointsTest)
+	s.Require().NoError(err)
 
 	// Add host network pod as a target for the control plane service
 	pod := s.AddPodWithHostNetwork("pod", endpointsTest.Subsets[0].Addresses[0].IP, map[string]string{"app": "test"}, nil, true)
@@ -1507,7 +1508,7 @@ func (s *ResolverTestSuite) TestDiscoverInternalSrcIdentityIgnoreControlPlaneIfB
 				},
 			},
 		})
-	s.Require().Equal(err, controlPlaneBackedByAHostNetworkPodError)
+	s.Require().Equal(controlPlaneBackedByAHostNetworkPodError, err)
 	s.Require().Empty(identity)
 
 	// Test source ip is pod ip
@@ -1520,7 +1521,7 @@ func (s *ResolverTestSuite) TestDiscoverInternalSrcIdentityIgnoreControlPlaneIfB
 				},
 			},
 		})
-	s.Require().Equal(err, controlPlaneBackedByAHostNetworkPodError)
+	s.Require().Equal(controlPlaneBackedByAHostNetworkPodError, err)
 	s.Require().Empty(identity)
 }
 

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -1474,6 +1474,56 @@ func (s *ResolverTestSuite) TestResolveOtterizeIdentityFilterSrcDestinationsByCr
 
 }
 
+func (s *ResolverTestSuite) TestDiscoverInternalSrcIdentityIgnoreControlPlaneIfBackedByHostNetworkPod() {
+
+	// get control plane service
+	controlPlaneService := &v1.Service{}
+	err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Name: "kubernetes", Namespace: "default"}, controlPlaneService)
+	s.Require().NoError(err)
+
+	// get endpoints for control plane service
+	endpointsTest := &v1.Endpoints{}
+	err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Name: "kubernetes", Namespace: "default"}, endpointsTest)
+
+	// Add host network pod as a target for the control plane service
+	pod := s.AddPodWithHostNetwork("pod", endpointsTest.Subsets[0].Addresses[0].IP, map[string]string{"app": "test"}, nil, true)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+	endpointsTest.Subsets[0].Addresses[0].TargetRef = &v1.ObjectReference{
+		Kind:      "Pod",
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+	err = s.Mgr.GetClient().Update(context.Background(), endpointsTest)
+	s.Require().NoError(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	// Test source ip is service ip
+	identity, err := s.resolver.discoverInternalSrcIdentity(context.Background(),
+		&model.RecordedDestinationsForSrc{
+			SrcIP: controlPlaneService.Spec.ClusterIP,
+			Destinations: []model.Destination{
+				{
+					Destination: "8.8.8.8",
+				},
+			},
+		})
+	s.Require().Equal(err, controlPlaneBackedByAHostNetworkPodError)
+	s.Require().Empty(identity)
+
+	// Test source ip is pod ip
+	identity, err = s.resolver.discoverInternalSrcIdentity(context.Background(),
+		&model.RecordedDestinationsForSrc{
+			SrcIP: pod.Status.PodIP,
+			Destinations: []model.Destination{
+				{
+					Destination: "8.8.8.8",
+				},
+			},
+		})
+	s.Require().Equal(err, controlPlaneBackedByAHostNetworkPodError)
+	s.Require().Empty(identity)
+}
+
 func TestRunSuite(t *testing.T) {
 	suite.Run(t, new(ResolverTestSuite))
 }

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -106,12 +106,13 @@ func (r *Resolver) resolveDestIdentity(ctx context.Context, dest model.Destinati
 		Namespace: destPod.Namespace,
 		Labels:    kubefinder.PodLabelsToOtterizeLabels(destPod),
 		ResolutionData: &model.IdentityResolutionData{
-			Host:      lo.ToPtr(dest.Destination),
-			Port:      dest.DestinationPort,
-			IsService: lo.ToPtr(false),
-			ExtraInfo: lo.ToPtr("resolveDestIdentity"),
-			LastSeen:  lo.ToPtr(dest.LastSeen.String()),
-			Uptime:    lo.ToPtr(time.Since(destPod.CreationTimestamp.Time).String()),
+			Host:        lo.ToPtr(dest.Destination),
+			PodHostname: lo.ToPtr(destPod.Name),
+			Port:        dest.DestinationPort,
+			IsService:   lo.ToPtr(false),
+			ExtraInfo:   lo.ToPtr("resolveDestIdentity"),
+			LastSeen:    lo.ToPtr(dest.LastSeen.String()),
+			Uptime:      lo.ToPtr(time.Since(destPod.CreationTimestamp.Time).String()),
 		},
 	}
 	if dstService.OwnerObject != nil {


### PR DESCRIPTION


### Description

When running on minikube the control plane service is backed by a host networking pod. In this scenario, we should avoid using it as the source of discovered intents, because this communication we discover may be of another host networking pod.


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
