### PR TITLE
Reporting workloads that are marked with the Prometheus scraping annotation to support automatically create network policies to allow Prometheus scraping in Otterize cloud

### DIFF
--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/gcpintentsholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/incomingtrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/labelreporter"
+	"github.com/otterize/network-mapper/src/mapper/pkg/metrics_collection_traffic"
 	"github.com/otterize/network-mapper/src/mapper/pkg/resourcevisibility"
 	"github.com/otterize/network-mapper/src/shared/echologrus"
 	"golang.org/x/sync/errgroup"
@@ -241,6 +242,11 @@ func main() {
 		namespaceReconciler := labelreporter.NewNamespaceReconciler(mgr.GetClient(), cloudClient)
 		if err := namespaceReconciler.SetupWithManager(mgr); err != nil {
 			logrus.WithError(err).Panic("unable to create namespace reconciler")
+		}
+
+		metricsCollectorPodReconciler := metrics_collection_traffic.NewPodReconciler(mgr.GetClient(), serviceidresolver.NewResolver(mgr.GetClient()), cloudClient)
+		if err = metricsCollectorPodReconciler.SetupWithManager(mgr); err != nil {
+			logrus.WithError(err).Panic("unable to create service reconciler")
 		}
 	}
 

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -244,9 +244,11 @@ func main() {
 			logrus.WithError(err).Panic("unable to create namespace reconciler")
 		}
 
