### PR TITLE
Fix bug where TCP SYN to a pod IP was not ignored on freshly started pods, potentially causing spammed discovered intents in cases of fast IP reuse

### DIFF
--- a/src/mapper/pkg/resolvers/resolver_test.go
+++ b/src/mapper/pkg/resolvers/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/network-mapper/src/mapper/pkg/awsintentsholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/azureintentsholder"
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
 	"github.com/otterize/network-mapper/src/mapper/pkg/dnscache"
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
@@ -1501,6 +1502,75 @@ func (s *ResolverTestSuite) TestDiscoverInternalSrcIdentityIgnoreControlPlaneIfB
 		})
 	s.Require().Equal(SourceIsHostNetworkPodError, err)
 	s.Require().Empty(identity)
+}
+
+func (s *ResolverTestSuite) TestReportTCPResultsIgnoreTargetsWithShortUptime() {
+	srcPodIP := "1.1.1.3"
+	_ = s.AddPod("pod3", srcPodIP, nil, nil)
+	targetPodIP := "1.1.1.2"
+	targetServiceIp := "10.0.0.37"
+	s.AddDeploymentWithService("service1", []string{targetPodIP}, map[string]string{"app": "service1"}, targetServiceIp)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	// Report TCP results of traffic from src pod to target pod with short uptime
+	packetBadTimingBeforePodsCreation := time.Now().Add(config.TimeServerHasToLiveBeforeWeTrustItDefault).Add(-time.Minute)
+	err := s.resolver.handleReportTCPCaptureResults(context.Background(), model.CaptureTCPResults{
+		Results: []model.RecordedDestinationsForSrc{
+			{
+				SrcIP: srcPodIP,
+				Destinations: []model.Destination{
+					{
+						Destination:     targetPodIP,
+						DestinationIP:   &targetPodIP,
+						DestinationPort: lo.ToPtr(int64(80)),
+						LastSeen:        packetBadTimingBeforePodsCreation,
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(s.intentsHolder.GetNewIntentsSinceLastGet(), 0)
+
+	// Report TCP results of traffic from src pod to target pod with good uptime
+	packetGoodTimingAfterPodsCreation := time.Now().Add(config.TimeServerHasToLiveBeforeWeTrustItDefault).Add(time.Minute)
+	err = s.resolver.handleReportTCPCaptureResults(context.Background(), model.CaptureTCPResults{
+		Results: []model.RecordedDestinationsForSrc{
+			{
+				SrcIP: srcPodIP,
+				Destinations: []model.Destination{
+					{
+						Destination:     targetPodIP,
+						DestinationIP:   &targetPodIP,
+						DestinationPort: lo.ToPtr(int64(80)),
+						LastSeen:        packetGoodTimingAfterPodsCreation,
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(s.intentsHolder.GetNewIntentsSinceLastGet(), 1)
+
+	// Report TCP results of traffic from src pod to target service with short uptime
+	err = s.resolver.handleReportTCPCaptureResults(context.Background(), model.CaptureTCPResults{
+		Results: []model.RecordedDestinationsForSrc{
+			{
+				SrcIP: srcPodIP,
+				Destinations: []model.Destination{
+					{
+						Destination:     targetServiceIp,
+						DestinationIP:   &targetServiceIp,
+						DestinationPort: lo.ToPtr(int64(80)),
+						LastSeen:        packetBadTimingBeforePodsCreation,
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(s.intentsHolder.GetNewIntentsSinceLastGet(), 1)
+
 }
 
 func TestRunSuite(t *testing.T) {

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -97,8 +97,8 @@ func (r *Resolver) resolveDestIdentityTCP(ctx context.Context, dest model.Destin
 
 	// If the mapper runs on AWS - pod ip addresses can be reused. In this case we ignore the traffic if service is not at least 5 minutes old.
 	fiveMinutesAgo := dest.LastSeen.Add(-viper.GetDuration(config.TimeServerHasToLiveBeforeWeTrustItKey))
-	if destPod.CreationTimestamp.Time.Before(fiveMinutesAgo) {
-		logrus.Debugf("Pod %s was created after capture time %s, ignoring", destPod.Name, dest.LastSeen)
+	if destPod.CreationTimestamp.Time.After(fiveMinutesAgo) {
+		logrus.Debugf("Pod %s is not up at least %d minutes, ignoring", destPod.Name, int(viper.GetDuration(config.TimeServerHasToLiveBeforeWeTrustItKey).Minutes()))
 		return model.OtterizeServiceIdentity{}, false, nil
 	}
 

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -57,12 +57,12 @@ func updateTelemetriesCounters(sourceType SourceType, intent model.Intent) {
 	}
 }
 
-func (r *Resolver) resolveDestIdentity(ctx context.Context, dest model.Destination, lastSeen time.Time) (model.OtterizeServiceIdentity, bool, error) {
-	destSvc, foundSvc, err := r.kubeFinder.ResolveIPToService(ctx, dest.Destination)
+func (r *Resolver) resolveDestIdentityTCP(ctx context.Context, dest model.Destination, lastSeen time.Time) (model.OtterizeServiceIdentity, bool, error) {
+	destSvc, isTargetService, err := r.kubeFinder.ResolveIPToService(ctx, dest.Destination)
 	if err != nil {
 		return model.OtterizeServiceIdentity{}, false, errors.Wrap(err)
 	}
-	if foundSvc {
+	if isTargetService {
 		dstSvcIdentity, ok, err := r.kubeFinder.ResolveOtterizeIdentityForService(ctx, destSvc, lastSeen)
 		if err != nil {
 			return model.OtterizeServiceIdentity{}, false, errors.Wrap(err)
@@ -70,7 +70,7 @@ func (r *Resolver) resolveDestIdentity(ctx context.Context, dest model.Destinati
 		if ok {
 			dstSvcIdentity.ResolutionData.Host = lo.ToPtr(dest.Destination)
 			dstSvcIdentity.ResolutionData.Port = dest.DestinationPort
-			dstSvcIdentity.ResolutionData.ExtraInfo = lo.ToPtr("resolveDestIdentity")
+			dstSvcIdentity.ResolutionData.ExtraInfo = lo.ToPtr("resolveDestIdentityTCP")
 			return dstSvcIdentity, true, nil
 		}
 	}
@@ -95,6 +95,13 @@ func (r *Resolver) resolveDestIdentity(ctx context.Context, dest model.Destinati
 		return model.OtterizeServiceIdentity{}, false, nil
 	}
 
+	// If the mapper runs on AWS - pod ip addresses can be reused. In this case we ignore the traffic if service is not at least 5 minutes old.
+	fiveMinutesAgo := dest.LastSeen.Add(-viper.GetDuration(config.TimeServerHasToLiveBeforeWeTrustItKey))
+	if destPod.CreationTimestamp.Time.Before(fiveMinutesAgo) {
+		logrus.Debugf("Pod %s was created after capture time %s, ignoring", destPod.Name, dest.LastSeen)
+		return model.OtterizeServiceIdentity{}, false, nil
+	}
+
 	dstService, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, destPod)
 	if err != nil {
 		logrus.WithError(err).Debugf("Could not resolve pod %s to identity", destPod.Name)
@@ -110,7 +117,7 @@ func (r *Resolver) resolveDestIdentity(ctx context.Context, dest model.Destinati
 			PodHostname:       lo.ToPtr(destPod.Name),
 			Port:              dest.DestinationPort,
 			IsService:         lo.ToPtr(false),
-			ExtraInfo:         lo.ToPtr("resolveDestIdentity"),
+			ExtraInfo:         lo.ToPtr("resolveDestIdentityTCP"),
 			LastSeen:          lo.ToPtr(dest.LastSeen.String()),
 			Uptime:            lo.ToPtr(time.Since(destPod.CreationTimestamp.Time).String()),
 			HasLinkerdSidecar: lo.ToPtr(hasLinkerdSidecar(destPod)),
@@ -523,7 +530,7 @@ func (r *Resolver) reportIncomingInternetTraffic(ctx context.Context, srcIP stri
 
 func (r *Resolver) handleInternalTrafficTCPResult(ctx context.Context, srcIdentity model.OtterizeServiceIdentity, dest model.Destination) {
 	lastSeen := dest.LastSeen
-	destIdentity, ok, err := r.resolveDestIdentity(ctx, dest, lastSeen)
+	destIdentity, ok, err := r.resolveDestIdentityTCP(ctx, dest, lastSeen)
 	if err != nil {
 		logrus.WithError(err).Error("could not resolve destination identity")
 		return


### PR DESCRIPTION
### Description

**Problem**: Freshly started pods were not ignoring TCP SYN packets to their IPs, leading to unintended connections. In cases of rapid IP reuse, this caused excessive discovered intents, adding unnecessary noise.

**Solution**: TCP SYN packets to a pod are now ignored if the pod has been running for less than 5 minutes. This prevents premature connection handling during fast IP reuse scenarios


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
