### PR TITLE
Bugfix: point to the latest version of intents operator in go dependencies 

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263
 	github.com/otterize/go-procnet v0.1.1
-	github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc
+	github.com/otterize/intents-operator/src v0.0.0-20250324163132-333fa205b668
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f
 	github.com/prometheus/client_golang v1.18.0
 	github.com/samber/lo v1.47.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -309,8 +309,8 @@ github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263 h1:Qd1Ml+uEhpesT8Og
 github.com/oriser/regroup v0.0.0-20210730155327-fca8d7531263/go.mod h1:odkMeLkWS8G6+WP2z3Pn2vkzhPSvBtFhAUYTKXAtZMQ=
 github.com/otterize/go-procnet v0.1.1 h1:5vRwX35VrsWcy2uP05sA4PmwpRoAu2L4vMJou4og8Kk=
 github.com/otterize/go-procnet v0.1.1/go.mod h1:WEm282HzrSVBZg6DX2fNB4dpVHBPTCjzHWvqOfauV+Q=
-github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc h1:GMGaWur2z5S6kSMpCHalDQ2n1MmfTjdbZjHCkOeIo/Q=
-github.com/otterize/intents-operator/src v0.0.0-20250323173807-a864651a1bfc/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
+github.com/otterize/intents-operator/src v0.0.0-20250324163132-333fa205b668 h1:H+DNpscShT1wG4tXfjch7J+qBavqNyHHglAnUtDbYmQ=
+github.com/otterize/intents-operator/src v0.0.0-20250324163132-333fa205b668/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f/go.mod h1:9SNBrJbNRAl1isohKk/t1Px85HuxPFylfMmOMVtCg2Q=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=


### PR DESCRIPTION
### Description
Point to the latest version of intents operator

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
