### PR TITLE
Initialize the GCP operations channel in resolvers

### DIFF
--- a/src/mapper/pkg/resolvers/resolver.go
+++ b/src/mapper/pkg/resolvers/resolver.go
@@ -76,6 +76,7 @@ func NewResolver(
 		istioConnectionResults:       make(chan model.IstioConnectionResults, 200),
 		awsOperations:                make(chan model.AWSOperationResults, 200),
 		azureOperations:              make(chan model.AzureOperationResults, 200),
+		gcpOperations:                make(chan model.GCPOperationResults, 200),
 		trafficLevelsResults:         make(chan model.TrafficLevelResults, 200),
 		awsIntentsHolder:             awsIntentsHolder,
 		gcpIntentsHolder:             gcpIntentsHolder,


### PR DESCRIPTION
### Description
 
Initialized the GCP operations channel in resolvers (won't work without it). Also improved the logs in the area.


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
