### PR TITLE
Improve cloud clientIntents suggestions by informing the cloud when a workload is using the workloadName override annotation

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263
 	github.com/otterize/go-procnet v0.1.1
-	github.com/otterize/intents-operator/src v0.0.0-20250318113934-28fe8471b11e
+	github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f
 	github.com/prometheus/client_golang v1.18.0
 	github.com/samber/lo v1.47.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -309,8 +309,8 @@ github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263 h1:Qd1Ml+uEhpesT8Og
 github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263/go.mod h1:odkMeLkWS8G6+WP2z3Pn2vkzhPSvBtFhAUYTKXAtZMQ=
 github.com/otterize/go-procnet v0.1.1 h1:5vRwX35VrsWcy2uP05sA4PmwpRoAu2L4vMJou4og8Kk=
 github.com/otterize/go-procnet v0.1.1/go.mod h1:WEm282HzrSVBZg6DX2fNB4dpVHBPTCjzHWvqOfauV+Q=
-github.com/otterize/intents-operator/src v0.0.0-20250318113934-28fe8471b11e h1:7psUzCPeqva3DarZLXZ7cJkzgnG34HrvOuQUAv0fxP4=
-github.com/otterize/intents-operator/src v0.0.0-20250318113934-28fe8471b11e/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
+github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc h1:GMGaWur2z5S6kSMpCHalDQ2n1MmfTjdbZjHCkOeIo/Q=
+github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f/go.mod h1:9SNBrJbNRAl1isohKk/t1Px85HuxPFylfMmOMVtCg2Q=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -205,29 +205,31 @@ func (v *IntOrStringInput) GetIntVal() nilable.Nilable[int] { return v.IntVal }
 func (v *IntOrStringInput) GetStrVal() nilable.Nilable[string] { return v.StrVal }
 
 type IntentInput struct {
-	Namespace            *string                   `json:"namespace"`
-	ClientName           *string                   `json:"clientName"`
-	ClientResolutionData *string                   `json:"clientResolutionData"`
-	ClientWorkloadKind   *string                   `json:"clientWorkloadKind"`
-	ServerName           *string                   `json:"serverName"`
-	ServerResolutionData *string                   `json:"serverResolutionData"`
-	ServerWorkloadKind   *string                   `json:"serverWorkloadKind"`
-	ServerAlias          *ServerAliasInput         `json:"serverAlias"`
-	ServerNamespace      *string                   `json:"serverNamespace"`
-	Type                 *IntentType               `json:"type"`
-	Topics               []*KafkaConfigInput       `json:"topics"`
-	Resources            []*HTTPConfigInput        `json:"resources"`
-	DatabaseResources    []*DatabaseConfigInput    `json:"databaseResources"`
-	AwsRole              *string                   `json:"awsRole"`
-	AwsActions           []*string                 `json:"awsActions"`
-	AzureRoles           []*string                 `json:"azureRoles"`
-	AzureActions         []*string                 `json:"azureActions"`
-	AzureDataActions     []*string                 `json:"azureDataActions"`
-	AzureKeyVaultPolicy  *AzureKeyVaultPolicyInput `json:"azureKeyVaultPolicy"`
-	GcpPermissions       []*string                 `json:"gcpPermissions"`
-	Internet             *InternetConfigInput      `json:"internet"`
-	Status               *IntentStatusInput        `json:"status"`
-	ResolutionData       *string                   `json:"resolutionData"`
+	Namespace                         *string                   `json:"namespace"`
+	ClientName                        *string                   `json:"clientName"`
+	ClientResolutionData              *string                   `json:"clientResolutionData"`
+	ClientWorkloadKind                *string                   `json:"clientWorkloadKind"`
+	ClientNameResolvedUsingAnnotation *bool                     `json:"clientNameResolvedUsingAnnotation"`
+	ServerName                        *string                   `json:"serverName"`
+	ServerResolutionData              *string                   `json:"serverResolutionData"`
+	ServerWorkloadKind                *string                   `json:"serverWorkloadKind"`
+	ServerNameResolvedUsingAnnotation *bool                     `json:"serverNameResolvedUsingAnnotation"`
+	ServerAlias                       *ServerAliasInput         `json:"serverAlias"`
+	ServerNamespace                   *string                   `json:"serverNamespace"`
+	Type                              *IntentType               `json:"type"`
+	Topics                            []*KafkaConfigInput       `json:"topics"`
+	Resources                         []*HTTPConfigInput        `json:"resources"`
+	DatabaseResources                 []*DatabaseConfigInput    `json:"databaseResources"`
+	AwsRole                           *string                   `json:"awsRole"`
+	AwsActions                        []*string                 `json:"awsActions"`
+	AzureRoles                        []*string                 `json:"azureRoles"`
+	AzureActions                      []*string                 `json:"azureActions"`
+	AzureDataActions                  []*string                 `json:"azureDataActions"`
+	AzureKeyVaultPolicy               *AzureKeyVaultPolicyInput `json:"azureKeyVaultPolicy"`
+	GcpPermissions                    []*string                 `json:"gcpPermissions"`
+	Internet                          *InternetConfigInput      `json:"internet"`
+	Status                            *IntentStatusInput        `json:"status"`
+	ResolutionData                    *string                   `json:"resolutionData"`
 }
 
 // GetNamespace returns IntentInput.Namespace, and is useful for accessing the field via an interface.