-		metricsCollectorPodReconciler := metrics_collection_traffic.NewPodReconciler(mgr.GetClient(), serviceidresolver.NewResolver(mgr.GetClient()), cloudClient)
+		metricsCollectionTrafficHandler := metrics_collection_traffic.NewMetricsCollectionTrafficHandler(mgr.GetClient(), serviceidresolver.NewResolver(mgr.GetClient()), cloudClient)
+
+		metricsCollectorPodReconciler := metrics_collection_traffic.NewPodReconciler(metricsCollectionTrafficHandler)
 		if err = metricsCollectorPodReconciler.SetupWithManager(mgr); err != nil {
-			logrus.WithError(err).Panic("unable to create service reconciler")
+			logrus.WithError(err).Panic("unable to create pod reconciler")
 		}
 	}
 

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -250,6 +250,16 @@ func main() {
 		if err = metricsCollectorPodReconciler.SetupWithManager(mgr); err != nil {
 			logrus.WithError(err).Panic("unable to create pod reconciler")
 		}
+
+		metricsCollectorServiceReconciler := metrics_collection_traffic.NewServiceReconciler(metricsCollectionTrafficHandler)
+		if err = metricsCollectorServiceReconciler.SetupWithManager(mgr); err != nil {
+			logrus.WithError(err).Panic("unable to create service reconciler")
+		}
+
+		metricsCollectorEndpointsReconciler := metrics_collection_traffic.NewEndpointsReconciler(metricsCollectionTrafficHandler)
+		if err = metricsCollectorEndpointsReconciler.SetupWithManager(mgr); err != nil {
+			logrus.WithError(err).Panic("unable to create endpoints reconciler")
+		}
 	}
 
 	if viper.GetBool(config.OTelEnabledKey) {

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -18,6 +18,7 @@ type CloudClient interface {
 	ReportTrafficLevels(ctx context.Context, trafficLevels []TrafficLevelInput) error
 	ReportNamespaceLabels(ctx context.Context, namespace string, labels []LabelInput) error
 	ReportWorkloadsLabels(ctx context.Context, workloadsLabels []ReportServiceMetadataInput) error
+	ReportK8sResourceEligibleForMetricsCollection(ctx context.Context, namespace string, reason EligibleForMetricsCollectionReason, resources []K8sResourceEligibleForMetricsCollectionInput) error
 }
 
 type CloudClientImpl struct {
@@ -93,6 +94,17 @@ func (c *CloudClientImpl) ReportK8sIngresses(ctx context.Context, namespace stri
 	logrus.Debug("Uploading k8s ingresses to cloud, count: ", len(ingresses))
 
 	_, err := ReportK8sIngresses(ctx, c.client, namespace, ingresses)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func (c *CloudClientImpl) ReportK8sResourceEligibleForMetricsCollection(ctx context.Context, namespace string, reason EligibleForMetricsCollectionReason, resources []K8sResourceEligibleForMetricsCollectionInput) error {
+	logrus.Debug("Uploading k8s metrics collector resource to cloud, count: ", len(resources))
+
+	_, err := ReportK8sResourceEligibleForMetricsCollection(ctx, c.client, namespace, reason, resources)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -93,6 +93,13 @@ func (v *DiscoveredIntentInput) GetDiscoveredAt() *time.Time { return v.Discover
 // GetIntent returns DiscoveredIntentInput.Intent, and is useful for accessing the field via an interface.
 func (v *DiscoveredIntentInput) GetIntent() *IntentInput { return v.Intent }
 
+type EligibleForMetricsCollectionReason string
+
+const (
+	EligibleForMetricsCollectionReasonPodAnnotations     EligibleForMetricsCollectionReason = "POD_ANNOTATIONS"
+	EligibleForMetricsCollectionReasonServiceAnnotations EligibleForMetricsCollectionReason = "SERVICE_ANNOTATIONS"
+)
+
 type ExternalTrafficDiscoveredIntentInput struct {
 	DiscoveredAt time.Time                  `json:"discoveredAt"`
 	Intent       ExternalTrafficIntentInput `json:"intent"`
@@ -479,6 +486,21 @@ const (
 	K8sPortProtocolUdp  K8sPortProtocol = "UDP"
 	K8sPortProtocolSctp K8sPortProtocol = "SCTP"
 )
+
+type K8sResourceEligibleForMetricsCollectionInput struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+}
+
+// GetNamespace returns K8sResourceEligibleForMetricsCollectionInput.Namespace, and is useful for accessing the field via an interface.
+func (v *K8sResourceEligibleForMetricsCollectionInput) GetNamespace() string { return v.Namespace }
+
+// GetName returns K8sResourceEligibleForMetricsCollectionInput.Name, and is useful for accessing the field via an interface.
+func (v *K8sResourceEligibleForMetricsCollectionInput) GetName() string { return v.Name }
+
+// GetKind returns K8sResourceEligibleForMetricsCollectionInput.Kind, and is useful for accessing the field via an interface.
+func (v *K8sResourceEligibleForMetricsCollectionInput) GetKind() string { return v.Kind }
 
 type K8sResourceIngressInput struct {
 	Spec   K8sResourceIngressSpecInput                    `json:"spec"`
@@ -871,6 +893,16 @@ type ReportK8sIngressesResponse struct {
 // GetReportK8sIngresses returns ReportK8sIngressesResponse.ReportK8sIngresses, and is useful for accessing the field via an interface.
 func (v *ReportK8sIngressesResponse) GetReportK8sIngresses() bool { return v.ReportK8sIngresses }
 
+// ReportK8sResourceEligibleForMetricsCollectionResponse is returned by ReportK8sResourceEligibleForMetricsCollection on success.
+type ReportK8sResourceEligibleForMetricsCollectionResponse struct {
+	ReportK8sResourceEligibleForMetricsCollection bool `json:"reportK8sResourceEligibleForMetricsCollection"`
+}
+
+// GetReportK8sResourceEligibleForMetricsCollection returns ReportK8sResourceEligibleForMetricsCollectionResponse.ReportK8sResourceEligibleForMetricsCollection, and is useful for accessing the field via an interface.
+func (v *ReportK8sResourceEligibleForMetricsCollectionResponse) GetReportK8sResourceEligibleForMetricsCollection() bool {
+	return v.ReportK8sResourceEligibleForMetricsCollection
+}
+
 // ReportK8sServicesResponse is returned by ReportK8sServices on success.
 type ReportK8sServicesResponse struct {
 	ReportK8sServices bool `json:"reportK8sServices"`
@@ -1092,6 +1124,28 @@ func (v *__ReportK8sIngressesInput) GetNamespace() string { return v.Namespace }
 // GetIngresses returns __ReportK8sIngressesInput.Ingresses, and is useful for accessing the field via an interface.
 func (v *__ReportK8sIngressesInput) GetIngresses() []K8sIngressInput { return v.Ingresses }
 
+// __ReportK8sResourceEligibleForMetricsCollectionInput is used internally by genqlient
+type __ReportK8sResourceEligibleForMetricsCollectionInput struct {
+	Namespace string                                         `json:"namespace"`
+	Reason    EligibleForMetricsCollectionReason             `json:"reason"`
+	Resources []K8sResourceEligibleForMetricsCollectionInput `json:"resources"`
+}
+
+// GetNamespace returns __ReportK8sResourceEligibleForMetricsCollectionInput.Namespace, and is useful for accessing the field via an interface.
+func (v *__ReportK8sResourceEligibleForMetricsCollectionInput) GetNamespace() string {
+	return v.Namespace
+}
+
+// GetReason returns __ReportK8sResourceEligibleForMetricsCollectionInput.Reason, and is useful for accessing the field via an interface.
+func (v *__ReportK8sResourceEligibleForMetricsCollectionInput) GetReason() EligibleForMetricsCollectionReason {
+	return v.Reason
+}
+
+// GetResources returns __ReportK8sResourceEligibleForMetricsCollectionInput.Resources, and is useful for accessing the field via an interface.
+func (v *__ReportK8sResourceEligibleForMetricsCollectionInput) GetResources() []K8sResourceEligibleForMetricsCollectionInput {
+	return v.Resources
+}
+
 // __ReportK8sServicesInput is used internally by genqlient
 type __ReportK8sServicesInput struct {
 	Namespace string            `json:"namespace"`
@@ -1290,6 +1344,43 @@ func ReportK8sIngresses(
 	var err_ error
 
 	var data_ ReportK8sIngressesResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by ReportK8sResourceEligibleForMetricsCollection.
+const ReportK8sResourceEligibleForMetricsCollection_Operation = `
+mutation ReportK8sResourceEligibleForMetricsCollection ($namespace: String!, $reason: EligibleForMetricsCollectionReason!, $resources: [K8sResourceEligibleForMetricsCollectionInput!]!) {
+	reportK8sResourceEligibleForMetricsCollection(namespace: $namespace, reason: $reason, resources: $resources)
+}
+`
+
+func ReportK8sResourceEligibleForMetricsCollection(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	reason EligibleForMetricsCollectionReason,
+	resources []K8sResourceEligibleForMetricsCollectionInput,
+) (*ReportK8sResourceEligibleForMetricsCollectionResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportK8sResourceEligibleForMetricsCollection",
+		Query:  ReportK8sResourceEligibleForMetricsCollection_Operation,
+		Variables: &__ReportK8sResourceEligibleForMetricsCollectionInput{
+			Namespace: namespace,
+			Reason:    reason,
+			Resources: resources,
+		},
+	}
+	var err_ error
+
+	var data_ ReportK8sResourceEligibleForMetricsCollectionResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -23,6 +23,10 @@ mutation ReportK8sIngresses($namespace: String!, $ingresses: [K8sIngressInput!]!
     reportK8sIngresses(namespace: $namespace, ingresses: $ingresses)
 }
 
+mutation ReportK8sResourceEligibleForMetricsCollection($namespace: String!, $reason: EligibleForMetricsCollectionReason!, $resources: [K8sResourceEligibleForMetricsCollectionInput!]!) {
+    reportK8sResourceEligibleForMetricsCollection(namespace: $namespace, reason: $reason, resources: $resources)
+}
+
 mutation ReportTrafficLevels(
     $trafficLevels: [TrafficLevelInput!]!
 ) {

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -105,6 +105,20 @@ func (mr *MockCloudClientMockRecorder) ReportK8sIngresses(ctx, namespace, ingres
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportK8sIngresses", reflect.TypeOf((*MockCloudClient)(nil).ReportK8sIngresses), ctx, namespace, ingresses)
 }
 
+// ReportK8sResourceEligibleForMetricsCollection mocks base method.
+func (m *MockCloudClient) ReportK8sResourceEligibleForMetricsCollection(ctx context.Context, namespace string, reason cloudclient.EligibleForMetricsCollectionReason, resources []cloudclient.K8sResourceEligibleForMetricsCollectionInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReportK8sResourceEligibleForMetricsCollection", ctx, namespace, reason, resources)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReportK8sResourceEligibleForMetricsCollection indicates an expected call of ReportK8sResourceEligibleForMetricsCollection.
+func (mr *MockCloudClientMockRecorder) ReportK8sResourceEligibleForMetricsCollection(ctx, namespace, reason, resources interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportK8sResourceEligibleForMetricsCollection", reflect.TypeOf((*MockCloudClient)(nil).ReportK8sResourceEligibleForMetricsCollection), ctx, namespace, reason, resources)
+}
+
 // ReportK8sServices mocks base method.
 func (m *MockCloudClient) ReportK8sServices(ctx context.Context, namespace string, services []cloudclient.K8sServiceInput) error {
 	m.ctrl.T.Helper()

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -743,6 +743,11 @@ type EdgeAccessStatuses {
 	linkerdPolicies: EdgeAccessStatus!
 }
 
+enum EligibleForMetricsCollectionReason {
+	POD_ANNOTATIONS
+	SERVICE_ANNOTATIONS
+}
+
 type Environment {
 	id: ID!
 	name: String!
@@ -1468,6 +1473,7 @@ input IntentsOperatorConfigurationInput {
 	awsALBLoadBalancerExemptionEnabled: Boolean
 	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
+	automateThirdPartyNetworkPolicies: AllowExternalTrafficPolicy
 }
 
 type IntentsOperatorState {
@@ -1565,6 +1571,12 @@ enum K8sPortProtocol {
 	TCP
 	UDP
 	SCTP
+}
+
+input K8sResourceEligibleForMetricsCollectionInput {
+	namespace: String!
+	name: String!
+	kind: String!
 }
 
 input K8sResourceIngressInput {
@@ -2030,6 +2042,11 @@ type Mutation {
 	reportK8sIngresses(
 		namespace: String!
 		ingresses: [K8sIngressInput!]!
+	): Boolean!
+	reportK8sResourceEligibleForMetricsCollection(
+		namespace: String!
+		reason: EligibleForMetricsCollectionReason!
+		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
 	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -9,33 +9,35 @@ import (
 )
 
 const (
-	ClusterDomainKey                      = "cluster-domain"
-	ClusterDomainDefault                  = kubeutils.DefaultClusterDomain
-	CloudApiAddrKey                       = "api-address"
-	CloudApiAddrDefault                   = "https://app.otterize.com/api"
-	UploadIntervalSecondsKey              = "upload-interval-seconds"
-	UploadIntervalSecondsDefault          = 60
-	UploadBatchSizeKey                    = "upload-batch-size"
-	UploadBatchSizeDefault                = 500
-	ExcludedNamespacesKey                 = "exclude-namespaces"
-	OTelEnabledKey                        = "enable-otel-export"
-	OTelEnabledDefault                    = false
-	OTelMetricKey                         = "otel-metric-name"
-	OTelMetricDefault                     = "traces_service_graph_request_total" // same as expected in otel-collector-contrib's servicegraphprocessor
-	ExternalTrafficCaptureEnabledKey      = "capture-external-traffic-enabled"
-	ExternalTrafficCaptureEnabledDefault  = true
-	CreateWebhookCertificateKey           = "create-webhook-certificate"
-	CreateWebhookCertificateDefault       = true
-	DNSCacheItemsMaxCapacityKey           = "dns-cache-items-max-capacity"
-	DNSCacheItemsMaxCapacityDefault       = 100000
-	DNSClientIntentsUpdateIntervalKey     = "dns-client-intents-update-interval"
-	DNSClientIntentsUpdateIntervalDefault = 100 * time.Millisecond
-	DNSClientIntentsUpdateEnabledKey      = "dns-client-intents-update-enabled"
-	DNSClientIntentsUpdateEnabledDefault  = true
-	ServiceCacheTTLDurationKey            = "service-cache-ttl-duration"
-	ServiceCacheTTLDurationDefault        = 1 * time.Minute
-	ServiceCacheSizeKey                   = "service-cache-size"
-	ServiceCacheSizeDefault               = 10000
+	ClusterDomainKey                         = "cluster-domain"
+	ClusterDomainDefault                     = kubeutils.DefaultClusterDomain
+	CloudApiAddrKey                          = "api-address"
+	CloudApiAddrDefault                      = "https://app.otterize.com/api"
+	UploadIntervalSecondsKey                 = "upload-interval-seconds"
+	UploadIntervalSecondsDefault             = 60
+	UploadBatchSizeKey                       = "upload-batch-size"
+	UploadBatchSizeDefault                   = 500
+	ExcludedNamespacesKey                    = "exclude-namespaces"
+	OTelEnabledKey                           = "enable-otel-export"
+	OTelEnabledDefault                       = false
+	OTelMetricKey                            = "otel-metric-name"
+	OTelMetricDefault                        = "traces_service_graph_request_total" // same as expected in otel-collector-contrib's servicegraphprocessor
+	ExternalTrafficCaptureEnabledKey         = "capture-external-traffic-enabled"
+	ExternalTrafficCaptureEnabledDefault     = true
+	CreateWebhookCertificateKey              = "create-webhook-certificate"
+	CreateWebhookCertificateDefault          = true
+	DNSCacheItemsMaxCapacityKey              = "dns-cache-items-max-capacity"
+	DNSCacheItemsMaxCapacityDefault          = 100000
+	DNSClientIntentsUpdateIntervalKey        = "dns-client-intents-update-interval"
+	DNSClientIntentsUpdateIntervalDefault    = 100 * time.Millisecond
+	DNSClientIntentsUpdateEnabledKey         = "dns-client-intents-update-enabled"
+	DNSClientIntentsUpdateEnabledDefault     = true
+	ServiceCacheTTLDurationKey               = "service-cache-ttl-duration"
+	ServiceCacheTTLDurationDefault           = 1 * time.Minute
+	ServiceCacheSizeKey                      = "service-cache-size"
+	ServiceCacheSizeDefault                  = 10000
+	MetricsCollectionTrafficCacheSizeKey     = "metrics-collection-traffic-cache-size"
+	MetricsCollectionTrafficCacheSizeDefault = 10000
 
 	EnableIstioCollectionKey                  = "enable-istio-collection"
 	EnableIstioCollectionDefault              = false
@@ -79,6 +81,7 @@ func init() {
 	viper.SetDefault(EnableIstioCollectionKey, EnableIstioCollectionDefault)
 	viper.SetDefault(ServiceCacheTTLDurationKey, ServiceCacheTTLDurationDefault)
 	viper.SetDefault(ServiceCacheSizeKey, ServiceCacheSizeDefault)
+	viper.SetDefault(MetricsCollectionTrafficCacheSizeKey, MetricsCollectionTrafficCacheSizeDefault)
 	viper.SetDefault(TimeServerHasToLiveBeforeWeTrustItKey, TimeServerHasToLiveBeforeWeTrustItDefault)
 	viper.SetDefault(ControlPlaneIPv4CidrPrefixLength, ControlPlaneIPv4CidrPrefixLengthDefault)
 

--- a/src/mapper/pkg/metrics_collection_traffic/endpoints_reconciler.go
+++ b/src/mapper/pkg/metrics_collection_traffic/endpoints_reconciler.go
@@ -1,0 +1,48 @@
+package metrics_collection_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+type EndpointsReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	metricsCollectionTrafficHandler *MetricsCollectionTrafficHandler
+}
+
+func NewEndpointsReconciler(metricsCollectionTrafficHandler *MetricsCollectionTrafficHandler) *EndpointsReconciler {
+	return &EndpointsReconciler{
+		metricsCollectionTrafficHandler: metricsCollectionTrafficHandler,
+	}
+}
+
+func (r *EndpointsReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Endpoints{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *EndpointsReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.metricsCollectionTrafficHandler.HandleAllServicesInNamespace(ctx, req)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/mapper/pkg/metrics_collection_traffic/metrics_collection_traffic_cache.go
+++ b/src/mapper/pkg/metrics_collection_traffic/metrics_collection_traffic_cache.go
@@ -1,0 +1,66 @@
+package metrics_collection_traffic
+
+import (
+	"fmt"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"golang.org/x/exp/slices"
+	"hash/crc32"
+)
+
+type CacheValue []byte
+
+type MetricsCollectionTrafficCache struct {
+	cache *expirable.LRU[string, CacheValue]
+}
+
+func NewMetricsCollectionTrafficCache() *MetricsCollectionTrafficCache {
+	size := viper.GetInt(config.MetricsCollectionTrafficCacheSizeKey)
+	// We don't want the cache to expire. It does not contain a lot of data, and we want to keep it as long as possible
+	// so we won't send unnecessary requests to the cloud.
+	cache := expirable.NewLRU[string, CacheValue](size, OnEvict, 0)
+
+	return &MetricsCollectionTrafficCache{
+		cache: cache,
+	}
+}
+
+func (c *MetricsCollectionTrafficCache) Get(namespace string, reason cloudclient.EligibleForMetricsCollectionReason) (CacheValue, bool) {
+	return c.cache.Get(c.key(namespace, reason))
+}
+
+func (c *MetricsCollectionTrafficCache) Set(namespace string, reason cloudclient.EligibleForMetricsCollectionReason, value CacheValue) bool {
+	return c.cache.Add(c.key(namespace, reason), value)
+}
+
+func (c *MetricsCollectionTrafficCache) key(namespace string, reason cloudclient.EligibleForMetricsCollectionReason) string {
+	return fmt.Sprintf("%s#%s", namespace, reason)
+}
+
+func (c *MetricsCollectionTrafficCache) GenerateValue(pods []cloudclient.K8sResourceEligibleForMetricsCollectionInput) (CacheValue, error) {
+	values := lo.Map(pods, func(resource cloudclient.K8sResourceEligibleForMetricsCollectionInput, _ int) string {
+		return fmt.Sprintf("%s#%s", resource.Name, resource.Kind)
+	})
+
+	slices.Sort(values)
+
+	hash := crc32.NewIEEE()
+	for _, value := range values {
+		_, err := hash.Write([]byte(value))
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+	}
+	hashSum := hash.Sum(nil)
+
+	return hashSum, nil
+}
+
+func OnEvict(key string, _ CacheValue) {
+	logrus.WithField("namespace", key).Debug("key evicted from cache, you may change configuration to increase cache size")
+}

--- a/src/mapper/pkg/metrics_collection_traffic/metrics_collection_traffic_handler.go
+++ b/src/mapper/pkg/metrics_collection_traffic/metrics_collection_traffic_handler.go
@@ -7,6 +7,8 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,7 +36,6 @@ func (r *MetricsCollectionTrafficHandler) HandleAllPodsInNamespace(ctx context.C
 
 	scrapePods := lo.Filter(podList.Items, func(pod corev1.Pod, _ int) bool {
 		return pod.Annotations["prometheus.io/scrape"] == "true"
-
 	})
 
 	podsToReport := make([]cloudclient.K8sResourceEligibleForMetricsCollectionInput, 0)
@@ -46,16 +47,102 @@ func (r *MetricsCollectionTrafficHandler) HandleAllPodsInNamespace(ctx context.C
 		podsToReport = append(podsToReport, cloudclient.K8sResourceEligibleForMetricsCollectionInput{Namespace: req.Namespace, Name: serviceId.Name, Kind: serviceId.Kind})
 	}
 
+	err = r.reportToCloud(ctx, req.Namespace, cloudclient.EligibleForMetricsCollectionReasonPodAnnotations, podsToReport)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func (r *MetricsCollectionTrafficHandler) HandleAllServicesInNamespace(ctx context.Context, req ctrl.Request) error {
+	serviceList := &corev1.ServiceList{}
+	err := r.Client.List(ctx, serviceList, client.InNamespace(req.Namespace))
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	scrapeServices := lo.Filter(serviceList.Items, func(pod corev1.Service, _ int) bool {
+		return pod.Annotations["prometheus.io/scrape"] == "true"
+	})
+
+	podsToReport := make([]cloudclient.K8sResourceEligibleForMetricsCollectionInput, 0)
+
+	for _, service := range scrapeServices {
+		// Get all the pods relevant to this service
+		endpoints := &corev1.Endpoints{}
+		err = r.Client.Get(ctx, client.ObjectKey{Namespace: service.Namespace, Name: service.Name}, endpoints)
+		if k8serrors.IsNotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return errors.Wrap(err)
+		}
+
+		endpointsPods, err := r.getEndpointsPods(ctx, endpoints)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+
+		for _, pod := range endpointsPods {
+			serviceId, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, &pod)
+			if err != nil {
+				return errors.Wrap(err)
+			}
+			podsToReport = append(podsToReport, cloudclient.K8sResourceEligibleForMetricsCollectionInput{Namespace: req.Namespace, Name: serviceId.Name, Kind: serviceId.Kind})
+		}
+	}
+
+	err = r.reportToCloud(ctx, req.Namespace, cloudclient.EligibleForMetricsCollectionReasonServiceAnnotations, podsToReport)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func (r *MetricsCollectionTrafficHandler) reportToCloud(ctx context.Context, namespace string, reason cloudclient.EligibleForMetricsCollectionReason, pods []cloudclient.K8sResourceEligibleForMetricsCollectionInput) error {
 	// Remove duplicates - in case we have multiple pods that indicates on the same workload
-	podsToReport = lo.UniqBy(podsToReport, func(item cloudclient.K8sResourceEligibleForMetricsCollectionInput) string {
+	pods = lo.UniqBy(pods, func(item cloudclient.K8sResourceEligibleForMetricsCollectionInput) string {
 		return item.Name
 	})
 
 	// TODO: Add cache and report to cloud only if something changed
 
-	err = r.otterizeCloud.ReportK8sResourceEligibleForMetricsCollection(ctx, req.Namespace, cloudclient.EligibleForMetricsCollectionReasonPodAnnotations, podsToReport)
+	err := r.otterizeCloud.ReportK8sResourceEligibleForMetricsCollection(ctx, namespace, reason, pods)
 	if err != nil {
 		return errors.Wrap(err)
 	}
+
 	return nil
+}
+
+func (r *MetricsCollectionTrafficHandler) getEndpointsPods(ctx context.Context, endpoints *corev1.Endpoints) ([]corev1.Pod, error) {
+	addresses := make([]corev1.EndpointAddress, 0)
+	for _, subset := range endpoints.Subsets {
+		addresses = append(addresses, subset.Addresses...)
+		addresses = append(addresses, subset.NotReadyAddresses...)
+	}
+
+	pods := make([]corev1.Pod, 0)
+	for _, address := range addresses {
+		if address.TargetRef == nil || address.TargetRef.Kind != "Pod" {
+			// If we could not find the relevant pod, we just skip to the next one
+			continue
+		}
+
+		pod := &corev1.Pod{}
+		err := r.Client.Get(ctx, types.NamespacedName{Name: address.TargetRef.Name, Namespace: address.TargetRef.Namespace}, pod)
+		if k8serrors.IsNotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return make([]corev1.Pod, 0), errors.Wrap(err)
+		}
+
+		pods = append(pods, *pod)
+	}
+	return pods, nil
 }

--- a/src/mapper/pkg/metrics_collection_traffic/metrics_collection_traffic_handler.go
+++ b/src/mapper/pkg/metrics_collection_traffic/metrics_collection_traffic_handler.go
@@ -1,0 +1,61 @@
+package metrics_collection_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type MetricsCollectionTrafficHandler struct {
+	client.Client
+	serviceIdResolver *serviceidresolver.Resolver
+	otterizeCloud     cloudclient.CloudClient
+}
+
+func NewMetricsCollectionTrafficHandler(client client.Client, serviceIdResolver *serviceidresolver.Resolver, otterizeCloud cloudclient.CloudClient) *MetricsCollectionTrafficHandler {
+	return &MetricsCollectionTrafficHandler{
+		Client:            client,
+		serviceIdResolver: serviceIdResolver,
+		otterizeCloud:     otterizeCloud,
+	}
+}
+
+func (r *MetricsCollectionTrafficHandler) HandleAllPodsInNamespace(ctx context.Context, req ctrl.Request) error {
+	podList := &corev1.PodList{}
+	err := r.Client.List(ctx, podList, client.InNamespace(req.Namespace))
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	scrapePods := lo.Filter(podList.Items, func(pod corev1.Pod, _ int) bool {
+		return pod.Annotations["prometheus.io/scrape"] == "true"
+
+	})
+
+	podsToReport := make([]cloudclient.K8sResourceEligibleForMetricsCollectionInput, 0)
+	for _, pod := range scrapePods {
+		serviceId, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, &pod)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		podsToReport = append(podsToReport, cloudclient.K8sResourceEligibleForMetricsCollectionInput{Namespace: req.Namespace, Name: serviceId.Name, Kind: serviceId.Kind})
+	}
+
+	// Remove duplicates - in case we have multiple pods that indicates on the same workload
+	podsToReport = lo.UniqBy(podsToReport, func(item cloudclient.K8sResourceEligibleForMetricsCollectionInput) string {
+		return item.Name
+	})
+
+	// TODO: Add cache and report to cloud only if something changed
+
+	err = r.otterizeCloud.ReportK8sResourceEligibleForMetricsCollection(ctx, req.Namespace, cloudclient.EligibleForMetricsCollectionReasonPodAnnotations, podsToReport)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	return nil
+}

--- a/src/mapper/pkg/metrics_collection_traffic/pod_reconciler.go
+++ b/src/mapper/pkg/metrics_collection_traffic/pod_reconciler.go
@@ -1,0 +1,79 @@
+package metrics_collection_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+type PodReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	serviceIdResolver *serviceidresolver.Resolver
+	otterizeCloud     cloudclient.CloudClient
+}
+
+func NewPodReconciler(client client.Client, serviceIdResolver *serviceidresolver.Resolver, otterizeCloud cloudclient.CloudClient) *PodReconciler {
+	return &PodReconciler{
+		Client:            client,
+		serviceIdResolver: serviceIdResolver,
+		otterizeCloud:     otterizeCloud,
+	}
+}
+
+func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Pod{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *PodReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	podList := &corev1.PodList{}
+	err := r.Client.List(ctx, podList, client.InNamespace(req.Namespace))
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	scrapePods := lo.Filter(podList.Items, func(pod corev1.Pod, _ int) bool {
+		return pod.Annotations["prometheus.io/scrape"] == "true"
+
+	})
+
+	podsToReport := make([]cloudclient.K8sResourceEligibleForMetricsCollectionInput, 0)
+	for _, pod := range scrapePods {
+		serviceId, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, &pod)
+		if err != nil {
+			return ctrl.Result{}, errors.Wrap(err)
+		}
+		podsToReport = append(podsToReport, cloudclient.K8sResourceEligibleForMetricsCollectionInput{Namespace: req.Namespace, Name: serviceId.Name, Kind: serviceId.Kind})
+	}
+
+	// Remove duplicates - in case we have multiple pods that indicates on the same workload
+	podsToReport = lo.UniqBy(podsToReport, func(item cloudclient.K8sResourceEligibleForMetricsCollectionInput) string {
+		return item.Name
+	})
+
+	// TODO: Add cache and report to cloud only if something changed
+
+	err = r.otterizeCloud.ReportK8sResourceEligibleForMetricsCollection(ctx, req.Namespace, cloudclient.EligibleForMetricsCollectionReasonPodAnnotations, podsToReport)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+	return ctrl.Result{}, nil
+}

--- a/src/mapper/pkg/metrics_collection_traffic/service_reconciler.go
+++ b/src/mapper/pkg/metrics_collection_traffic/service_reconciler.go
@@ -1,0 +1,48 @@
+package metrics_collection_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+type ServiceReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	metricsCollectionTrafficHandler *MetricsCollectionTrafficHandler
+}
+
+func NewServiceReconciler(metricsCollectionTrafficHandler *MetricsCollectionTrafficHandler) *ServiceReconciler {
+	return &ServiceReconciler{
+		metricsCollectionTrafficHandler: metricsCollectionTrafficHandler,
+	}
+}
+
+func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Service{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *ServiceReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.metricsCollectionTrafficHandler.HandleAllServicesInNamespace(ctx, req)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	return ctrl.Result{}, nil
+}


### PR DESCRIPTION
### Description
Otterize now supports automatically enabling Prometheus (and others like) metrics scraping for workloads that are marked with `prometheus.io/scrape` annotation.
The network mapper will now report those workloads to the cloud as well, to support the feature in Otterize-cloud shadow mode.

### References
- [Intents operator support](https://github.com/otterize/intents-operator/pull/579)
- [Helm charts support](https://github.com/otterize/helm-charts/pull/295)
- [Documentations](https://github.com/otterize/docs/pull/292)

### Testing
Unit tests were added

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
