### PR TITLE
Collect traffic levels data from node-agent and upload to cloud

### DIFF
--- a/build/kafka-watcher.Dockerfile
+++ b/build/kafka-watcher.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22.1-alpine as buildenv
+FROM --platform=$BUILDPLATFORM golang:1.22.1-alpine AS buildenv
 RUN apk add --no-cache ca-certificates git protoc
 RUN apk add build-base libpcap-dev
 WORKDIR /src
@@ -9,10 +9,10 @@ RUN go mod download
 
 COPY . .
 
-FROM buildenv as test
+FROM buildenv AS test
 RUN go test ./kafka-watcher/...
 
-FROM test as builder
+FROM test AS builder
 ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /main ./kafka-watcher/cmd

--- a/build/mapper.Dockerfile
+++ b/build/mapper.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22.1-alpine as buildenv
+FROM --platform=$BUILDPLATFORM golang:1.22.1-alpine AS buildenv
 RUN apk add --no-cache ca-certificates git protoc
 RUN apk add build-base libpcap-dev
 WORKDIR /src
@@ -9,7 +9,7 @@ RUN go mod download
 
 COPY . .
 
-FROM buildenv as test
+FROM buildenv AS test
 # install dependencies for "envtest" package
 RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e && \
     source <(setup-envtest use -p env) && \
@@ -17,7 +17,7 @@ RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-2023021
     ln -s "$KUBEBUILDER_ASSETS" /usr/local/kubebuilder/bin
 RUN go test ./mapper/...
 
-FROM test as builder
+FROM test AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/build/sniffer.Dockerfile
+++ b/build/sniffer.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.22.1-alpine as buildenv
+FROM --platform=linux/amd64 golang:1.22.1-alpine AS buildenv
 RUN apk add --no-cache ca-certificates git protoc
 RUN apk add build-base libpcap-dev
 WORKDIR /src
@@ -9,12 +9,12 @@ RUN go mod download
 
 COPY . .
 
-FROM buildenv as test
+FROM buildenv AS test
 RUN go test ./sniffer/... && echo dep > /dep
 
 # We start from the base image again, only this time it's using the target arch instead of always amd64. This is done to make the build faster.
 # Unlike the mapper, it can't be amd64 throughout and use Go's cross-compilation, since the sniffer depends on libpcap (C library).
-FROM golang:1.22.1-alpine as builder
+FROM golang:1.22.1-alpine AS builder
 COPY --from=test /dep /dep
 RUN apk add --no-cache ca-certificates git protoc
 RUN apk add build-base libpcap-dev
@@ -29,7 +29,7 @@ RUN go build -trimpath -o /main ./sniffer/cmd
 ARG VERSION
 RUN echo -n $VERSION > /version
 
-FROM alpine as release
+FROM alpine AS release
 RUN apk add --no-cache ca-certificates libpcap
 WORKDIR /
 COPY --from=builder /main /main

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	istiowatcher "github.com/otterize/network-mapper/src/istio-watcher/pkg/watcher"
 	"github.com/otterize/network-mapper/src/mapper/pkg/awsintentsholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/azureintentsholder"
+	"github.com/otterize/network-mapper/src/mapper/pkg/collectors/traffic"
 	"github.com/otterize/network-mapper/src/mapper/pkg/dnscache"
 	"github.com/otterize/network-mapper/src/mapper/pkg/dnsintentspublisher"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
