### PR TITLE
Improve troubleshooting capabilities by sending the listening port of detected established connections from the sniffer to the mapper

### DIFF
--- a/src/sniffer/pkg/collectors/socketscanner.go
+++ b/src/sniffer/pkg/collectors/socketscanner.go
@@ -6,6 +6,7 @@ import (
 	sharedconfig "github.com/otterize/network-mapper/src/shared/config"
 	"github.com/otterize/network-mapper/src/sniffer/pkg/utils"
 	"github.com/otterize/nilable"
+	"github.com/samber/lo"
 	"github.com/spf13/viper"
 
 	"time"
@@ -52,7 +53,7 @@ func (s *SocketScanner) scanTcpFile(hostname string, path string) {
 		// Only report sockets from the client-side by checking if the local port for this socket is the same port as a listen socket.
 		if _, isServersideSocket := listenPorts[sock.LocalAddr.Port]; !isServersideSocket {
 			// The hostname we have here is the hostname for the client.
-			s.addCapturedRequest(sock.LocalAddr.IP.String(), hostname, sock.RemoteAddr.IP.String(), sock.RemoteAddr.IP.String(), time.Now(), nilable.Nilable[int]{}, nil)
+			s.addCapturedRequest(sock.LocalAddr.IP.String(), hostname, sock.RemoteAddr.IP.String(), sock.RemoteAddr.IP.String(), time.Now(), nilable.Nilable[int]{}, lo.ToPtr(int(sock.LocalAddr.Port)))
 		}
 	}
 }

--- a/src/sniffer/pkg/collectors/socketscanner_test.go
+++ b/src/sniffer/pkg/collectors/socketscanner_test.go
@@ -108,8 +108,9 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 			SrcHostname: "thisverypod",
 			Destinations: []mapperclient.Destination{
 				{
-					Destination:   "10.98.14.179",
-					DestinationIP: nilable.From("10.98.14.179"),
+					Destination:     "10.98.14.179",
+					DestinationIP:   nilable.From("10.98.14.179"),
+					DestinationPort: nilable.From(35236),
 				},
 			},
 		},
@@ -118,8 +119,9 @@ func (s *SocketScannerTestSuite) TestScanProcDir() {
 			SrcHostname: "thisverypod",
 			Destinations: []mapperclient.Destination{
 				{
-					Destination:   "207.168.35.14",
-					DestinationIP: nilable.From("207.168.35.14"),
+					Destination:     "207.168.35.14",
+					DestinationIP:   nilable.From("207.168.35.14"),
+					DestinationPort: nilable.From(53438),
 				},
 			},
 		},


### PR DESCRIPTION
### Description

Send the listening port from the socket scanner to the mapper for additional debugging information


### Testing

Changed tests for the socket scanner.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