@@ -242,6 +244,11 @@ func (v *IntentInput) GetClientResolutionData() *string { return v.ClientResolut
 // GetClientWorkloadKind returns IntentInput.ClientWorkloadKind, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetClientWorkloadKind() *string { return v.ClientWorkloadKind }
 
+// GetClientNameResolvedUsingAnnotation returns IntentInput.ClientNameResolvedUsingAnnotation, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetClientNameResolvedUsingAnnotation() *bool {
+	return v.ClientNameResolvedUsingAnnotation
+}
+
 // GetServerName returns IntentInput.ServerName, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetServerName() *string { return v.ServerName }
 
@@ -250,6 +257,11 @@ func (v *IntentInput) GetServerResolutionData() *string { return v.ServerResolut
 
 // GetServerWorkloadKind returns IntentInput.ServerWorkloadKind, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetServerWorkloadKind() *string { return v.ServerWorkloadKind }
+
+// GetServerNameResolvedUsingAnnotation returns IntentInput.ServerNameResolvedUsingAnnotation, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetServerNameResolvedUsingAnnotation() *bool {
+	return v.ServerNameResolvedUsingAnnotation
+}
 
 // GetServerAlias returns IntentInput.ServerAlias, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetServerAlias() *ServerAliasInput { return v.ServerAlias }

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -156,6 +156,12 @@ enum AccessApprovalRulesetFilterValue {
 	ANY
 }
 
