### PR TITLE
Fix issue with traffic originating from Kubernetes control plane not being detected correctly on GKE, by configuring control-plane-ipv4-cidr-subnet-mask

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263
 	github.com/otterize/go-procnet v0.1.1
-	github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc
+	github.com/otterize/intents-operator/src v0.0.0-20250324163132-333fa205b668
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f
 	github.com/prometheus/client_golang v1.18.0
 	github.com/samber/lo v1.47.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -309,8 +309,8 @@ github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263 h1:Qd1Ml+uEhpesT8Og
 github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263/go.mod h1:odkMeLkWS8G6+WP2z3Pn2vkzhPSvBtFhAUYTKXAtZMQ=
 github.com/otterize/go-procnet v0.1.1 h1:5vRwX35VrsWcy2uP05sA4PmwpRoAu2L4vMJou4og8Kk=
 github.com/otterize/go-procnet v0.1.1/go.mod h1:WEm282HzrSVBZg6DX2fNB4dpVHBPTCjzHWvqOfauV+Q=
-github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc h1:GMGaWur2z5S6kSMpCHalDQ2n1MmfTjdbZjHCkOeIo/Q=
-github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
+github.com/otterize/intents-operator/src v0.0.0-20250324163132-333fa205b668 h1:H+DNpscShT1wG4tXfjch7J+qBavqNyHHglAnUtDbYmQ=
+github.com/otterize/intents-operator/src v0.0.0-20250324163132-333fa205b668/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f/go.mod h1:9SNBrJbNRAl1isohKk/t1Px85HuxPFylfMmOMVtCg2Q=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -48,6 +48,9 @@ const (
 	MetricFetchTimeoutDefault                 = 10 * time.Second
 	TimeServerHasToLiveBeforeWeTrustItKey     = "time-server-has-to-live-before-we-trust-it"
 	TimeServerHasToLiveBeforeWeTrustItDefault = 5 * time.Minute
+
+	ControlPlaneIPv4CidrSubnetMask        = "control-plane-ipv4-cidr-subnet-mask"
+	ControlPlaneIPv4CidrSubnetMaskDefault = "/32"
 )
 
 var excludedNamespaces *goset.Set[string]
@@ -77,5 +80,7 @@ func init() {
 	viper.SetDefault(ServiceCacheTTLDurationKey, ServiceCacheTTLDurationDefault)
 	viper.SetDefault(ServiceCacheSizeKey, ServiceCacheSizeDefault)
 	viper.SetDefault(TimeServerHasToLiveBeforeWeTrustItKey, TimeServerHasToLiveBeforeWeTrustItDefault)
+	viper.SetDefault(ControlPlaneIPv4CidrSubnetMask, ControlPlaneIPv4CidrSubnetMaskDefault)
+
 	excludedNamespaces = goset.FromSlice(viper.GetStringSlice(ExcludedNamespacesKey))
 }

--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -49,8 +49,8 @@ const (
 	TimeServerHasToLiveBeforeWeTrustItKey     = "time-server-has-to-live-before-we-trust-it"
 	TimeServerHasToLiveBeforeWeTrustItDefault = 5 * time.Minute
 
-	ControlPlaneIPv4CidrSubnetMask        = "control-plane-ipv4-cidr-subnet-mask"
-	ControlPlaneIPv4CidrSubnetMaskDefault = "/32"
+	ControlPlaneIPv4CidrPrefixLength        = "control-plane-ipv4-cidr-prefix-length"
+	ControlPlaneIPv4CidrPrefixLengthDefault = 32
 )
 
 var excludedNamespaces *goset.Set[string]
@@ -80,7 +80,7 @@ func init() {
 	viper.SetDefault(ServiceCacheTTLDurationKey, ServiceCacheTTLDurationDefault)
 	viper.SetDefault(ServiceCacheSizeKey, ServiceCacheSizeDefault)
 	viper.SetDefault(TimeServerHasToLiveBeforeWeTrustItKey, TimeServerHasToLiveBeforeWeTrustItDefault)
-	viper.SetDefault(ControlPlaneIPv4CidrSubnetMask, ControlPlaneIPv4CidrSubnetMaskDefault)
+	viper.SetDefault(ControlPlaneIPv4CidrPrefixLength, ControlPlaneIPv4CidrPrefixLengthDefault)
 
 	excludedNamespaces = goset.FromSlice(viper.GetStringSlice(ExcludedNamespacesKey))
 }

