### PR TITLE
Fix bug where the workload identity resolution algorithm could fail if an owner ref uses a wrong apiVersion or kind

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263
 	github.com/otterize/go-procnet v0.1.1
-	github.com/otterize/intents-operator/src v0.0.0-20250311080009-87fc63399bfe
+	github.com/otterize/intents-operator/src v0.0.0-20250318113934-28fe8471b11e
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f
 	github.com/prometheus/client_golang v1.18.0
 	github.com/samber/lo v1.47.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -309,8 +309,8 @@ github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263 h1:Qd1Ml+uEhpesT8Og
 github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263/go.mod h1:odkMeLkWS8G6+WP2z3Pn2vkzhPSvBtFhAUYTKXAtZMQ=
 github.com/otterize/go-procnet v0.1.1 h1:5vRwX35VrsWcy2uP05sA4PmwpRoAu2L4vMJou4og8Kk=
 github.com/otterize/go-procnet v0.1.1/go.mod h1:WEm282HzrSVBZg6DX2fNB4dpVHBPTCjzHWvqOfauV+Q=
-github.com/otterize/intents-operator/src v0.0.0-20250311080009-87fc63399bfe h1:Aki+So5gMbHwFWj4FZHWGd4QB2PyaUNGbJhzNUYAdJA=
-github.com/otterize/intents-operator/src v0.0.0-20250311080009-87fc63399bfe/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
+github.com/otterize/intents-operator/src v0.0.0-20250318113934-28fe8471b11e h1:7psUzCPeqva3DarZLXZ7cJkzgnG34HrvOuQUAv0fxP4=
+github.com/otterize/intents-operator/src v0.0.0-20250318113934-28fe8471b11e/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f/go.mod h1:9SNBrJbNRAl1isohKk/t1Px85HuxPFylfMmOMVtCg2Q=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=


### PR DESCRIPTION
### Description

Sometimes, the object's owner reference may be incorrect or not included in the schema. We don't want to fail in those situations; it is sufficient to halt owner resolution and report the error.

### References

https://github.com/otterize/intents-operator/pull/578

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