+type AccessApprovalRulesetResources {
+	clusters: [Cluster!]!
+	services: [Service!]!
+	namespaces: [Namespace!]!
+}
+
 type AccessApprovalRulesetSummary {
 	environment: Environment!
 	count: Int!
@@ -242,6 +248,8 @@ input AppliedIntentsRequestApprovalData {
 
 type AppliedIntentsRequestStatus {
 	id: ID!
+	resourceId: String!
+	generation: Int!
 """client"""
 	service: Service!
 	timestamp: Time!
@@ -253,6 +261,7 @@ enum AppliedIntentsRequestStatusLabel {
 	PENDING
 	APPROVED
 	DENIED
+	STALE
 }
 
 type AppliedIntentsRequestWithDetails {
@@ -782,6 +791,7 @@ enum EventType {
 	ACTIVE
 	EBPF_ATTACHED
 	EBPF_ATTACH_FAILED
+	EBPF_PROCESSING_ERROR
 }
 
 input ExternalTrafficDiscoveredIntentInput {
@@ -1056,7 +1066,7 @@ input IngressControllerConfigInput {
 """Ruleset"""
 input InputAccessApprovalRuleset {
 """Ruleset"""
-	id: ID
+	id: ID!
 """Ruleset"""
 	origin: InputAccessApprovalRulesetConfigFilter!
 """Ruleset"""
@@ -1211,6 +1221,25 @@ input InputServiceFilter {
 	integrationIds: [ID!]
 }
 
+input InputTerraformAwsPolicyInfo {
+	arn: String!
+	address: String!
+}
+
+input InputTerraformAwsRoleInfo {
+	arn: String!
+	address: String!
+	inlinePolicy: String!
+	attachedPolicies: [InputTerraformAwsPolicyInfo!]
+}
+
+input InputTerraformResourceInfo {
+	modulePath: String!
+	gitOriginUrl: String!
+	gitCommitHash: String!
+	awsRoles: [InputTerraformAwsRoleInfo!]
+}
+
 input InputTimeFilterValue {
 	value: Time!
 	operator: TimeFilterOperators!
@@ -1345,9 +1374,11 @@ input IntentInput {
 	clientName: String!
 	clientResolutionData: String
 	clientWorkloadKind: String
+	clientNameResolvedUsingAnnotation: Boolean
 	serverName: String!
 	serverResolutionData: String
 	serverWorkloadKind: String
+	serverNameResolvedUsingAnnotation: Boolean
 	serverAlias: ServerAliasInput
 	serverNamespace: String
 	type: IntentType
@@ -1367,8 +1398,13 @@ input IntentInput {
 }
 
 input IntentRequestInput {
-	requestId: ID!
+	resourceGeneration: IntentRequestResourceGeneration!
 	intent: IntentInput!
+}
+
+input IntentRequestResourceGeneration {
+	resourceId: String!
+	generation: Int!
 }
 
 type IntentStatus {
@@ -1753,8 +1789,11 @@ type Mutation {
 		id: ID!
 		result: AppliedIntentsRequestApprovalData!
 	): Boolean!
+	syncPendingRequestStatuses(
+		intentResourceGeneration: [IntentRequestResourceGeneration!]!
+	): [AppliedIntentsRequestStatus!]!
 """rulesets"""
-	createOrUpdateAccessApprovalRulesets(
+	saveAccessApprovalRulesets(
 		environmentId: ID!
 		rules: [InputAccessApprovalRuleset!]!
 	): Boolean!
@@ -2047,6 +2086,10 @@ type Mutation {
 	sendCLITelemetries(
 		telemetries: [CLITelemetry!]!
 	): Boolean!
+"""report terraform resources from Otterize CLI"""
+	reportTerraformResources(
+		resourceInfo: InputTerraformResourceInfo!
+	): TerraformResourceInfo!
 """Update service"""
 	reportTrafficLevels(
 		trafficLevels: [TrafficLevelInput!]!
@@ -2235,7 +2278,7 @@ type Query {
 	accessApprovalRulesetSummary: [AccessApprovalRulesetSummary!]!
 	accessApprovalRulesetList(
 		filter: InputAccessApprovalRulesetFilter
-	): [AccessApprovalRuleset!]!
+	): RulesetsWithResources!
 """Get cluster"""
 	cluster(
 		id: ID!
@@ -2385,6 +2428,12 @@ type Query {
 	serviceByIdentity(
 		identity: ServiceIdentityInput!
 	): Service!
+"""get terraform resource by git identity"""
+	terraformResourceByIdentity(
+		modulePath: String!
+		gitOriginUrl: String!
+		gitCommitHash: String!
+	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
 """Get user"""
@@ -2450,6 +2499,11 @@ type Resource {
 enum RowDiff {
 	ADDED
 	REMOVED
+}
+
+type RulesetsWithResources {
+	rulesets: [AccessApprovalRuleset!]!
+	resources: AccessApprovalRulesetResources!
 }
 
 input SelectorKeyValueInput {
@@ -2718,6 +2772,25 @@ input TelemetryData {
 input TelemetryInput {
 	component: Component!
 	data: TelemetryData!
+}
+
+type TerraformAwsPolicyInfo {
+	arn: String!
+	address: String!
+}
+
+type TerraformAwsRoleInfo {
+	arn: String!
+	address: String!
+	inlinePolicy: String!
+	attachedPolicies: [TerraformAwsPolicyInfo!]
+}
+
+type TerraformResourceInfo {
+	modulePath: String!
+	gitOriginUrl: String!
+	gitCommitHash: String!
+	awsRoles: [TerraformAwsRoleInfo!]
 }
 
 type TestDatabaseConnectionResponse {

--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -43,11 +43,13 @@ func (c *CloudUploader) NotifyIntents(ctx context.Context, intents []intentsstor
 		toCloud := &cloudclient.DiscoveredIntentInput{
 			DiscoveredAt: lo.ToPtr(intent.Timestamp),
 			Intent: &cloudclient.IntentInput{
-				ClientName:      &intent.Intent.Client.Name,
-				Namespace:       &intent.Intent.Client.Namespace,
-				ServerName:      &intent.Intent.Server.Name,
-				ServerNamespace: &intent.Intent.Server.Namespace,
-				Type:            modelIntentTypeToAPI(intent.Intent.Type),
+				ClientName:                        &intent.Intent.Client.Name,
+				Namespace:                         &intent.Intent.Client.Namespace,
+				ClientNameResolvedUsingAnnotation: intent.Intent.Client.NameResolvedUsingAnnotation,
+				ServerName:                        &intent.Intent.Server.Name,
+				ServerNamespace:                   &intent.Intent.Server.Namespace,
+				ServerNameResolvedUsingAnnotation: intent.Intent.Server.NameResolvedUsingAnnotation,
+				Type:                              modelIntentTypeToAPI(intent.Intent.Type),
 				Topics: lo.Map(intent.Intent.KafkaTopics,
 					func(item model.KafkaConfig, _ int) *cloudclient.KafkaConfigInput {
 						return lo.ToPtr(modelKafkaConfToAPI(item))

--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -99,12 +99,13 @@ type ComplexityRoot struct {
 	}
 
 	OtterizeServiceIdentity struct {
-		KubernetesService func(childComplexity int) int
-		Labels            func(childComplexity int) int
-		Name              func(childComplexity int) int
-		Namespace         func(childComplexity int) int
-		PodOwnerKind      func(childComplexity int) int
-		ResolutionData    func(childComplexity int) int
+		KubernetesService           func(childComplexity int) int
+		Labels                      func(childComplexity int) int
+		Name                        func(childComplexity int) int
+		NameResolvedUsingAnnotation func(childComplexity int) int
+		Namespace                   func(childComplexity int) int
+		PodOwnerKind                func(childComplexity int) int
+		ResolutionData              func(childComplexity int) int
 	}
 
 	PodLabel struct {
@@ -458,6 +459,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OtterizeServiceIdentity.Name(childComplexity), true
 
+	case "OtterizeServiceIdentity.nameResolvedUsingAnnotations":
+		if e.complexity.OtterizeServiceIdentity.NameResolvedUsingAnnotation == nil {
+			break
+		}
+
+		return e.complexity.OtterizeServiceIdentity.NameResolvedUsingAnnotation(childComplexity), true
+
 	case "OtterizeServiceIdentity.namespace":
 		if e.complexity.OtterizeServiceIdentity.Namespace == nil {
 			break
@@ -716,6 +724,7 @@ type OtterizeServiceIdentity {
     name: String!
     namespace: String!
     labels: [PodLabel!]
+    nameResolvedUsingAnnotations: Boolean
     resolutionData: IdentityResolutionData
     """
     If the service identity was resolved from a pod owner, the GroupVersionKind of the pod owner.
@@ -1807,6 +1816,8 @@ func (ec *executionContext) fieldContext_Intent_client(ctx context.Context, fiel
 				return ec.fieldContext_OtterizeServiceIdentity_namespace(ctx, field)
 			case "labels":
 				return ec.fieldContext_OtterizeServiceIdentity_labels(ctx, field)
+			case "nameResolvedUsingAnnotations":
+				return ec.fieldContext_OtterizeServiceIdentity_nameResolvedUsingAnnotations(ctx, field)
 			case "resolutionData":
 				return ec.fieldContext_OtterizeServiceIdentity_resolutionData(ctx, field)
 			case "podOwnerKind":
@@ -1865,6 +1876,8 @@ func (ec *executionContext) fieldContext_Intent_server(ctx context.Context, fiel
 				return ec.fieldContext_OtterizeServiceIdentity_namespace(ctx, field)
 			case "labels":
 				return ec.fieldContext_OtterizeServiceIdentity_labels(ctx, field)
+			case "nameResolvedUsingAnnotations":
+				return ec.fieldContext_OtterizeServiceIdentity_nameResolvedUsingAnnotations(ctx, field)
 			case "resolutionData":
 				return ec.fieldContext_OtterizeServiceIdentity_resolutionData(ctx, field)
 			case "podOwnerKind":
@@ -2854,6 +2867,47 @@ func (ec *executionContext) fieldContext_OtterizeServiceIdentity_labels(ctx cont
 	return fc, nil
 }
 
+func (ec *executionContext) _OtterizeServiceIdentity_nameResolvedUsingAnnotations(ctx context.Context, field graphql.CollectedField, obj *model.OtterizeServiceIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OtterizeServiceIdentity_nameResolvedUsingAnnotations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NameResolvedUsingAnnotation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OtterizeServiceIdentity_nameResolvedUsingAnnotations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OtterizeServiceIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _OtterizeServiceIdentity_resolutionData(ctx context.Context, field graphql.CollectedField, obj *model.OtterizeServiceIdentity) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_OtterizeServiceIdentity_resolutionData(ctx, field)
 	if err != nil {
@@ -3443,6 +3497,8 @@ func (ec *executionContext) fieldContext_ServiceIntents_client(ctx context.Conte
 				return ec.fieldContext_OtterizeServiceIdentity_namespace(ctx, field)
 			case "labels":
 				return ec.fieldContext_OtterizeServiceIdentity_labels(ctx, field)
+			case "nameResolvedUsingAnnotations":
+				return ec.fieldContext_OtterizeServiceIdentity_nameResolvedUsingAnnotations(ctx, field)
 			case "resolutionData":
 				return ec.fieldContext_OtterizeServiceIdentity_resolutionData(ctx, field)
 			case "podOwnerKind":
@@ -3501,6 +3557,8 @@ func (ec *executionContext) fieldContext_ServiceIntents_intents(ctx context.Cont
 				return ec.fieldContext_OtterizeServiceIdentity_namespace(ctx, field)
 			case "labels":
 				return ec.fieldContext_OtterizeServiceIdentity_labels(ctx, field)
+			case "nameResolvedUsingAnnotations":
+				return ec.fieldContext_OtterizeServiceIdentity_nameResolvedUsingAnnotations(ctx, field)
 			case "resolutionData":
 				return ec.fieldContext_OtterizeServiceIdentity_resolutionData(ctx, field)
 			case "podOwnerKind":
@@ -6334,6 +6392,8 @@ func (ec *executionContext) _OtterizeServiceIdentity(ctx context.Context, sel as
 			}
 		case "labels":
 			out.Values[i] = ec._OtterizeServiceIdentity_labels(ctx, field, obj)
+		case "nameResolvedUsingAnnotations":
+			out.Values[i] = ec._OtterizeServiceIdentity_nameResolvedUsingAnnotations(ctx, field, obj)
 		case "resolutionData":
 			out.Values[i] = ec._OtterizeServiceIdentity_resolutionData(ctx, field, obj)
 		case "podOwnerKind":

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -123,10 +123,11 @@ type NamespacedName struct {
 }
 
 type OtterizeServiceIdentity struct {
-	Name           string                  `json:"name"`
-	Namespace      string                  `json:"namespace"`
-	Labels         []PodLabel              `json:"labels,omitempty"`
-	ResolutionData *IdentityResolutionData `json:"resolutionData,omitempty"`
+	Name                        string                  `json:"name"`
+	Namespace                   string                  `json:"namespace"`
+	Labels                      []PodLabel              `json:"labels,omitempty"`
+	NameResolvedUsingAnnotation *bool                   `json:"nameResolvedUsingAnnotations,omitempty"`
+	ResolutionData              *IdentityResolutionData `json:"resolutionData,omitempty"`
 	// If the service identity was resolved from a pod owner, the GroupVersionKind of the pod owner.
 	PodOwnerKind *GroupVersionKind `json:"podOwnerKind,omitempty"`
 	// If the service identity was resolved from a Kubernetes service, its name.

--- a/src/mapper/pkg/kubefinder/kubefinder.go
+++ b/src/mapper/pkg/kubefinder/kubefinder.go
@@ -483,10 +483,11 @@ func (k *KubeFinder) ResolveOtterizeIdentityForService(ctx context.Context, svc 
 	resolutionData.Uptime = lo.ToPtr(time.Since(pod.CreationTimestamp.Time).String())
 
 	dstSvcIdentity := model.OtterizeServiceIdentity{
-		Name:           dstService.Name,
-		Namespace:      pod.Namespace,
-		Labels:         PodLabelsToOtterizeLabels(&pod),
-		ResolutionData: &resolutionData,
+		Name:                        dstService.Name,
+		Namespace:                   pod.Namespace,
+		Labels:                      PodLabelsToOtterizeLabels(&pod),
+		ResolutionData:              &resolutionData,
+		NameResolvedUsingAnnotation: dstService.ResolvedUsingOverrideAnnotation,
 	}
 
 	if dstService.OwnerObject != nil {

--- a/src/mapper/pkg/resolvers/helpers.go
+++ b/src/mapper/pkg/resolvers/helpers.go
@@ -87,9 +87,10 @@ func (r *Resolver) resolveInClusterIdentity(ctx context.Context, pod *corev1.Pod
 	}
 
 	modelSvcIdentity := model.OtterizeServiceIdentity{
-		Name:      svcIdentity.Name,
-		Namespace: pod.Namespace,
-		Labels:    kubefinder.PodLabelsToOtterizeLabels(pod),
+		Name:                        svcIdentity.Name,
+		Namespace:                   pod.Namespace,
+		Labels:                      kubefinder.PodLabelsToOtterizeLabels(pod),
+		NameResolvedUsingAnnotation: svcIdentity.ResolvedUsingOverrideAnnotation,
 		ResolutionData: &model.IdentityResolutionData{
 			Host:              lo.ToPtr(pod.Status.PodIP),
 			PodHostname:       lo.ToPtr(pod.Name),

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -111,9 +111,10 @@ func (r *Resolver) resolveDestIdentityTCP(ctx context.Context, dest model.Destin
 	}
 
 	dstSvcIdentity := model.OtterizeServiceIdentity{
-		Name:      dstService.Name,
-		Namespace: destPod.Namespace,
-		Labels:    kubefinder.PodLabelsToOtterizeLabels(destPod),
+		Name:                        dstService.Name,
+		Namespace:                   destPod.Namespace,
+		Labels:                      kubefinder.PodLabelsToOtterizeLabels(destPod),
+		NameResolvedUsingAnnotation: dstService.ResolvedUsingOverrideAnnotation,
 		ResolutionData: &model.IdentityResolutionData{
 			Host:              lo.ToPtr(dest.Destination),
 			PodHostname:       lo.ToPtr(destPod.Name),
@@ -193,9 +194,10 @@ func (r *Resolver) addSocketScanPodIntent(ctx context.Context, srcSvcIdentity mo
 		return errors.Wrap(err)
 	}
 	dstSvcIdentity := &model.OtterizeServiceIdentity{
-		Name:      dstService.Name,
-		Namespace: destPod.Namespace,
-		Labels:    kubefinder.PodLabelsToOtterizeLabels(destPod),
+		Name:                        dstService.Name,
+		Namespace:                   destPod.Namespace,
+		Labels:                      kubefinder.PodLabelsToOtterizeLabels(destPod),
+		NameResolvedUsingAnnotation: dstService.ResolvedUsingOverrideAnnotation,
 		ResolutionData: &model.IdentityResolutionData{
 			Host:              lo.ToPtr(dest.Destination),
 			PodHostname:       lo.ToPtr(destPod.Name),
@@ -487,6 +489,9 @@ func (r *Resolver) resolveOtterizeIdentityForDestinationAddress(ctx context.Cont
 	}
 	if serviceName.Name != "" {
 		dstSvcIdentity.KubernetesService = &serviceName.Name
+	}
+	if dstSvcIdentity.NameResolvedUsingAnnotation != nil {
+		dstSvcIdentity.NameResolvedUsingAnnotation = dstService.ResolvedUsingOverrideAnnotation
 	}
 	return dstSvcIdentity, true, nil
 }
@@ -823,8 +828,8 @@ func (r *Resolver) handleReportIstioConnectionResults(ctx context.Context, resul
 			continue
 		}
 
-		srcSvcIdentity := model.OtterizeServiceIdentity{Name: srcService.Name, Namespace: srcPod.Namespace, Labels: kubefinder.PodLabelsToOtterizeLabels(srcPod)}
-		dstSvcIdentity := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: dstPod.Namespace, Labels: kubefinder.PodLabelsToOtterizeLabels(dstPod)}
+		srcSvcIdentity := model.OtterizeServiceIdentity{Name: srcService.Name, Namespace: srcPod.Namespace, Labels: kubefinder.PodLabelsToOtterizeLabels(srcPod), NameResolvedUsingAnnotation: srcService.ResolvedUsingOverrideAnnotation}
+		dstSvcIdentity := model.OtterizeServiceIdentity{Name: dstService.Name, Namespace: dstPod.Namespace, Labels: kubefinder.PodLabelsToOtterizeLabels(dstPod), NameResolvedUsingAnnotation: dstService.ResolvedUsingOverrideAnnotation}
 		if srcService.OwnerObject != nil {
 			srcSvcIdentity.PodOwnerKind = model.GroupVersionKindFromKubeGVK(srcService.OwnerObject.GetObjectKind().GroupVersionKind())
 		}

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -55,6 +55,7 @@ type OtterizeServiceIdentity {
     name: String!
     namespace: String!
     labels: [PodLabel!]
+    nameResolvedUsingAnnotation: Boolean
     resolutionData: IdentityResolutionData
     """
     If the service identity was resolved from a pod owner, the GroupVersionKind of the pod owner.


### PR DESCRIPTION
### Description

Improve cloud clientIntents suggestions by informing the cloud when a workload is using the workloadName override annotation

### References

https://github.com/otterize/intents-operator/pull/580/commits
https://docs.otterize.com/reference/workload-identities

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