--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -55,6 +55,9 @@ func (s *KubeFinderTestSuite) TestResolveIpToControlPlaneSubnet() {
 	endpoints := s.GetAPIServerEndpoints()
 	endpointIP := endpoints.Subsets[0].Addresses[0].IP
 	viper.Set(config.ControlPlaneIPv4CidrPrefixLength, "28")
+	defer func() {
+		viper.Set(config.ControlPlaneIPv4CidrPrefixLength, config.ControlPlaneIPv4CidrPrefixLengthDefault)
+	}()
 
 	_, subnet, err := net.ParseCIDR(fmt.Sprintf("%s/28", endpointIP))
 	s.Require().NoError(err)

--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -3,10 +3,13 @@ package kubefinder
 import (
 	"context"
 	"fmt"
+	"github.com/otterize/network-mapper/src/mapper/pkg/config"
 	"github.com/otterize/network-mapper/src/shared/testbase"
 	"github.com/samber/lo"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
+	"net"
 	"testing"
 )
 
@@ -36,6 +39,34 @@ func (s *KubeFinderTestSuite) TestResolveIpToPod() {
 	s.Require().NoError(err)
 	s.Require().Equal("test-pod", pod.Name)
 
+}
+
+func (s *KubeFinderTestSuite) TestResolveIpToControlPlane() {
+	endpoints := s.GetAPIServerEndpoints()
+	endpointIP := endpoints.Subsets[0].Addresses[0].IP
+	pod, found, err := s.kubeFinder.ResolveIPToControlPlane(context.Background(), endpointIP)
+	s.Require().NoError(err)
+	s.Require().True(found)
+	s.Require().Equal("kubernetes", pod.Name)
+	s.Require().Equal("default", pod.Namespace)
+}
+
+func (s *KubeFinderTestSuite) TestResolveIpToControlPlaneSubnet() {
+	endpoints := s.GetAPIServerEndpoints()
+	endpointIP := endpoints.Subsets[0].Addresses[0].IP
+	viper.Set(config.ControlPlaneIPv4CidrPrefixLength, "28")
+
+	_, subnet, err := net.ParseCIDR(fmt.Sprintf("%s/28", endpointIP))
+	s.Require().NoError(err)
+
+	// iterate over IPs in the same subnet (only increment the last byte for simplicity)
+	for ip := subnet.IP.Mask(subnet.Mask).To4(); subnet.Contains(ip); ip[3]++ {
+		pod, found, err := s.kubeFinder.ResolveIPToControlPlane(context.Background(), ip.String())
+		s.Require().NoError(err)
+		s.Require().True(found)
+		s.Require().Equal("kubernetes", pod.Name)
+		s.Require().Equal("default", pod.Namespace)
+	}
 }
 
 func (s *KubeFinderTestSuite) TestResolveServiceAddressToIps() {

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -322,6 +322,23 @@ func (s *ControllerManagerTestSuiteBase) GetAPIServerService() *corev1.Service {
 	return service
 }
 
+func (s *ControllerManagerTestSuiteBase) GetAPIServerEndpoints() *corev1.Endpoints {
+	endpoints := &corev1.Endpoints{}
+	s.Require().NoError(wait.PollUntilContextTimeout(context.Background(),
+		waitForCreationInterval,
+		waitForCreationTimeout,
+		true,
+		func(ctx context.Context) (done bool, err error) {
+			err = s.Mgr.GetClient().Get(ctx, types.NamespacedName{Name: "kubernetes", Namespace: "default"}, endpoints)
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		}),
+	)
+	return endpoints
+}
+
 func (s *ControllerManagerTestSuiteBase) AddReplicaSet(name string, podIps []string, podLabels map[string]string) (*appsv1.ReplicaSet, []*corev1.Pod) {
 	replicaSet := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("replicaset-%s", name), Namespace: s.TestNamespace},


### PR DESCRIPTION
### Description
This PR solves an issue with the network-mapper when running on specific GKE configurations, where traffic originating from the kubernetes control plane may come from various IP addresses in an IPv4 subnet reserved to it by the cluster settings. By default, on GKE, this would be the "/28" subnet of the kubernetes.default service endpoint. This has to be provided as external configuration on deployment time, as there is no way to query this info from within the cluster (without google API access permissions). 

For other cloud vendors, no such setting exists by default, and so the existing behavior of matching the exact private endpoint IP is maintained as default. 

### References
https://cloud.google.com/kubernetes-engine/docs/best-practices/networking


### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist
- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