@@ -166,6 +167,7 @@ func main() {
 	incomingTrafficIntentsHolder := incomingtrafficholder.NewIncomingTrafficIntentsHolder()
 	awsIntentsHolder := awsintentsholder.New()
 	azureIntentsHolder := azureintentsholder.New()
+	trafficCollector := traffic.NewCollector()
 
 	resolver := resolvers.NewResolver(
 		kubeFinder,
@@ -176,6 +178,7 @@ func main() {
 		azureIntentsHolder,
 		dnsCache,
 		incomingTrafficIntentsHolder,
+		trafficCollector,
 	)
 	resolver.Register(mapperServer)
 

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -162,17 +162,12 @@ func main() {
 	defer cancelFn()
 	mgr.GetCache().WaitForCacheSync(initCtx) // needed to let the manager initialize before used in intentsHolder
 
-	cloudClient, cloudEnabled, err := cloudclient.NewClient(errGroupCtx)
-	if err != nil {
-		logrus.WithError(err).Panic("Failed to initialize cloud client")
-	}
-
 	intentsHolder := intentsstore.NewIntentsHolder()
 	externalTrafficIntentsHolder := externaltrafficholder.NewExternalTrafficIntentsHolder()
 	incomingTrafficIntentsHolder := incomingtrafficholder.NewIncomingTrafficIntentsHolder()
 	awsIntentsHolder := awsintentsholder.New()
 	azureIntentsHolder := azureintentsholder.New()
-	trafficCollector := traffic.NewCollector(cloudClient)
+	trafficCollector := traffic.NewCollector()
 
 	resolver := resolvers.NewResolver(
 		kubeFinder,
@@ -204,6 +199,10 @@ func main() {
 	}
 
 	cloudUploaderConfig := clouduploader.ConfigFromViper()
+	cloudClient, cloudEnabled, err := cloudclient.NewClient(errGroupCtx)
+	if err != nil {
+		logrus.WithError(err).Panic("Failed to initialize cloud client")
+	}
 	if cloudEnabled {
 		cloudUploader := clouduploader.NewCloudUploader(intentsHolder, cloudUploaderConfig, cloudClient)
 

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -213,6 +213,7 @@ func main() {
 		}
 		awsIntentsHolder.RegisterNotifyIntents(cloudUploader.NotifyAWSIntents)
 		azureIntentsHolder.RegisterNotifyIntents(cloudUploader.NotifyAzureIntents)
+		trafficCollector.RegisterNotifyTraffic(cloudUploader.NotifyTrafficLevels)
 
 		go cloudUploader.PeriodicStatusReport(errGroupCtx)
 
@@ -271,6 +272,11 @@ func main() {
 	errgrp.Go(func() error {
 		defer errorreporter.AutoNotify()
 		azureIntentsHolder.PeriodicIntentsUpload(errGroupCtx, cloudUploaderConfig.UploadInterval)
+		return nil
+	})
+	errgrp.Go(func() error {
+		defer errorreporter.AutoNotify()
+		trafficCollector.PeriodicUpload(errGroupCtx, cloudUploaderConfig.UploadInterval)
 		return nil
 	})
 

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -15,14 +15,7 @@ type CloudClient interface {
 	ReportIncomingTrafficDiscoveredIntents(ctx context.Context, intents []IncomingTrafficDiscoveredIntentInput) error
 	ReportK8sServices(ctx context.Context, namespace string, services []K8sServiceInput) error
 	ReportK8sIngresses(ctx context.Context, namespace string, ingresses []K8sIngressInput) error
-	ReportTrafficLevels(
-		ctx context.Context,
-		source string,
-		sourceNamespace string,
-		destination string,
-		destinationNamespace string,
-		trafficCounter TrafficLevelInput,
-	) error
+	ReportTrafficLevels(ctx context.Context, trafficLevels []TrafficLevelInput) error
 }
 
 type CloudClientImpl struct {
@@ -107,22 +100,14 @@ func (c *CloudClientImpl) ReportK8sIngresses(ctx context.Context, namespace stri
 
 func (c *CloudClientImpl) ReportTrafficLevels(
 	ctx context.Context,
-	clientName string,
-	clientNamespace string,
-	serverName string,
-	serverNamespace string,
-	trafficLevel TrafficLevelInput,
+	trafficLevels []TrafficLevelInput,
 ) error {
 	logrus.Debug("Uploading traffic info to cloud")
 
 	_, err := ReportTrafficLevels(
 		ctx,
 		c.client,
-		clientName,
-		clientNamespace,
-		serverName,
-		serverNamespace,
-		trafficLevel,
+		trafficLevels,
 	)
 	if err != nil {
 		return errors.Wrap(err)

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -107,22 +107,22 @@ func (c *CloudClientImpl) ReportK8sIngresses(ctx context.Context, namespace stri
 
 func (c *CloudClientImpl) ReportTrafficLevels(
 	ctx context.Context,
-	source string,
-	sourceNamespace string,
-	destination string,
-	destinationNamespace string,
-	trafficCounter TrafficLevelInput,
+	clientName string,
+	clientNamespace string,
+	serverName string,
+	serverNamespace string,
+	trafficLevel TrafficLevelInput,
 ) error {
 	logrus.Debug("Uploading traffic info to cloud")
 
-	_, err := UpdateTrafficInfo(
+	_, err := ReportTrafficLevels(
 		ctx,
 		c.client,
-		source,
-		sourceNamespace,
-		destination,
-		destinationNamespace,
-		trafficCounter,
+		clientName,
+		clientNamespace,
+		serverName,
+		serverNamespace,
+		trafficLevel,
 	)
 	if err != nil {
 		return errors.Wrap(err)

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -15,6 +15,14 @@ type CloudClient interface {
 	ReportIncomingTrafficDiscoveredIntents(ctx context.Context, intents []IncomingTrafficDiscoveredIntentInput) error
 	ReportK8sServices(ctx context.Context, namespace string, services []K8sServiceInput) error
 	ReportK8sIngresses(ctx context.Context, namespace string, ingresses []K8sIngressInput) error
+	ReportTrafficLevels(
+		ctx context.Context,
+		source string,
+		sourceNamespace string,
+		destination string,
+		destinationNamespace string,
+		trafficCounter TrafficLevelInput,
+	) error
 }
 
 type CloudClientImpl struct {
@@ -90,6 +98,32 @@ func (c *CloudClientImpl) ReportK8sIngresses(ctx context.Context, namespace stri
 	logrus.Debug("Uploading k8s ingresses to cloud, count: ", len(ingresses))
 
 	_, err := ReportK8sIngresses(ctx, c.client, namespace, ingresses)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func (c *CloudClientImpl) ReportTrafficLevels(
+	ctx context.Context,
+	source string,
+	sourceNamespace string,
+	destination string,
+	destinationNamespace string,
+	trafficCounter TrafficLevelInput,
+) error {
+	logrus.Debug("Uploading traffic info to cloud")
+
+	_, err := UpdateTrafficInfo(
+		ctx,
+		c.client,
+		source,
+		sourceNamespace,
+		destination,
+		destinationNamespace,
+		trafficCounter,
+	)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -852,6 +852,15 @@ type ReportK8sServicesResponse struct {
 // GetReportK8sServices returns ReportK8sServicesResponse.ReportK8sServices, and is useful for accessing the field via an interface.
 func (v *ReportK8sServicesResponse) GetReportK8sServices() bool { return v.ReportK8sServices }
 
+// ReportTrafficLevelsResponse is returned by ReportTrafficLevels on success.
+type ReportTrafficLevelsResponse struct {
+	// Update service
+	ReportTrafficLevels bool `json:"reportTrafficLevels"`
+}
+
+// GetReportTrafficLevels returns ReportTrafficLevelsResponse.ReportTrafficLevels, and is useful for accessing the field via an interface.
+func (v *ReportTrafficLevelsResponse) GetReportTrafficLevels() bool { return v.ReportTrafficLevels }
+
 type SelectorKeyValueInput struct {
 	Key   nilable.Nilable[string] `json:"key"`
 	Value nilable.Nilable[string] `json:"value"`
@@ -914,24 +923,15 @@ type SessionAffinityConfig struct {
 func (v *SessionAffinityConfig) GetClientIP() nilable.Nilable[ClientIPConfig] { return v.ClientIP }
 
 type TrafficLevelInput struct {
-	Data  int `json:"data"`
-	Flows int `json:"flows"`
+	DataBytesPerSecond  int `json:"dataBytesPerSecond"`
+	FlowsCountPerSecond int `json:"flowsCountPerSecond"`
 }
 
-// GetData returns TrafficLevelInput.Data, and is useful for accessing the field via an interface.
-func (v *TrafficLevelInput) GetData() int { return v.Data }
+// GetDataBytesPerSecond returns TrafficLevelInput.DataBytesPerSecond, and is useful for accessing the field via an interface.
+func (v *TrafficLevelInput) GetDataBytesPerSecond() int { return v.DataBytesPerSecond }
 
-// GetFlows returns TrafficLevelInput.Flows, and is useful for accessing the field via an interface.
-func (v *TrafficLevelInput) GetFlows() int { return v.Flows }
-
-// UpdateTrafficInfoResponse is returned by UpdateTrafficInfo on success.
-type UpdateTrafficInfoResponse struct {
-	// Update service
-	ReportTrafficLevels bool `json:"reportTrafficLevels"`
-}
-
-// GetReportTrafficLevels returns UpdateTrafficInfoResponse.ReportTrafficLevels, and is useful for accessing the field via an interface.
-func (v *UpdateTrafficInfoResponse) GetReportTrafficLevels() bool { return v.ReportTrafficLevels }
+// GetFlowsCountPerSecond returns TrafficLevelInput.FlowsCountPerSecond, and is useful for accessing the field via an interface.
+func (v *TrafficLevelInput) GetFlowsCountPerSecond() int { return v.FlowsCountPerSecond }
 
 // __ReportComponentStatusInput is used internally by genqlient
 type __ReportComponentStatusInput struct {
@@ -993,29 +993,29 @@ func (v *__ReportK8sServicesInput) GetNamespace() string { return v.Namespace }
 // GetServices returns __ReportK8sServicesInput.Services, and is useful for accessing the field via an interface.
 func (v *__ReportK8sServicesInput) GetServices() []K8sServiceInput { return v.Services }
 
-// __UpdateTrafficInfoInput is used internally by genqlient
-type __UpdateTrafficInfoInput struct {
-	SourceName           string            `json:"sourceName"`
-	SourceNamesapce      string            `json:"sourceNamesapce"`
-	Destination          string            `json:"destination"`
-	DestinationNamespace string            `json:"destinationNamespace"`
-	TrafficCounter       TrafficLevelInput `json:"trafficCounter"`
+// __ReportTrafficLevelsInput is used internally by genqlient
+type __ReportTrafficLevelsInput struct {
+	ClientName      string            `json:"clientName"`
+	ClientNamespace string            `json:"clientNamespace"`
+	ServerName      string            `json:"serverName"`
+	ServerNamespace string            `json:"serverNamespace"`
+	TrafficLevel    TrafficLevelInput `json:"trafficLevel"`
 }
 
-// GetSourceName returns __UpdateTrafficInfoInput.SourceName, and is useful for accessing the field via an interface.
-func (v *__UpdateTrafficInfoInput) GetSourceName() string { return v.SourceName }
+// GetClientName returns __ReportTrafficLevelsInput.ClientName, and is useful for accessing the field via an interface.
+func (v *__ReportTrafficLevelsInput) GetClientName() string { return v.ClientName }
 
-// GetSourceNamesapce returns __UpdateTrafficInfoInput.SourceNamesapce, and is useful for accessing the field via an interface.
-func (v *__UpdateTrafficInfoInput) GetSourceNamesapce() string { return v.SourceNamesapce }
+// GetClientNamespace returns __ReportTrafficLevelsInput.ClientNamespace, and is useful for accessing the field via an interface.
+func (v *__ReportTrafficLevelsInput) GetClientNamespace() string { return v.ClientNamespace }
 
-// GetDestination returns __UpdateTrafficInfoInput.Destination, and is useful for accessing the field via an interface.
-func (v *__UpdateTrafficInfoInput) GetDestination() string { return v.Destination }
+// GetServerName returns __ReportTrafficLevelsInput.ServerName, and is useful for accessing the field via an interface.
+func (v *__ReportTrafficLevelsInput) GetServerName() string { return v.ServerName }
 
-// GetDestinationNamespace returns __UpdateTrafficInfoInput.DestinationNamespace, and is useful for accessing the field via an interface.
-func (v *__UpdateTrafficInfoInput) GetDestinationNamespace() string { return v.DestinationNamespace }
+// GetServerNamespace returns __ReportTrafficLevelsInput.ServerNamespace, and is useful for accessing the field via an interface.
+func (v *__ReportTrafficLevelsInput) GetServerNamespace() string { return v.ServerNamespace }
 
-// GetTrafficCounter returns __UpdateTrafficInfoInput.TrafficCounter, and is useful for accessing the field via an interface.
-func (v *__UpdateTrafficInfoInput) GetTrafficCounter() TrafficLevelInput { return v.TrafficCounter }
+// GetTrafficLevel returns __ReportTrafficLevelsInput.TrafficLevel, and is useful for accessing the field via an interface.
+func (v *__ReportTrafficLevelsInput) GetTrafficLevel() TrafficLevelInput { return v.TrafficLevel }
 
 // The query or mutation executed by ReportComponentStatus.
 const ReportComponentStatus_Operation = `
@@ -1219,36 +1219,36 @@ func ReportK8sServices(
 	return &data_, err_
 }
 
-// The query or mutation executed by UpdateTrafficInfo.
-const UpdateTrafficInfo_Operation = `
-mutation UpdateTrafficInfo ($sourceName: String!, $sourceNamesapce: String!, $destination: String!, $destinationNamespace: String!, $trafficCounter: TrafficLevelInput!) {
-	reportTrafficLevels(sourceName: $sourceName, sourceNamespace: $sourceNamesapce, destinationName: $destination, destinationNamespace: $destinationNamespace, trafficCounter: $trafficCounter)
+// The query or mutation executed by ReportTrafficLevels.
+const ReportTrafficLevels_Operation = `
+mutation ReportTrafficLevels ($clientName: String!, $clientNamespace: String!, $serverName: String!, $serverNamespace: String!, $trafficLevel: TrafficLevelInput!) {
+	reportTrafficLevels(clientName: $clientName, clientNamespace: $clientNamespace, serverName: $serverName, serverNamespace: $serverNamespace, trafficLevel: $trafficLevel)
 }
 `
 
-func UpdateTrafficInfo(
+func ReportTrafficLevels(
 	ctx_ context.Context,
 	client_ graphql.Client,
-	sourceName string,
-	sourceNamesapce string,
-	destination string,
-	destinationNamespace string,
-	trafficCounter TrafficLevelInput,
-) (*UpdateTrafficInfoResponse, error) {
+	clientName string,
+	clientNamespace string,
+	serverName string,
+	serverNamespace string,
+	trafficLevel TrafficLevelInput,
+) (*ReportTrafficLevelsResponse, error) {
 	req_ := &graphql.Request{
-		OpName: "UpdateTrafficInfo",
-		Query:  UpdateTrafficInfo_Operation,
-		Variables: &__UpdateTrafficInfoInput{
-			SourceName:           sourceName,
-			SourceNamesapce:      sourceNamesapce,
-			Destination:          destination,
-			DestinationNamespace: destinationNamespace,
-			TrafficCounter:       trafficCounter,
+		OpName: "ReportTrafficLevels",
+		Query:  ReportTrafficLevels_Operation,
+		Variables: &__ReportTrafficLevelsInput{
+			ClientName:      clientName,
+			ClientNamespace: clientNamespace,
+			ServerName:      serverName,
+			ServerNamespace: serverNamespace,
+			TrafficLevel:    trafficLevel,
 		},
 	}
 	var err_ error
 
-	var data_ UpdateTrafficInfoResponse
+	var data_ ReportTrafficLevelsResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -923,9 +923,25 @@ type SessionAffinityConfig struct {
 func (v *SessionAffinityConfig) GetClientIP() nilable.Nilable[ClientIPConfig] { return v.ClientIP }
 
 type TrafficLevelInput struct {
-	DataBytesPerSecond  int `json:"dataBytesPerSecond"`
-	FlowsCountPerSecond int `json:"flowsCountPerSecond"`
+	ClientName          string `json:"clientName"`
+	ClientNamespace     string `json:"clientNamespace"`
+	ServerName          string `json:"serverName"`
+	ServerNamespace     string `json:"serverNamespace"`
+	DataBytesPerSecond  int    `json:"dataBytesPerSecond"`
+	FlowsCountPerSecond int    `json:"flowsCountPerSecond"`
 }
+
+// GetClientName returns TrafficLevelInput.ClientName, and is useful for accessing the field via an interface.
+func (v *TrafficLevelInput) GetClientName() string { return v.ClientName }
+
+// GetClientNamespace returns TrafficLevelInput.ClientNamespace, and is useful for accessing the field via an interface.
+func (v *TrafficLevelInput) GetClientNamespace() string { return v.ClientNamespace }
+
+// GetServerName returns TrafficLevelInput.ServerName, and is useful for accessing the field via an interface.
+func (v *TrafficLevelInput) GetServerName() string { return v.ServerName }
+
+// GetServerNamespace returns TrafficLevelInput.ServerNamespace, and is useful for accessing the field via an interface.
+func (v *TrafficLevelInput) GetServerNamespace() string { return v.ServerNamespace }
 
 // GetDataBytesPerSecond returns TrafficLevelInput.DataBytesPerSecond, and is useful for accessing the field via an interface.
 func (v *TrafficLevelInput) GetDataBytesPerSecond() int { return v.DataBytesPerSecond }
@@ -995,27 +1011,11 @@ func (v *__ReportK8sServicesInput) GetServices() []K8sServiceInput { return v.Se
 
 // __ReportTrafficLevelsInput is used internally by genqlient
 type __ReportTrafficLevelsInput struct {
-	ClientName      string            `json:"clientName"`
-	ClientNamespace string            `json:"clientNamespace"`
-	ServerName      string            `json:"serverName"`
-	ServerNamespace string            `json:"serverNamespace"`
-	TrafficLevel    TrafficLevelInput `json:"trafficLevel"`
+	TrafficLevels []TrafficLevelInput `json:"trafficLevels"`
 }
 
-// GetClientName returns __ReportTrafficLevelsInput.ClientName, and is useful for accessing the field via an interface.
-func (v *__ReportTrafficLevelsInput) GetClientName() string { return v.ClientName }
-
-// GetClientNamespace returns __ReportTrafficLevelsInput.ClientNamespace, and is useful for accessing the field via an interface.
-func (v *__ReportTrafficLevelsInput) GetClientNamespace() string { return v.ClientNamespace }
-
-// GetServerName returns __ReportTrafficLevelsInput.ServerName, and is useful for accessing the field via an interface.
-func (v *__ReportTrafficLevelsInput) GetServerName() string { return v.ServerName }
-
-// GetServerNamespace returns __ReportTrafficLevelsInput.ServerNamespace, and is useful for accessing the field via an interface.
-func (v *__ReportTrafficLevelsInput) GetServerNamespace() string { return v.ServerNamespace }
-
-// GetTrafficLevel returns __ReportTrafficLevelsInput.TrafficLevel, and is useful for accessing the field via an interface.
-func (v *__ReportTrafficLevelsInput) GetTrafficLevel() TrafficLevelInput { return v.TrafficLevel }
+// GetTrafficLevels returns __ReportTrafficLevelsInput.TrafficLevels, and is useful for accessing the field via an interface.
+func (v *__ReportTrafficLevelsInput) GetTrafficLevels() []TrafficLevelInput { return v.TrafficLevels }
 
 // The query or mutation executed by ReportComponentStatus.
 const ReportComponentStatus_Operation = `
@@ -1221,29 +1221,21 @@ func ReportK8sServices(
 
 // The query or mutation executed by ReportTrafficLevels.
 const ReportTrafficLevels_Operation = `
-mutation ReportTrafficLevels ($clientName: String!, $clientNamespace: String!, $serverName: String!, $serverNamespace: String!, $trafficLevel: TrafficLevelInput!) {
-	reportTrafficLevels(clientName: $clientName, clientNamespace: $clientNamespace, serverName: $serverName, serverNamespace: $serverNamespace, trafficLevel: $trafficLevel)
+mutation ReportTrafficLevels ($trafficLevels: [TrafficLevelInput!]!) {
+	reportTrafficLevels(trafficLevels: $trafficLevels)
 }
 `
 
 func ReportTrafficLevels(
 	ctx_ context.Context,
 	client_ graphql.Client,
-	clientName string,
-	clientNamespace string,
-	serverName string,
-	serverNamespace string,
-	trafficLevel TrafficLevelInput,
+	trafficLevels []TrafficLevelInput,
 ) (*ReportTrafficLevelsResponse, error) {
 	req_ := &graphql.Request{
 		OpName: "ReportTrafficLevels",
 		Query:  ReportTrafficLevels_Operation,
 		Variables: &__ReportTrafficLevelsInput{
-			ClientName:      clientName,
-			ClientNamespace: clientNamespace,
-			ServerName:      serverName,
-			ServerNamespace: serverNamespace,
-			TrafficLevel:    trafficLevel,
+			TrafficLevels: trafficLevels,
 		},
 	}
 	var err_ error

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -913,6 +913,26 @@ type SessionAffinityConfig struct {
 // GetClientIP returns SessionAffinityConfig.ClientIP, and is useful for accessing the field via an interface.
 func (v *SessionAffinityConfig) GetClientIP() nilable.Nilable[ClientIPConfig] { return v.ClientIP }
 
+type TrafficLevelInput struct {
+	Data  int `json:"data"`
+	Flows int `json:"flows"`
+}
+
+// GetData returns TrafficLevelInput.Data, and is useful for accessing the field via an interface.
+func (v *TrafficLevelInput) GetData() int { return v.Data }
+
+// GetFlows returns TrafficLevelInput.Flows, and is useful for accessing the field via an interface.
+func (v *TrafficLevelInput) GetFlows() int { return v.Flows }
+
+// UpdateTrafficInfoResponse is returned by UpdateTrafficInfo on success.
+type UpdateTrafficInfoResponse struct {
+	// Update service
+	ReportTrafficLevels bool `json:"reportTrafficLevels"`
+}
+
+// GetReportTrafficLevels returns UpdateTrafficInfoResponse.ReportTrafficLevels, and is useful for accessing the field via an interface.
+func (v *UpdateTrafficInfoResponse) GetReportTrafficLevels() bool { return v.ReportTrafficLevels }
+
 // __ReportComponentStatusInput is used internally by genqlient
 type __ReportComponentStatusInput struct {
 	Component ComponentType `json:"component"`
@@ -972,6 +992,30 @@ func (v *__ReportK8sServicesInput) GetNamespace() string { return v.Namespace }
 
 // GetServices returns __ReportK8sServicesInput.Services, and is useful for accessing the field via an interface.
 func (v *__ReportK8sServicesInput) GetServices() []K8sServiceInput { return v.Services }
+
+// __UpdateTrafficInfoInput is used internally by genqlient
+type __UpdateTrafficInfoInput struct {
+	SourceName           string            `json:"sourceName"`
+	SourceNamesapce      string            `json:"sourceNamesapce"`
+	Destination          string            `json:"destination"`
+	DestinationNamespace string            `json:"destinationNamespace"`
+	TrafficCounter       TrafficLevelInput `json:"trafficCounter"`
+}
+
+// GetSourceName returns __UpdateTrafficInfoInput.SourceName, and is useful for accessing the field via an interface.
+func (v *__UpdateTrafficInfoInput) GetSourceName() string { return v.SourceName }
+
+// GetSourceNamesapce returns __UpdateTrafficInfoInput.SourceNamesapce, and is useful for accessing the field via an interface.
+func (v *__UpdateTrafficInfoInput) GetSourceNamesapce() string { return v.SourceNamesapce }
+
+// GetDestination returns __UpdateTrafficInfoInput.Destination, and is useful for accessing the field via an interface.
+func (v *__UpdateTrafficInfoInput) GetDestination() string { return v.Destination }
+
+// GetDestinationNamespace returns __UpdateTrafficInfoInput.DestinationNamespace, and is useful for accessing the field via an interface.
+func (v *__UpdateTrafficInfoInput) GetDestinationNamespace() string { return v.DestinationNamespace }
+
+// GetTrafficCounter returns __UpdateTrafficInfoInput.TrafficCounter, and is useful for accessing the field via an interface.
+func (v *__UpdateTrafficInfoInput) GetTrafficCounter() TrafficLevelInput { return v.TrafficCounter }
 
 // The query or mutation executed by ReportComponentStatus.
 const ReportComponentStatus_Operation = `
@@ -1164,6 +1208,47 @@ func ReportK8sServices(
 	var err_ error
 
 	var data_ ReportK8sServicesResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by UpdateTrafficInfo.
+const UpdateTrafficInfo_Operation = `
+mutation UpdateTrafficInfo ($sourceName: String!, $sourceNamesapce: String!, $destination: String!, $destinationNamespace: String!, $trafficCounter: TrafficLevelInput!) {
+	reportTrafficLevels(sourceName: $sourceName, sourceNamespace: $sourceNamesapce, destinationName: $destination, destinationNamespace: $destinationNamespace, trafficCounter: $trafficCounter)
+}
+`
+
+func UpdateTrafficInfo(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	sourceName string,
+	sourceNamesapce string,
+	destination string,
+	destinationNamespace string,
+	trafficCounter TrafficLevelInput,
+) (*UpdateTrafficInfoResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "UpdateTrafficInfo",
+		Query:  UpdateTrafficInfo_Operation,
+		Variables: &__UpdateTrafficInfoInput{
+			SourceName:           sourceName,
+			SourceNamesapce:      sourceNamesapce,
+			Destination:          destination,
+			DestinationNamespace: destinationNamespace,
+			TrafficCounter:       trafficCounter,
+		},
+	}
+	var err_ error
+
+	var data_ UpdateTrafficInfoResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -24,16 +24,7 @@ mutation ReportK8sIngresses($namespace: String!, $ingresses: [K8sIngressInput!]!
 }
 
 mutation ReportTrafficLevels(
-    $clientName: String!,
-    $clientNamespace: String!,
-    $serverName: String!,
-    $serverNamespace: String!,
-    $trafficLevel: TrafficLevelInput!
+    $trafficLevels: [TrafficLevelInput!]!
 ) {
-    reportTrafficLevels(
-        clientName: $clientName,
-        clientNamespace: $clientNamespace,
-        serverName: $serverName,
-        serverNamespace: $serverNamespace,
-        trafficLevel: $trafficLevel)
+    reportTrafficLevels(trafficLevels: $trafficLevels)
 }

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -23,17 +23,17 @@ mutation ReportK8sIngresses($namespace: String!, $ingresses: [K8sIngressInput!]!
     reportK8sIngresses(namespace: $namespace, ingresses: $ingresses)
 }
 
-mutation UpdateTrafficInfo(
-    $sourceName: String!,
-    $sourceNamesapce: String!,
-    $destination: String!,
-    $destinationNamespace: String!,
-    $trafficCounter: TrafficLevelInput!
+mutation ReportTrafficLevels(
+    $clientName: String!,
+    $clientNamespace: String!,
+    $serverName: String!,
+    $serverNamespace: String!,
+    $trafficLevel: TrafficLevelInput!
 ) {
     reportTrafficLevels(
-        sourceName: $sourceName,
-        sourceNamespace: $sourceNamesapce,
-        destinationName: $destination,
-        destinationNamespace: $destinationNamespace,
-        trafficCounter: $trafficCounter)
+        clientName: $clientName,
+        clientNamespace: $clientNamespace,
+        serverName: $serverName,
+        serverNamespace: $serverNamespace,
+        trafficLevel: $trafficLevel)
 }

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -22,3 +22,18 @@ mutation ReportK8sServices($namespace: String!, $services: [K8sServiceInput!]!) 
 mutation ReportK8sIngresses($namespace: String!, $ingresses: [K8sIngressInput!]!) {
     reportK8sIngresses(namespace: $namespace, ingresses: $ingresses)
 }
+
+mutation UpdateTrafficInfo(
+    $sourceName: String!,
+    $sourceNamesapce: String!,
+    $destination: String!,
+    $destinationNamespace: String!,
+    $trafficCounter: TrafficLevelInput!
+) {
+    reportTrafficLevels(
+        sourceName: $sourceName,
+        sourceNamespace: $sourceNamesapce,
+        destinationName: $destination,
+        destinationNamespace: $destinationNamespace,
+        trafficCounter: $trafficCounter)
+}

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -120,15 +120,15 @@ func (mr *MockCloudClientMockRecorder) ReportK8sServices(ctx, namespace, service
 }
 
 // ReportTrafficLevels mocks base method.
-func (m *MockCloudClient) ReportTrafficLevels(ctx context.Context, source, sourceNamespace, destination, destinationNamespace string, trafficCounter cloudclient.TrafficLevelInput) error {
+func (m *MockCloudClient) ReportTrafficLevels(ctx context.Context, trafficLevels []cloudclient.TrafficLevelInput) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportTrafficLevels", ctx, source, sourceNamespace, destination, destinationNamespace, trafficCounter)
+	ret := m.ctrl.Call(m, "ReportTrafficLevels", ctx, trafficLevels)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReportTrafficLevels indicates an expected call of ReportTrafficLevels.
-func (mr *MockCloudClientMockRecorder) ReportTrafficLevels(ctx, source, sourceNamespace, destination, destinationNamespace, trafficCounter interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ReportTrafficLevels(ctx, trafficLevels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportTrafficLevels", reflect.TypeOf((*MockCloudClient)(nil).ReportTrafficLevels), ctx, source, sourceNamespace, destination, destinationNamespace, trafficCounter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportTrafficLevels", reflect.TypeOf((*MockCloudClient)(nil).ReportTrafficLevels), ctx, trafficLevels)
 }

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -118,3 +118,17 @@ func (mr *MockCloudClientMockRecorder) ReportK8sServices(ctx, namespace, service
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportK8sServices", reflect.TypeOf((*MockCloudClient)(nil).ReportK8sServices), ctx, namespace, services)
 }
+
+// ReportTrafficLevels mocks base method.
+func (m *MockCloudClient) ReportTrafficLevels(ctx context.Context, source, sourceNamespace, destination, destinationNamespace string, trafficCounter cloudclient.TrafficLevelInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReportTrafficLevels", ctx, source, sourceNamespace, destination, destinationNamespace, trafficCounter)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReportTrafficLevels indicates an expected call of ReportTrafficLevels.
+func (mr *MockCloudClientMockRecorder) ReportTrafficLevels(ctx, source, sourceNamespace, destination, destinationNamespace, trafficCounter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportTrafficLevels", reflect.TypeOf((*MockCloudClient)(nil).ReportTrafficLevels), ctx, source, sourceNamespace, destination, destinationNamespace, trafficCounter)
+}

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -1897,11 +1897,7 @@ type Mutation {
 	): Boolean!
 """Update service"""
 	reportTrafficLevels(
-		clientName: String!
-		clientNamespace: String!
-		serverName: String!
-		serverNamespace: String!
-		trafficLevel: TrafficLevelInput!
+		trafficLevels: [TrafficLevelInput!]!
 	): Boolean!
 	saveOnboardingFeedback(
 		userEmail: String!
@@ -2588,6 +2584,10 @@ type TrafficLevel {
 }
 
 input TrafficLevelInput {
+	clientName: String!
+	clientNamespace: String!
+	serverName: String!
+	serverNamespace: String!
 	dataBytesPerSecond: Int!
 	flowsCountPerSecond: Int!
 }

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -148,6 +148,7 @@ type AccessGraphEdge {
 	accessStatus: EdgeAccessStatus!
 	accessStatuses: EdgeAccessStatuses!
 	findings: [CallFinding!]!
+	traffic: TrafficCounter!
 }
 
 """ Access graph filter """
@@ -177,6 +178,7 @@ type AccessLogEdge {
 	originIntent: Intent!
 	dns: String!
 	accessStatus: EdgeAccessStatus!
+	traffic: TrafficCounter!
 }
 
 enum AllowExternalTrafficPolicy {
@@ -1894,6 +1896,14 @@ type Mutation {
 	sendCLITelemetries(
 		telemetries: [CLITelemetry!]!
 	): Boolean!
+"""Update service"""
+	reportTrafficLevels(
+		sourceName: String!
+		sourceNamespace: String!
+		destinationName: String!
+		destinationNamespace: String!
+		trafficCounter: TrafficLevelInput!
+	): Boolean!
 	saveOnboardingFeedback(
 		userEmail: String!
 		feedback: String!
@@ -2571,6 +2581,16 @@ type TimeRange {
 input TimeRangeInput {
 	from: Time
 	to: Time
+}
+
+type TrafficCounter {
+	data: Int!
+	flows: Int!
+}
+
+input TrafficLevelInput {
+	data: Int!
+	flows: Int!
 }
 
 enum TutorialEvent {

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -148,7 +148,7 @@ type AccessGraphEdge {
 	accessStatus: EdgeAccessStatus!
 	accessStatuses: EdgeAccessStatuses!
 	findings: [CallFinding!]!
-	traffic: TrafficCounter!
+	traffic: TrafficLevel!
 }
 
 """ Access graph filter """
@@ -178,7 +178,6 @@ type AccessLogEdge {
 	originIntent: Intent!
 	dns: String!
 	accessStatus: EdgeAccessStatus!
-	traffic: TrafficCounter!
 }
 
 enum AllowExternalTrafficPolicy {
@@ -1898,11 +1897,11 @@ type Mutation {
 	): Boolean!
 """Update service"""
 	reportTrafficLevels(
-		sourceName: String!
-		sourceNamespace: String!
-		destinationName: String!
-		destinationNamespace: String!
-		trafficCounter: TrafficLevelInput!
+		clientName: String!
+		clientNamespace: String!
+		serverName: String!
+		serverNamespace: String!
+		trafficLevel: TrafficLevelInput!
 	): Boolean!
 	saveOnboardingFeedback(
 		userEmail: String!
@@ -2583,14 +2582,14 @@ input TimeRangeInput {
 	to: Time
 }
 
-type TrafficCounter {
-	data: Int!
-	flows: Int!
+type TrafficLevel {
+	dataBytesPerSecond: Int!
+	flowsCountPerSecond: Int!
 }
 
 input TrafficLevelInput {
-	data: Int!
-	flows: Int!
+	dataBytesPerSecond: Int!
+	flowsCountPerSecond: Int!
 }
 
 enum TutorialEvent {

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -399,8 +399,10 @@ type Cluster {
 type ClusterConfiguration {
 	globalDefaultDeny: Boolean!
 	istioGlobalDefaultDeny: Boolean!
+	linkerdGlobalDefaultDeny: Boolean!
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	useKafkaACLsInAccessGraphStates: Boolean!
 	useAWSIAMInAccessGraphStates: Boolean!
 	useGCPIAMInAccessGraphStates: Boolean!
@@ -412,8 +414,10 @@ type ClusterConfiguration {
 input ClusterConfigurationInput {
 	globalDefaultDeny: Boolean!
 	istioGlobalDefaultDeny: Boolean
+	linkerdGlobalDefaultDeny: Boolean
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	useKafkaACLsInAccessGraphStates: Boolean!
 	useAWSIAMInAccessGraphStates: Boolean
 	useGCPIAMInAccessGraphStates: Boolean
@@ -581,9 +585,19 @@ input DiscoveredIntentInput {
 	intent: IntentInput!
 }
 
+input EBPFDiagnostics {
+	containerImage: String
+	executable: String
+	executableHash: String
+	programName: String
+	podName: String
+	podNamespace: String
+}
+
 type EdgeAccessStatus {
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	useKafkaPoliciesInAccessGraphStates: Boolean!
 	verdict: EdgeAccessStatusVerdict!
 	reason: EdgeAccessStatusReason!
@@ -645,6 +659,7 @@ type EdgeAccessStatuses {
 	gcpIam: EdgeAccessStatus!
 	azureIAM: EdgeAccessStatus!
 	database: EdgeAccessStatus!
+	linkerdPolicies: EdgeAccessStatus!
 }
 
 type Environment {
@@ -693,6 +708,8 @@ enum EventType {
 	PROTECTED_SERVICE_APPLIED
 	PROTECTED_SERVICE_DELETED
 	ACTIVE
+	EBPF_ATTACHED
+	EBPF_ATTACH_FAILED
 }
 
 input ExternalTrafficDiscoveredIntentInput {
@@ -859,11 +876,13 @@ input GitHubRepoInfoInput {
 type GitHubSettings {
 	isActive: Boolean!
 	repoFilterPairs: [GitHubRepoFilterPair!]!
+	enableAutoMerge: Boolean!
 }
 
 input GitHubSettingsInput {
 	isActive: Boolean!
 	repoFilterPairs: [GitHubRepoFilterPairInput!]!
+	enableAutoMerge: Boolean
 }
 
 type GitLabRepoFilterPair {
@@ -1068,6 +1087,13 @@ input InputTimeFilterValue {
 	operator: TimeFilterOperators!
 }
 
+input InputValidateIDFilter {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
+}
+
 """ Workload/Resource inventory filter """
 input InputWorkloadInventoryFilter {
 """ Workload/Resource inventory filter """
@@ -1242,6 +1268,7 @@ type IntentsOperatorConfiguration {
 	networkPolicyEnforcementEnabled: Boolean!
 	kafkaACLEnforcementEnabled: Boolean!
 	istioPolicyEnforcementEnabled: Boolean!
+	linkerdPolicyEnforcementEnabled: Boolean!
 	awsIAMPolicyEnforcementEnabled: Boolean!
 	gcpIAMPolicyEnforcementEnabled: Boolean!
 	azureIAMPolicyEnforcementEnabled: Boolean!
@@ -1257,6 +1284,7 @@ input IntentsOperatorConfigurationInput {
 	networkPolicyEnforcementEnabled: Boolean
 	kafkaACLEnforcementEnabled: Boolean
 	istioPolicyEnforcementEnabled: Boolean
+	linkerdPolicyEnforcementEnabled: Boolean
 	protectedServicesEnabled: Boolean
 	egressNetworkPolicyEnforcementEnabled: Boolean
 	awsIAMPolicyEnforcementEnabled: Boolean
@@ -2005,6 +2033,9 @@ type Query {
 	accessGraph(
 		filter: InputAccessGraphFilter
 	): AccessGraph!
+	accessGraphServices(
+		filter: InputAccessGraphFilter
+	): [Service!]!
 	serviceAccessGraph(
 		id: ID!
 	): ServiceAccessGraph!
@@ -2058,6 +2089,10 @@ type Query {
 	oneEnvironment(
 		name: String!
 	): Environment!
+"""Validate existing ID filters and return valid filters"""
+	validateFilters(
+		filter: InputValidateIDFilter!
+	): ValidIDFilter!
 	findings(
 		filter: InputFindingFilter
 		tree: Boolean
@@ -2104,12 +2139,6 @@ type Query {
 	testDatabaseVisibilityConnection(
 		databaseInfo: DatabaseInfoInput!
 	): TestDatabaseConnectionResponse!
-	clientIntentEventsForWorkload(
-		id: ID!
-	): [ClientIntentEvent!]
-	clientIntentStatusForWorkload(
-		id: ID!
-	): ClientIntentStatus
 """List user invites"""
 	invites(
 		email: String
@@ -2359,6 +2388,7 @@ type ServiceAccessStatus {
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useKafkaACLsInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	protectionStatus: ServerProtectionStatus!
 	protectionStatuses: ServerProtectionStatuses!
 	blockingStatus: ServerBlockingStatus!
@@ -2501,11 +2531,14 @@ enum TelemetryComponentType {
 	CREDENTIALS_OPERATOR
 	NETWORK_MAPPER
 	CLI
+	NODE_AGENT
 }
 
 input TelemetryData {
 	eventType: EventType!
 	count: Int
+	error: String
+	ebpf: EBPFDiagnostics
 }
 
 input TelemetryInput {
@@ -2604,6 +2637,15 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
+}
+
+""" Used to validate ID based filters """
+type ValidIDFilter {
+	clusterIds: IDFilterValue
+	serviceIds: IDFilterValue
+	namespaceIds: IDFilterValue
+	regulationIds: IDFilterValue
+	environmentIds: IDFilterValue
 }
 
 type Workload {

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -268,21 +268,21 @@ func (c *CloudUploader) NotifyTrafficLevels(ctx context.Context, trafficLevels t
 		return
 	}
 
+	var inputs []cloudclient.TrafficLevelInput
 	for trafficPair, trafficData := range trafficLevels {
-		err := c.client.ReportTrafficLevels(
-			ctx,
-			trafficPair.Source.Name,
-			trafficPair.Source.Namespace,
-			trafficPair.Destination.Name,
-			trafficPair.Destination.Namespace,
-			cloudclient.TrafficLevelInput{
-				DataBytesPerSecond:  trafficData.Bytes,
-				FlowsCountPerSecond: trafficData.Flows,
-			},
-		)
-		if err != nil {
-			logrus.WithError(err).Error("Failed to update traffic info")
-		}
+		inputs = append(inputs, cloudclient.TrafficLevelInput{
+			ClientName:          trafficPair.Source.Name,
+			ClientNamespace:     trafficPair.Source.Namespace,
+			ServerName:          trafficPair.Destination.Name,
+			ServerNamespace:     trafficPair.Destination.Namespace,
+			DataBytesPerSecond:  trafficData.Bytes,
+			FlowsCountPerSecond: trafficData.Flows,
+		})
+	}
+
+	err := c.client.ReportTrafficLevels(ctx, inputs)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to report traffic levels to cloud")
 	}
 }
 

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -276,8 +276,8 @@ func (c *CloudUploader) NotifyTrafficLevels(ctx context.Context, trafficLevels t
 			trafficPair.Destination.Name,
 			trafficPair.Destination.Namespace,
 			cloudclient.TrafficLevelInput{
-				Data:  trafficData.Bytes,
-				Flows: trafficData.Flows,
+				DataBytesPerSecond:  trafficData.Bytes,
+				FlowsCountPerSecond: trafficData.Flows,
 			},
 		)
 		if err != nil {

--- a/src/mapper/pkg/collectors/traffic/collector.go
+++ b/src/mapper/pkg/collectors/traffic/collector.go
@@ -1,0 +1,43 @@
+package traffic
+
+import (
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type trafficLevelKey struct {
+	sourceIP      types.NamespacedName
+	destinationIP types.NamespacedName
+}
+
+type trafficLevel struct {
+	bytes int
+	flows int
+}
+
+type Collector struct {
+	trafficLevels map[trafficLevelKey]*trafficLevel
+}
+
+func NewCollector() *Collector {
+	return &Collector{}
+}
+
+func (c *Collector) Add(sourceIP, destinationIP string, bytes, flows int) {
+	//trafficKey := trafficLevelKey{
+	//	source:      source.AsNamespacedName(),
+	//	destination: destination.AsNamespacedName(),
+	//}
+	//
+	//value, found := c.trafficLevels[trafficKey]
+	//
+	//if !found {
+	//	value = &trafficLevel{}
+	//	c.trafficLevels[trafficKey] = value
+	//}
+	//
+	//value.bytes += bytes
+	//value.flows += flows
+
+	logrus.Warnf("Traffic level: %+v", 0)
+}

--- a/src/mapper/pkg/collectors/traffic/collector.go
+++ b/src/mapper/pkg/collectors/traffic/collector.go
@@ -66,23 +66,25 @@ func (c *Collector) getTrafficMap() TrafficLevelMap {
 	trafficLevelMap := make(TrafficLevelMap)
 
 	for k, v := range c.trafficLevels {
-		var averageBytes, averageFlows int
+		var sumBytes, sumFlows int
 		var count int
 
 		for _, data := range v {
 			if time.Since(data.at) < time.Hour {
-				averageBytes += data.Bytes
-				averageFlows += data.Flows
+				// count only data within the last hour
+				sumBytes += data.Bytes
+				sumFlows += data.Flows
 				count++
 			} else {
+				// drop data older than an hour
 				c.trafficLevels[k] = c.trafficLevels[k][1:]
 			}
 		}
 
 		if count > 0 {
 			trafficLevelMap[k] = TrafficLevelData{
-				Bytes: averageBytes / count,
-				Flows: averageFlows / count,
+				Bytes: sumBytes / count,
+				Flows: sumFlows / count,
 			}
 		}
 	}

--- a/src/mapper/pkg/collectors/traffic/collector.go
+++ b/src/mapper/pkg/collectors/traffic/collector.go
@@ -1,9 +1,7 @@
 package traffic
 
 import (
-	"context"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
-	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
 	"github.com/sirupsen/logrus"
 )
 
@@ -18,13 +16,11 @@ type trafficLevel struct {
 }
 
 type Collector struct {
-	client        cloudclient.CloudClient
 	trafficLevels map[trafficLevelKey]*trafficLevel
 }
 
-func NewCollector(client cloudclient.CloudClient) *Collector {
+func NewCollector() *Collector {
 	return &Collector{
-		client:        client,
 		trafficLevels: make(map[trafficLevelKey]*trafficLevel),
 	}
 }
@@ -53,18 +49,18 @@ func (c *Collector) Add(source, destination serviceidentity.ServiceIdentity, byt
 		value.flows,
 	)
 
-	err := c.client.ReportTrafficLevels(
-		context.TODO(),
-		source.Name,
-		source.Namespace,
-		destination.Name,
-		destination.Namespace,
-		cloudclient.TrafficLevelInput{
-			Data:  value.bytes,
-			Flows: value.flows,
-		},
-	)
-	if err != nil {
-		logrus.WithError(err).Error("Failed to update traffic info")
-	}
+	//err := c.client.ReportTrafficLevels(
+	//	context.TODO(),
+	//	source.Name,
+	//	source.Namespace,
+	//	destination.Name,
+	//	destination.Namespace,
+	//	cloudclient.TrafficLevelInput{
+	//		Data:  value.bytes,
+	//		Flows: value.flows,
+	//	},
+	//)
+	//if err != nil {
+	//	logrus.WithError(err).Error("Failed to update traffic info")
+	//}
 }

--- a/src/mapper/pkg/collectors/traffic/collector.go
+++ b/src/mapper/pkg/collectors/traffic/collector.go
@@ -1,13 +1,13 @@
 package traffic
 
 import (
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type trafficLevelKey struct {
-	sourceIP      types.NamespacedName
-	destinationIP types.NamespacedName
+	source      serviceidentity.ServiceIdentity
+	destination serviceidentity.ServiceIdentity
 }
 
 type trafficLevel struct {
@@ -20,24 +20,32 @@ type Collector struct {
 }
 
 func NewCollector() *Collector {
-	return &Collector{}
+	return &Collector{
+		trafficLevels: make(map[trafficLevelKey]*trafficLevel),
+	}
 }
 
-func (c *Collector) Add(sourceIP, destinationIP string, bytes, flows int) {
-	//trafficKey := trafficLevelKey{
-	//	source:      source.AsNamespacedName(),
-	//	destination: destination.AsNamespacedName(),
-	//}
-	//
-	//value, found := c.trafficLevels[trafficKey]
-	//
-	//if !found {
-	//	value = &trafficLevel{}
-	//	c.trafficLevels[trafficKey] = value
-	//}
-	//
-	//value.bytes += bytes
-	//value.flows += flows
+func (c *Collector) Add(source, destination serviceidentity.ServiceIdentity, bytes, flows int) {
+	trafficKey := trafficLevelKey{
+		source:      source,
+		destination: destination,
+	}
 
-	logrus.Warnf("Traffic level: %+v", 0)
+	value, found := c.trafficLevels[trafficKey]
+
+	if !found {
+		value = &trafficLevel{}
+		c.trafficLevels[trafficKey] = value
+	}
+
+	value.bytes += bytes
+	value.flows += flows
+
+	logrus.Infof(
+		"Traffic levels: %s - %s: %d bytes, %d flows",
+		source.String(),
+		destination.String(),
+		value.bytes,
+		value.flows,
+	)
 }

--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -93,6 +93,7 @@ type ComplexityRoot struct {
 		ReportKafkaMapperResults     func(childComplexity int, results model.KafkaMapperResults) int
 		ReportSocketScanResults      func(childComplexity int, results model.SocketScanResults) int
 		ReportTCPCaptureResults      func(childComplexity int, results model.CaptureTCPResults) int
+		ReportTrafficLevelResults    func(childComplexity int, results model.TrafficLevelResults) int
 		ResetCapture                 func(childComplexity int) int
 	}
 
@@ -131,6 +132,7 @@ type MutationResolver interface {
 	ReportIstioConnectionResults(ctx context.Context, results model.IstioConnectionResults) (bool, error)
 	ReportAWSOperation(ctx context.Context, operation []model.AWSOperation) (bool, error)
 	ReportAzureOperation(ctx context.Context, operation []model.AzureOperation) (bool, error)
+	ReportTrafficLevelResults(ctx context.Context, results model.TrafficLevelResults) (bool, error)
 }
 type QueryResolver interface {
 	ServiceIntents(ctx context.Context, namespaces []string, includeLabels []string, includeAllLabels *bool) ([]model.ServiceIntents, error)
@@ -402,6 +404,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.ReportTCPCaptureResults(childComplexity, args["results"].(model.CaptureTCPResults)), true
 
+	case "Mutation.reportTrafficLevelResults":
+		if e.complexity.Mutation.ReportTrafficLevelResults == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_reportTrafficLevelResults_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.ReportTrafficLevelResults(childComplexity, args["results"].(model.TrafficLevelResults)), true
+
 	case "Mutation.resetCapture":
 		if e.complexity.Mutation.ResetCapture == nil {
 			break
@@ -531,6 +545,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRecordedDestinationsForSrc,
 		ec.unmarshalInputServerFilter,
 		ec.unmarshalInputSocketScanResults,
+		ec.unmarshalInputTrafficLevelResult,
+		ec.unmarshalInputTrafficLevelResults,
 	)
 	first := true
 
@@ -808,6 +824,18 @@ input AzureOperation {
     clientNamespace: String!
 }
 
+input TrafficLevelResult {
+    srcIP: String!
+    dstIP: String!
+
+    bytesSent: Int!
+    flows: Int!
+}
+
+input TrafficLevelResults {
+    results: [TrafficLevelResult!]!
+}
+
 type Query {
     """
     Kept for backwards compatibility with CLI -
@@ -845,7 +873,9 @@ type Mutation {
     reportIstioConnectionResults(results: IstioConnectionResults!): Boolean!
     reportAWSOperation(operation: [AWSOperation!]!): Boolean!
     reportAzureOperation(operation: [AzureOperation!]!): Boolean!
-}`, BuiltIn: false},
+    reportTrafficLevelResults(results: TrafficLevelResults!): Boolean!
+}
+`, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
 
@@ -950,6 +980,21 @@ func (ec *executionContext) field_Mutation_reportTCPCaptureResults_args(ctx cont
 	if tmp, ok := rawArgs["results"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("results"))
 		arg0, err = ec.unmarshalNCaptureTCPResults2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐCaptureTCPResults(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["results"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_reportTrafficLevelResults_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.TrafficLevelResults
+	if tmp, ok := rawArgs["results"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("results"))
+		arg0, err = ec.unmarshalNTrafficLevelResults2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐTrafficLevelResults(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -2519,6 +2564,61 @@ func (ec *executionContext) fieldContext_Mutation_reportAzureOperation(ctx conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_reportAzureOperation_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_reportTrafficLevelResults(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_reportTrafficLevelResults(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().ReportTrafficLevelResults(rctx, fc.Args["results"].(model.TrafficLevelResults))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_reportTrafficLevelResults(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_reportTrafficLevelResults_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -5633,6 +5733,81 @@ func (ec *executionContext) unmarshalInputSocketScanResults(ctx context.Context,
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputTrafficLevelResult(ctx context.Context, obj interface{}) (model.TrafficLevelResult, error) {
+	var it model.TrafficLevelResult
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"srcIP", "dstIP", "bytesSent", "flows"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "srcIP":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("srcIP"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SrcIP = data
+		case "dstIP":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dstIP"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DstIP = data
+		case "bytesSent":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("bytesSent"))
+			data, err := ec.unmarshalNInt2int64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.BytesSent = data
+		case "flows":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("flows"))
+			data, err := ec.unmarshalNInt2int64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Flows = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputTrafficLevelResults(ctx context.Context, obj interface{}) (model.TrafficLevelResults, error) {
+	var it model.TrafficLevelResults
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"results"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "results":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("results"))
+			data, err := ec.unmarshalNTrafficLevelResult2ᚕgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐTrafficLevelResultᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Results = data
+		}
+	}
+
+	return it, nil
+}
+
 // endregion **************************** input.gotpl *****************************
 
 // region    ************************** interface.gotpl ***************************
@@ -5946,6 +6121,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "reportAzureOperation":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_reportAzureOperation(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "reportTrafficLevelResults":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_reportTrafficLevelResults(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -6721,6 +6903,21 @@ func (ec *executionContext) marshalNHttpResource2githubᚗcomᚋotterizeᚋnetwo
 	return ec._HttpResource(ctx, sel, &v)
 }
 
+func (ec *executionContext) unmarshalNInt2int64(ctx context.Context, v interface{}) (int64, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.SelectionSet, v int64) graphql.Marshaler {
+	res := graphql.MarshalInt64(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) marshalNIntent2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐIntent(ctx context.Context, sel ast.SelectionSet, v model.Intent) graphql.Marshaler {
 	return ec._Intent(ctx, sel, &v)
 }
@@ -7034,6 +7231,33 @@ func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel as
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNTrafficLevelResult2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐTrafficLevelResult(ctx context.Context, v interface{}) (model.TrafficLevelResult, error) {
+	res, err := ec.unmarshalInputTrafficLevelResult(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNTrafficLevelResult2ᚕgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐTrafficLevelResultᚄ(ctx context.Context, v interface{}) ([]model.TrafficLevelResult, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]model.TrafficLevelResult, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNTrafficLevelResult2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐTrafficLevelResult(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNTrafficLevelResults2githubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐTrafficLevelResults(ctx context.Context, v interface{}) (model.TrafficLevelResults, error) {
+	res, err := ec.unmarshalInputTrafficLevelResults(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -153,6 +153,17 @@ type SocketScanResults struct {
 	Results []RecordedDestinationsForSrc `json:"results"`
 }
 
+type TrafficLevelResult struct {
+	SrcIP     string `json:"srcIP"`
+	DstIP     string `json:"dstIP"`
+	BytesSent int64  `json:"bytesSent"`
+	Flows     int64  `json:"flows"`
+}
+
+type TrafficLevelResults struct {
+	Results []TrafficLevelResult `json:"results"`
+}
+
 type HTTPMethod string
 
 const (

--- a/src/mapper/pkg/graph/model/results_length.go
+++ b/src/mapper/pkg/graph/model/results_length.go
@@ -31,3 +31,7 @@ func (c AzureOperationResults) Length() int {
 func (c CaptureTCPResults) Length() int {
 	return len(c.Results)
 }
+
+func (c TrafficLevelResults) Length() int {
+	return len(c.Results)
+}

--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/network-mapper/src/mapper/pkg/awsintentsholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/azureintentsholder"
+	"github.com/otterize/network-mapper/src/mapper/pkg/collectors/traffic"
 	"github.com/otterize/network-mapper/src/mapper/pkg/dnscache"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
@@ -71,6 +72,7 @@ func (s *ResolverTestSuite) SetupTest() {
 		s.azureIntentsHolder,
 		dnsCache,
 		s.incomingTrafficIntentsHolder,
+		traffic.NewCollector(),
 	)
 
 	resolver.Register(e)

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -307,6 +307,19 @@ func (r *Resolver) handleAzureOperationReport(ctx context.Context, operation mod
 	return nil
 }
 
+func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.TrafficLevelResults) error {
+	for _, report := range results.Results {
+		r.trafficCollector.Add(
+			report.SrcIP,
+			report.DstIP,
+			int(report.BytesSent),
+			int(report.Flows),
+		)
+	}
+
+	return nil
+}
+
 func (r *Resolver) handleDNSCaptureResultsAsKubernetesPods(ctx context.Context, dest model.Destination, srcSvcIdentity model.OtterizeServiceIdentity) error {
 	dstSvcIdentity, ok, err := r.resolveOtterizeIdentityForDestinationAddress(ctx, dest)
 	if err != nil {

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -320,14 +320,20 @@ func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.T
 		sourceIdentity, err := r.resolveIPToIdentity(ctx, report.SrcIP)
 
 		if err != nil {
-			logrus.WithError(err).Errorf("Could not resolve source IP %s to identity", report.SrcIP)
+			logrus.
+				WithField("ip", report.SrcIP).
+				WithError(err).
+				Errorf("Could not resolve source IP %s to identity", report.SrcIP)
 			continue
 		}
 
 		destinationIdentity, err := r.resolveIPToIdentity(ctx, report.DstIP)
 
 		if err != nil {
-			logrus.WithError(err).Errorf("Could not resolve destination IP %s to identity", report.DstIP)
+			logrus.
+				WithField("ip", report.DstIP).
+				WithError(err).
+				Errorf("Could not resolve destination IP %s to identity", report.DstIP)
 			continue
 		}
 

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -310,8 +310,6 @@ func (r *Resolver) handleAzureOperationReport(ctx context.Context, operation mod
 
 func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.TrafficLevelResults) error {
 	for _, report := range results.Results {
-		logrus.Infof("Traffic level report: %s %s", report.SrcIP, report.DstIP)
-
 		sourceIdentity, err := r.resolveIPToIdentity(ctx, report.SrcIP)
 
 		if err != nil {

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -323,7 +323,7 @@ func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.T
 			logrus.
 				WithField("ip", report.SrcIP).
 				WithError(err).
-				Errorf("Could not resolve source IP %s to identity", report.SrcIP)
+				Error("Could not resolve source IP to identity")
 			continue
 		}
 
@@ -333,7 +333,7 @@ func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.T
 			logrus.
 				WithField("ip", report.DstIP).
 				WithError(err).
-				Errorf("Could not resolve destination IP %s to identity", report.DstIP)
+				Error("Could not resolve destination IP to identity")
 			continue
 		}
 
@@ -823,7 +823,7 @@ func (r *Resolver) resolveIPToIdentity(ctx context.Context, ip string) (servicei
 	isPod, err := r.kubeFinder.IsPodIp(ctx, ip)
 
 	if err != nil {
-		logrus.WithError(err).Errorf("could not determine if %s is a pod", ip)
+		logrus.WithField("ip", ip).WithError(err).Error("could not determine if IP is a pod")
 		return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 	}
 
@@ -831,28 +831,28 @@ func (r *Resolver) resolveIPToIdentity(ctx context.Context, ip string) (servicei
 		sourcePod, err := r.kubeFinder.ResolveIPToPod(ctx, ip)
 
 		if err != nil {
-			logrus.WithError(err).Errorf("could not resolve source pod for %s", ip)
+			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source pod")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 
 		identity, err = r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, sourcePod)
 
 		if err != nil {
-			logrus.WithError(err).Errorf("could not resolve source identity for %s", ip)
+			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source identity")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 	} else {
 		sourceService, ok, err := r.kubeFinder.ResolveIPToService(ctx, ip)
 
 		if !ok || err != nil {
-			logrus.WithError(err).Errorf("could not resolve source service for %s", ip)
+			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source service")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 
 		otrSourceIdentity, ok, err := r.kubeFinder.ResolveOtterizeIdentityForService(ctx, sourceService, time.Now())
 
 		if !ok || err != nil {
-			logrus.WithError(err).Errorf("could not resolve source identity for %s", ip)
+			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source identity")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 		identity = serviceidentity.ServiceIdentity{

--- a/src/mapper/pkg/resolvers/schema.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.resolvers.go
@@ -121,6 +121,18 @@ func (r *mutationResolver) ReportAzureOperation(ctx context.Context, operation [
 	}
 }
 
+// ReportTrafficLevelResults is the resolver for the reportTrafficLevelResults field.
+func (r *mutationResolver) ReportTrafficLevelResults(ctx context.Context, results model.TrafficLevelResults) (bool, error) {
+	select {
+	case r.trafficLevelsResults <- results:
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+		return false, nil
+	}
+}
+
 // ServiceIntents is the resolver for the serviceIntents field.
 func (r *queryResolver) ServiceIntents(ctx context.Context, namespaces []string, includeLabels []string, includeAllLabels *bool) ([]model.ServiceIntents, error) {
 	shouldIncludeAllLabels := false

--- a/src/mapperclient/client.go
+++ b/src/mapperclient/client.go
@@ -56,6 +56,11 @@ func (c *Client) ReportSocketScanResults(ctx context.Context, results SocketScan
 	return errors.Wrap(err)
 }
 
+func (c *Client) ReportTrafficLevels(ctx context.Context, results TrafficLevelResults) error {
+	_, err := reportTrafficLevelResults(ctx, c.client, results)
+	return errors.Wrap(err)
+}
+
 func (c *Client) Health(ctx context.Context) error {
 	_, err := Health(ctx, c.client)
 	return errors.Wrap(err)

--- a/src/mapperclient/generated.go
+++ b/src/mapperclient/generated.go
@@ -164,6 +164,32 @@ type SocketScanResults struct {
 // GetResults returns SocketScanResults.Results, and is useful for accessing the field via an interface.
 func (v *SocketScanResults) GetResults() []RecordedDestinationsForSrc { return v.Results }
 
+type TrafficLevelResult struct {
+	SrcIP     string `json:"srcIP"`
+	DstIP     string `json:"dstIP"`
+	BytesSent int    `json:"bytesSent"`
+	Flows     int    `json:"flows"`
+}
+
+// GetSrcIP returns TrafficLevelResult.SrcIP, and is useful for accessing the field via an interface.
+func (v *TrafficLevelResult) GetSrcIP() string { return v.SrcIP }
+
+// GetDstIP returns TrafficLevelResult.DstIP, and is useful for accessing the field via an interface.
+func (v *TrafficLevelResult) GetDstIP() string { return v.DstIP }
+
+// GetBytesSent returns TrafficLevelResult.BytesSent, and is useful for accessing the field via an interface.
+func (v *TrafficLevelResult) GetBytesSent() int { return v.BytesSent }
+
+// GetFlows returns TrafficLevelResult.Flows, and is useful for accessing the field via an interface.
+func (v *TrafficLevelResult) GetFlows() int { return v.Flows }
+
+type TrafficLevelResults struct {
+	Results []TrafficLevelResult `json:"results"`
+}
+
+// GetResults returns TrafficLevelResults.Results, and is useful for accessing the field via an interface.
+func (v *TrafficLevelResults) GetResults() []TrafficLevelResult { return v.Results }
+
 // __reportAWSOperationInput is used internally by genqlient
 type __reportAWSOperationInput struct {
 	Operation []AWSOperation `json:"operation"`
@@ -211,6 +237,14 @@ type __reportTCPCaptureResultsInput struct {
 
 // GetResults returns __reportTCPCaptureResultsInput.Results, and is useful for accessing the field via an interface.
 func (v *__reportTCPCaptureResultsInput) GetResults() CaptureTCPResults { return v.Results }
+
+// __reportTrafficLevelResultsInput is used internally by genqlient
+type __reportTrafficLevelResultsInput struct {
+	Results TrafficLevelResults `json:"results"`
+}
+
+// GetResults returns __reportTrafficLevelResultsInput.Results, and is useful for accessing the field via an interface.
+func (v *__reportTrafficLevelResultsInput) GetResults() TrafficLevelResults { return v.Results }
 
 // reportAWSOperationResponse is returned by reportAWSOperation on success.
 type reportAWSOperationResponse struct {
@@ -264,6 +298,16 @@ type reportTCPCaptureResultsResponse struct {
 // GetReportTCPCaptureResults returns reportTCPCaptureResultsResponse.ReportTCPCaptureResults, and is useful for accessing the field via an interface.
 func (v *reportTCPCaptureResultsResponse) GetReportTCPCaptureResults() bool {
 	return v.ReportTCPCaptureResults
+}
+
+// reportTrafficLevelResultsResponse is returned by reportTrafficLevelResults on success.
+type reportTrafficLevelResultsResponse struct {
+	ReportTrafficLevelResults bool `json:"reportTrafficLevelResults"`
+}
+
+// GetReportTrafficLevelResults returns reportTrafficLevelResultsResponse.ReportTrafficLevelResults, and is useful for accessing the field via an interface.
+func (v *reportTrafficLevelResultsResponse) GetReportTrafficLevelResults() bool {
+	return v.ReportTrafficLevelResults
 }
 
 // The query or mutation executed by Health.
@@ -482,6 +526,39 @@ func reportTCPCaptureResults(
 	var err_ error
 
 	var data_ reportTCPCaptureResultsResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by reportTrafficLevelResults.
+const reportTrafficLevelResults_Operation = `
+mutation reportTrafficLevelResults ($results: TrafficLevelResults!) {
+	reportTrafficLevelResults(results: $results)
+}
+`
+
+func reportTrafficLevelResults(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	results TrafficLevelResults,
+) (*reportTrafficLevelResultsResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "reportTrafficLevelResults",
+		Query:  reportTrafficLevelResults_Operation,
+		Variables: &__reportTrafficLevelResultsInput{
+			Results: results,
+		},
+	}
+	var err_ error
+
+	var data_ reportTrafficLevelResultsResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/mapperclient/operations.graphql
+++ b/src/mapperclient/operations.graphql
@@ -22,6 +22,10 @@ mutation reportAzureOperation($operation: [AzureOperation!]!) {
     reportAzureOperation(operation: $operation)
 }
 
+mutation reportTrafficLevelResults($results: TrafficLevelResults!) {
+    reportTrafficLevelResults(results: $results)
+}
+
 
 query Health {
     health

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -178,6 +178,18 @@ input AzureOperation {
     clientNamespace: String!
 }
 
+input TrafficLevelResult {
+    srcIP: String!
+    dstIP: String!
+
+    bytesSent: Int!
+    flows: Int!
+}
+
+input TrafficLevelResults {
+    results: [TrafficLevelResult!]!
+}
+
 type Query {
     """
     Kept for backwards compatibility with CLI -
@@ -215,4 +227,5 @@ type Mutation {
     reportIstioConnectionResults(results: IstioConnectionResults!): Boolean!
     reportAWSOperation(operation: [AWSOperation!]!): Boolean!
     reportAzureOperation(operation: [AzureOperation!]!): Boolean!
+    reportTrafficLevelResults(results: TrafficLevelResults!): Boolean!
 }


### PR DESCRIPTION
### Description

Aggregate data collected by the Otterize node-agent, using the traffic levels eBPF programs. This data includes the number of bytes, and number of connections between the services. The mapper then calculates a moving average, and reports it to the cloud.


- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
