### PR TITLE
Support configurable health server port for sniffer to prevent possible errors on startup

### DIFF
--- a/src/shared/config/config.go
+++ b/src/shared/config/config.go
@@ -17,6 +17,8 @@ const (
 	DebugDefault                 = false
 	PrometheusMetricsPortKey     = "metrics-port"
 	PrometheusMetricsPortDefault = 2112
+	HealthProbesPortKey          = "health-probes-port"
+	HealthProbesPortDefault      = "57921"
 	TelemetryErrorsAPIKeyKey     = "telemetry-errors-api-key"
 	TelemetryErrorsAPIKeyDefault = "d86195588a41fa03aa6711993bb1c765"
 	EnableTCPKey                 = "enable-tcp"
@@ -42,6 +44,7 @@ func init() {
 	viper.SetDefault(MapperApiUrlKey, MapperApiUrlDefault)
 	viper.SetDefault(DebugKey, DebugDefault)
 	viper.SetDefault(PrometheusMetricsPortKey, PrometheusMetricsPortDefault)
+	viper.SetDefault(HealthProbesPortKey, HealthProbesPortDefault)
 	viper.SetDefault(TelemetryErrorsAPIKeyKey, TelemetryErrorsAPIKeyDefault)
 	viper.SetDefault(EnableTCPKey, EnableTCPSnifferDefault)
 	viper.SetDefault(EnableSocketScannerKey, EnableSocketScannerDefault)

--- a/src/shared/config/config.go
+++ b/src/shared/config/config.go
@@ -18,7 +18,7 @@ const (
 	PrometheusMetricsPortKey     = "metrics-port"
 	PrometheusMetricsPortDefault = 2112
 	HealthProbesPortKey          = "health-probes-port"
-	HealthProbesPortDefault      = "57921"
+	HealthProbesPortDefault      = "9090"
 	TelemetryErrorsAPIKeyKey     = "telemetry-errors-api-key"
 	TelemetryErrorsAPIKeyDefault = "d86195588a41fa03aa6711993bb1c765"
 	EnableTCPKey                 = "enable-tcp"

--- a/src/sniffer/cmd/main.go
+++ b/src/sniffer/cmd/main.go
@@ -45,6 +45,7 @@ func main() {
 	ctrl.SetLogger(logrusr.New(logrus.StandardLogger()))
 
 	mapperClient := mapperclient.New(viper.GetString(sharedconfig.MapperApiUrlKey))
+	healthProbesPort := viper.GetInt(sharedconfig.HealthProbesPortKey)
 
 	healthServer := echo.New()
 	healthServer.HideBanner = true
@@ -77,7 +78,7 @@ func main() {
 	errgrp.Go(func() error {
 		logrus.Debug("Started health server")
 		defer errorreporter.AutoNotify()
-		return healthServer.Start(":9090")
+		return healthServer.Start(fmt.Sprintf(":%d", healthProbesPort))
 	})
 
 	logrus.Debug("Starting sniffer")


### PR DESCRIPTION
### Description
Support configurable health server port for sniffer to prevent possible errors on startup 
Solving #260 