### PR TITLE
Fix issue where invalid traffic reports were reported to Otterize Cloud

### DIFF
--- a/src/mapper/pkg/clouduploader/cloud_upload.go
+++ b/src/mapper/pkg/clouduploader/cloud_upload.go
@@ -309,10 +309,10 @@ func (c *CloudUploader) NotifyTrafficLevels(ctx context.Context, trafficLevels t
 	var inputs []cloudclient.TrafficLevelInput
 	for trafficPair, trafficData := range trafficLevels {
 		inputs = append(inputs, cloudclient.TrafficLevelInput{
-			ClientName:          trafficPair.Source.Name,
-			ClientNamespace:     trafficPair.Source.Namespace,
-			ServerName:          trafficPair.Destination.Name,
-			ServerNamespace:     trafficPair.Destination.Namespace,
+			ClientName:          trafficPair.SourceName,
+			ClientNamespace:     trafficPair.SourceNamespace,
+			ServerName:          trafficPair.DestinationName,
+			ServerNamespace:     trafficPair.DestinationNamespace,
 			DataBytesPerSecond:  trafficData.Bytes,
 			FlowsCountPerSecond: trafficData.Flows,
 		})

--- a/src/mapper/pkg/collectors/traffic/collector.go
+++ b/src/mapper/pkg/collectors/traffic/collector.go
@@ -7,8 +7,10 @@ import (
 )
 
 type TrafficLevelKey struct {
-	Source      serviceidentity.ServiceIdentity
-	Destination serviceidentity.ServiceIdentity
+	SourceName           string
+	SourceNamespace      string
+	DestinationName      string
+	DestinationNamespace string
 }
 
 type TrafficLevelData struct {
@@ -34,8 +36,10 @@ func NewCollector() *Collector {
 
 func (c *Collector) Add(source, destination serviceidentity.ServiceIdentity, bytes, flows int) {
 	trafficKey := TrafficLevelKey{
-		Source:      source,
-		Destination: destination,
+		SourceName:           source.Name,
+		SourceNamespace:      source.Namespace,
+		DestinationName:      destination.Name,
+		DestinationNamespace: destination.Namespace,
 	}
 
 	c.trafficLevels[trafficKey] = append(c.trafficLevels[trafficKey], TrafficLevelData{

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -394,6 +394,18 @@ func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.T
 			continue
 		}
 
+		if sourceIdentity.Name == "" || destinationIdentity.Name == "" || sourceIdentity.Namespace == "" || destinationIdentity.Namespace == "" {
+			// catches a bug where the source or destination identity is not set, without any other errors
+			logrus.
+				WithContext(ctx).
+				WithField("sourceIP", report.SrcIP).
+				WithField("destinationIP", report.DstIP).
+				WithField("sourceIdentity", sourceIdentity).
+				WithField("destinationIdentity", destinationIdentity).
+				Error("invalid traffic level report")
+			continue
+		}
+
 		r.trafficCollector.Add(
 			sourceIdentity,
 			destinationIdentity,

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -912,18 +912,23 @@ func (r *Resolver) resolveIPToIdentity(ctx context.Context, ip string) (servicei
 		}
 	} else {
 		sourceService, ok, err := r.kubeFinder.ResolveIPToService(ctx, ip)
-
-		if !ok || err != nil {
+		if !ok {
+			err = errors.New("no mapping between IP and service")
+		}
+		if err != nil {
 			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source service")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 
 		otrSourceIdentity, ok, err := r.kubeFinder.ResolveOtterizeIdentityForService(ctx, sourceService, time.Now())
-
-		if !ok || err != nil {
+		if !ok {
+			err = errors.New("no mapping between service and otterize identity")
+		}
+		if err != nil {
 			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source identity")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
+
 		identity = serviceidentity.ServiceIdentity{
 			Name:      otrSourceIdentity.Name,
 			Namespace: otrSourceIdentity.Namespace,

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -380,7 +380,7 @@ func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.T
 			logrus.
 				WithField("ip", report.SrcIP).
 				WithError(err).
-				Error("Could not resolve source IP to identity")
+				Debug("could not resolve source IP to identity")
 			continue
 		}
 
@@ -390,7 +390,7 @@ func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.T
 			logrus.
 				WithField("ip", report.DstIP).
 				WithError(err).
-				Error("Could not resolve destination IP to identity")
+				Debug("could not resolve destination IP to identity")
 			continue
 		}
 
@@ -400,8 +400,8 @@ func (r *Resolver) handleTrafficLevelReport(ctx context.Context, results model.T
 				WithContext(ctx).
 				WithField("sourceIP", report.SrcIP).
 				WithField("destinationIP", report.DstIP).
-				WithField("sourceIdentity", sourceIdentity).
-				WithField("destinationIdentity", destinationIdentity).
+				WithField("sourceIdentity", sourceIdentity.String()).
+				WithField("destinationIdentity", destinationIdentity.String()).
 				Error("invalid traffic level report")
 			continue
 		}
@@ -892,7 +892,6 @@ func (r *Resolver) resolveIPToIdentity(ctx context.Context, ip string) (servicei
 	isPod, err := r.kubeFinder.IsPodIp(ctx, ip)
 
 	if err != nil {
-		logrus.WithField("ip", ip).WithError(err).Error("could not determine if IP is a pod")
 		return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 	}
 
@@ -900,14 +899,12 @@ func (r *Resolver) resolveIPToIdentity(ctx context.Context, ip string) (servicei
 		sourcePod, err := r.kubeFinder.ResolveIPToPod(ctx, ip)
 
 		if err != nil {
-			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source pod")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 
 		identity, err = r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, sourcePod)
 
 		if err != nil {
-			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source identity")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 	} else {
@@ -916,7 +913,6 @@ func (r *Resolver) resolveIPToIdentity(ctx context.Context, ip string) (servicei
 			err = errors.New("no mapping between IP and service")
 		}
 		if err != nil {
-			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source service")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 
@@ -925,7 +921,6 @@ func (r *Resolver) resolveIPToIdentity(ctx context.Context, ip string) (servicei
 			err = errors.New("no mapping between service and otterize identity")
 		}
 		if err != nil {
-			logrus.WithField("ip", ip).WithError(err).Error("could not resolve source identity")
 			return serviceidentity.ServiceIdentity{}, errors.Wrap(err)
 		}
 


### PR DESCRIPTION
### Description

After enabling traffic levels, we encountered two issues:
1. The client or server name were sent as empty. If there had been an error resolving, the report should not have been sent at all, and error would be emitted. Added a specific check for this.
2. Reports are not being combined correctly - indexing by name and namespace only, not other fields in `ServiceIdentity`.


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
