### PR TITLE
Report network policies to the cloud for better insights on unused policies and blocked traffic

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -40,6 +40,7 @@ require (
 	go.uber.org/mock v0.2.0
 	golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874
 	golang.org/x/sync v0.10.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.29.0
 	k8s.io/apiextensions-apiserver v0.29.0
@@ -141,7 +142,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -40,13 +40,13 @@ require (
 	go.uber.org/mock v0.2.0
 	golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874
 	golang.org/x/sync v0.10.0
-	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.29.0
 	k8s.io/apiextensions-apiserver v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
 	sigs.k8s.io/controller-runtime v0.17.2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -142,11 +142,11 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/externaltrafficholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/gcpintentsholder"
 	"github.com/otterize/network-mapper/src/mapper/pkg/incomingtrafficholder"
+	"github.com/otterize/network-mapper/src/mapper/pkg/networkpolicyreport"
 	"github.com/otterize/network-mapper/src/mapper/pkg/resourcevisibility"
 	"github.com/otterize/network-mapper/src/shared/echologrus"
 	"golang.org/x/sync/errgroup"
@@ -229,6 +230,11 @@ func main() {
 		serviceReconciler := resourcevisibility.NewServiceReconciler(mgr.GetClient(), cloudClient, kubeFinder)
 		if err := serviceReconciler.SetupWithManager(mgr); err != nil {
 			logrus.WithError(err).Panic("unable to create service reconciler")
+		}
+
+		netpolReconciler := networkpolicyreport.NewNetworkPolicyReconciler(mgr.GetClient(), cloudClient)
+		if err := netpolReconciler.SetupWithManager(mgr); err != nil {
+			logrus.WithError(err).Panic("unable to create network policy reconciler")
 		}
 	}
 

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -16,6 +16,7 @@ type CloudClient interface {
 	ReportK8sServices(ctx context.Context, namespace string, services []K8sServiceInput) error
 	ReportK8sIngresses(ctx context.Context, namespace string, ingresses []K8sIngressInput) error
 	ReportTrafficLevels(ctx context.Context, trafficLevels []TrafficLevelInput) error
+	ReportNetworkPolicies(ctx context.Context, namespace string, policies []NetworkPolicyInput) error
 }
 
 type CloudClientImpl struct {
@@ -108,6 +109,28 @@ func (c *CloudClientImpl) ReportTrafficLevels(
 		ctx,
 		c.client,
 		trafficLevels,
+	)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func (c *CloudClientImpl) ReportNetworkPolicies(
+	ctx context.Context,
+	namespace string,
+	policies []NetworkPolicyInput,
+) error {
+	logrus.WithField("namespace", namespace).
+		WithField("count", len(policies)).
+		Infof("Reporting network policies")
+
+	_, err := ReportNetworkPolicies(
+		ctx,
+		c.client,
+		namespace,
+		policies,
 	)
 	if err != nil {
 		return errors.Wrap(err)

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -900,6 +900,16 @@ func (v *ReportNamespaceLabelsResponse) GetReportNamespaceLabels() bool {
 	return v.ReportNamespaceLabels
 }
 
+// ReportNetworkPoliciesResponse is returned by ReportNetworkPolicies on success.
+type ReportNetworkPoliciesResponse struct {
+	ReportNetworkPolicies bool `json:"reportNetworkPolicies"`
+}
+
+// GetReportNetworkPolicies returns ReportNetworkPoliciesResponse.ReportNetworkPolicies, and is useful for accessing the field via an interface.
+func (v *ReportNetworkPoliciesResponse) GetReportNetworkPolicies() bool {
+	return v.ReportNetworkPolicies
+}
+
 type ReportServiceMetadataInput struct {
 	Identity ServiceIdentityInput `json:"identity"`
 	Metadata ServiceMetadataInput `json:"metadata"`
@@ -910,16 +920,6 @@ func (v *ReportServiceMetadataInput) GetIdentity() ServiceIdentityInput { return
 
 // GetMetadata returns ReportServiceMetadataInput.Metadata, and is useful for accessing the field via an interface.
 func (v *ReportServiceMetadataInput) GetMetadata() ServiceMetadataInput { return v.Metadata }
-
-// ReportNetworkPoliciesResponse is returned by ReportNetworkPolicies on success.
-type ReportNetworkPoliciesResponse struct {
-	ReportNetworkPolicies bool `json:"reportNetworkPolicies"`
-}
-
-// GetReportNetworkPolicies returns ReportNetworkPoliciesResponse.ReportNetworkPolicies, and is useful for accessing the field via an interface.
-func (v *ReportNetworkPoliciesResponse) GetReportNetworkPolicies() bool {
-	return v.ReportNetworkPolicies
-}
 
 // ReportTrafficLevelsResponse is returned by ReportTrafficLevels on success.
 type ReportTrafficLevelsResponse struct {
@@ -1124,6 +1124,32 @@ func (v *__ReportK8sServicesInput) GetNamespace() string { return v.Namespace }
 
 // GetServices returns __ReportK8sServicesInput.Services, and is useful for accessing the field via an interface.
 func (v *__ReportK8sServicesInput) GetServices() []K8sServiceInput { return v.Services }
+
+// __ReportNamespaceLabelsInput is used internally by genqlient
+type __ReportNamespaceLabelsInput struct {
+	Name   string       `json:"name"`
+	Labels []LabelInput `json:"labels"`
+}
+
+// GetName returns __ReportNamespaceLabelsInput.Name, and is useful for accessing the field via an interface.
+func (v *__ReportNamespaceLabelsInput) GetName() string { return v.Name }
+
+// GetLabels returns __ReportNamespaceLabelsInput.Labels, and is useful for accessing the field via an interface.
+func (v *__ReportNamespaceLabelsInput) GetLabels() []LabelInput { return v.Labels }
+
+// __ReportNetworkPoliciesInput is used internally by genqlient
+type __ReportNetworkPoliciesInput struct {
+	Namespace       string               `json:"namespace"`
+	NetworkPolicies []NetworkPolicyInput `json:"networkPolicies"`
+}
+
+// GetNamespace returns __ReportNetworkPoliciesInput.Namespace, and is useful for accessing the field via an interface.
+func (v *__ReportNetworkPoliciesInput) GetNamespace() string { return v.Namespace }
+
+// GetNetworkPolicies returns __ReportNetworkPoliciesInput.NetworkPolicies, and is useful for accessing the field via an interface.
+func (v *__ReportNetworkPoliciesInput) GetNetworkPolicies() []NetworkPolicyInput {
+	return v.NetworkPolicies
+}
 
 // __ReportTrafficLevelsInput is used internally by genqlient
 type __ReportTrafficLevelsInput struct {
@@ -1334,6 +1360,76 @@ func ReportK8sServices(
 	var err_ error
 
 	var data_ ReportK8sServicesResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by ReportNamespaceLabels.
+const ReportNamespaceLabels_Operation = `
+mutation ReportNamespaceLabels ($name: String!, $labels: [LabelInput!]!) {
+	reportNamespaceLabels(name: $name, labels: $labels)
+}
+`
+
+func ReportNamespaceLabels(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	name string,
+	labels []LabelInput,
+) (*ReportNamespaceLabelsResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportNamespaceLabels",
+		Query:  ReportNamespaceLabels_Operation,
+		Variables: &__ReportNamespaceLabelsInput{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+	var err_ error
+
+	var data_ ReportNamespaceLabelsResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by ReportNetworkPolicies.
+const ReportNetworkPolicies_Operation = `
+mutation ReportNetworkPolicies ($namespace: String!, $networkPolicies: [NetworkPolicyInput!]!) {
+	reportNetworkPolicies(namespace: $namespace, networkPolicies: $networkPolicies)
+}
+`
+
+func ReportNetworkPolicies(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	networkPolicies []NetworkPolicyInput,
+) (*ReportNetworkPoliciesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportNetworkPolicies",
+		Query:  ReportNetworkPolicies_Operation,
+		Variables: &__ReportNetworkPoliciesInput{
+			Namespace:       namespace,
+			NetworkPolicies: networkPolicies,
+		},
+	}
+	var err_ error
+
+	var data_ ReportNetworkPoliciesResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -788,6 +788,17 @@ const (
 	LoadBalancerIPModeProxy LoadBalancerIPMode = "PROXY"
 )
 
+type NetworkPolicyInput struct {
+	Name string `json:"name"`
+	Yaml string `json:"yaml"`
+}
+
+// GetName returns NetworkPolicyInput.Name, and is useful for accessing the field via an interface.
+func (v *NetworkPolicyInput) GetName() string { return v.Name }
+
+// GetYaml returns NetworkPolicyInput.Yaml, and is useful for accessing the field via an interface.
+func (v *NetworkPolicyInput) GetYaml() string { return v.Yaml }
+
 type PathType string
 
 const (
@@ -867,6 +878,16 @@ type ReportK8sServicesResponse struct {
 
 // GetReportK8sServices returns ReportK8sServicesResponse.ReportK8sServices, and is useful for accessing the field via an interface.
 func (v *ReportK8sServicesResponse) GetReportK8sServices() bool { return v.ReportK8sServices }
+
+// ReportNetworkPoliciesResponse is returned by ReportNetworkPolicies on success.
+type ReportNetworkPoliciesResponse struct {
+	ReportNetworkPolicies bool `json:"reportNetworkPolicies"`
+}
+
+// GetReportNetworkPolicies returns ReportNetworkPoliciesResponse.ReportNetworkPolicies, and is useful for accessing the field via an interface.
+func (v *ReportNetworkPoliciesResponse) GetReportNetworkPolicies() bool {
+	return v.ReportNetworkPolicies
+}
 
 // ReportTrafficLevelsResponse is returned by ReportTrafficLevels on success.
 type ReportTrafficLevelsResponse struct {
@@ -1024,6 +1045,20 @@ func (v *__ReportK8sServicesInput) GetNamespace() string { return v.Namespace }
 
 // GetServices returns __ReportK8sServicesInput.Services, and is useful for accessing the field via an interface.
 func (v *__ReportK8sServicesInput) GetServices() []K8sServiceInput { return v.Services }
+
+// __ReportNetworkPoliciesInput is used internally by genqlient
+type __ReportNetworkPoliciesInput struct {
+	Namespace       string               `json:"namespace"`
+	NetworkPolicies []NetworkPolicyInput `json:"networkPolicies"`
+}
+
+// GetNamespace returns __ReportNetworkPoliciesInput.Namespace, and is useful for accessing the field via an interface.
+func (v *__ReportNetworkPoliciesInput) GetNamespace() string { return v.Namespace }
+
+// GetNetworkPolicies returns __ReportNetworkPoliciesInput.NetworkPolicies, and is useful for accessing the field via an interface.
+func (v *__ReportNetworkPoliciesInput) GetNetworkPolicies() []NetworkPolicyInput {
+	return v.NetworkPolicies
+}
 
 // __ReportTrafficLevelsInput is used internally by genqlient
 type __ReportTrafficLevelsInput struct {
@@ -1224,6 +1259,41 @@ func ReportK8sServices(
 	var err_ error
 
 	var data_ ReportK8sServicesResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by ReportNetworkPolicies.
+const ReportNetworkPolicies_Operation = `
+mutation ReportNetworkPolicies ($namespace: String!, $networkPolicies: [NetworkPolicyInput!]!) {
+	reportNetworkPolicies(namespace: $namespace, networkPolicies: $networkPolicies)
+}
+`
+
+func ReportNetworkPolicies(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	networkPolicies []NetworkPolicyInput,
+) (*ReportNetworkPoliciesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportNetworkPolicies",
+		Query:  ReportNetworkPolicies_Operation,
+		Variables: &__ReportNetworkPoliciesInput{
+			Namespace:       namespace,
+			NetworkPolicies: networkPolicies,
+		},
+	}
+	var err_ error
+
+	var data_ ReportNetworkPoliciesResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -28,3 +28,7 @@ mutation ReportTrafficLevels(
 ) {
     reportTrafficLevels(trafficLevels: $trafficLevels)
 }
+
+mutation ReportNetworkPolicies($namespace: String!, $networkPolicies: [NetworkPolicyInput!]!) {
+    reportNetworkPolicies(namespace: $namespace, networkPolicies: $networkPolicies)
+}

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -119,6 +119,20 @@ func (mr *MockCloudClientMockRecorder) ReportK8sServices(ctx, namespace, service
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportK8sServices", reflect.TypeOf((*MockCloudClient)(nil).ReportK8sServices), ctx, namespace, services)
 }
 
+// ReportNetworkPolicies mocks base method.
+func (m *MockCloudClient) ReportNetworkPolicies(ctx context.Context, namespace string, policies []cloudclient.NetworkPolicyInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReportNetworkPolicies", ctx, namespace, policies)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReportNetworkPolicies indicates an expected call of ReportNetworkPolicies.
+func (mr *MockCloudClientMockRecorder) ReportNetworkPolicies(ctx, namespace, policies interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportNetworkPolicies", reflect.TypeOf((*MockCloudClient)(nil).ReportNetworkPolicies), ctx, namespace, policies)
+}
+
 // ReportTrafficLevels mocks base method.
 func (m *MockCloudClient) ReportTrafficLevels(ctx context.Context, trafficLevels []cloudclient.TrafficLevelInput) error {
 	m.ctrl.T.Helper()

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -215,6 +215,7 @@ type AccessLogEdge {
 	accessStatus: EdgeAccessStatus!
 }
 
+""" This enum should be removed after removing allowExternalTrafficPolicy from IntentsOperatorConfigurationInput, it is here for backward compatibility """
 enum AllowExternalTrafficPolicy {
 	OFF
 	ALWAYS
@@ -272,6 +273,12 @@ type AppliedIntentsRequestWithDetails {
 	status: AppliedIntentsRequestStatusLabel!
 	reason: String
 	clientIntents: ClientIntentsFileRepresentation!
+}
+
+enum AutomateThirdPartyNetworkPolicy {
+	OFF
+	ALWAYS
+	IF_BLOCKED_BY_OTTERIZE
 }
 
 enum AwsIamStep {
@@ -722,6 +729,8 @@ enum EdgeAccessStatusReason {
 	BLOCKED_BY_DEFAULT_DENY_MISSING_EXTERNAL_TRAFFIC_POLICY
 	BLOCKED_BY_APPLIED_INTENTS_MISSING_EXTERNAL_TRAFFIC_POLICY
 	ALLOWED_BY_EXTERNALLY_MANAGED_NETWORK_POLICY
+	ALLOWED_BY_METRICS_COLLECTION_TRAFFIC_NETWORK_POLICY
+	WOULD_BE_ALLOWED_BY_METRICS_COLLECTION_TRAFFIC_NETWORK_POLICY
 }
 
 enum EdgeAccessStatusVerdict {
@@ -741,6 +750,11 @@ type EdgeAccessStatuses {
 	azureIAM: EdgeAccessStatus!
 	database: EdgeAccessStatus!
 	linkerdPolicies: EdgeAccessStatus!
+}
+
+enum EligibleForMetricsCollectionReason {
+	POD_ANNOTATIONS
+	SERVICE_ANNOTATIONS
 }
 
 type Environment {
@@ -1486,6 +1500,8 @@ input IntentsOperatorConfigurationInput {
 	awsALBLoadBalancerExemptionEnabled: Boolean
 	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
+	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
+	prometheusServerConfigs: [PrometheusServerConfigInput!]
 }
 
 type IntentsOperatorState {
@@ -1578,6 +1594,12 @@ enum K8sPortProtocol {
 	TCP
 	UDP
 	SCTP
+}
+
+input K8sResourceEligibleForMetricsCollectionInput {
+	namespace: String!
+	name: String!
+	kind: String!
 }
 
 input K8sResourceIngressInput {
@@ -2040,6 +2062,11 @@ type Mutation {
 		namespace: String!
 		ingresses: [K8sIngressInput!]!
 	): Boolean!
+	reportK8sResourceEligibleForMetricsCollection(
+		namespace: String!
+		reason: EligibleForMetricsCollectionReason!
+		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
+	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!
 		serverConfigs: [KafkaServerConfigInput!]!
@@ -2069,6 +2096,9 @@ type Mutation {
 		name: String
 		imageURL: String
 		settings: OrganizationSettingsInput
+	): Organization!
+	updateDomainsDefaultRole(
+		defaultRole: OrgMembershipRole!
 	): Organization!
 """Remove user from organization"""
 	removeUserFromOrganization(
@@ -2211,6 +2241,11 @@ type NetworkPolicyWorkload {
 	service: Service!
 }
 
+enum OrgMembershipRole {
+	ADMIN
+	VIEWER
+}
+
 type Organization {
 	id: ID!
 	name: String!
@@ -2225,6 +2260,7 @@ type OrganizationSettings {
 	enforcedRegulations: [String!]
 	ignoredCloudDomains: [String!]
 	defaultIntentsApprovalActionByEnv: [DefaultIntentsApprovalActionByEnv!]!
+	domainsDefaultRole: OrgMembershipRole!
 }
 
 input OrganizationSettingsInput {
@@ -2254,6 +2290,12 @@ input PortStatusInput {
 	port: Int!
 	protocol: K8sPortProtocol!
 	error: String
+}
+
+input PrometheusServerConfigInput {
+	name: String!
+	namespace: String!
+	kind: String!
 }
 
 input ProtectedServiceInput {

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -2067,11 +2067,6 @@ type Mutation {
 		reason: EligibleForMetricsCollectionReason!
 		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
 	): Boolean!
-	reportK8sResourceEligibleForMetricsCollection(
-		namespace: String!
-		reason: EligibleForMetricsCollectionReason!
-		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
-	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!
 		serverConfigs: [KafkaServerConfigInput!]!

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -1198,6 +1198,24 @@ input InputIntegrationAccessGraphFilter {
 	serviceFilterType: IDFilterOperators
 }
 
+""" Network policies filter """
+input InputNetworkPolicyFilter {
+""" Network policies filter """
+	search: String
+""" Network policies filter """
+	clusterIds: InputIDFilterValue
+""" Network policies filter """
+	namespaceIds: InputIDFilterValue
+""" Network policies filter """
+	environmentIds: InputIDFilterValue
+""" Network policies filter """
+	networkPolicyIds: InputIDFilterValue
+""" Network policies filter """
+	policyKinds: InputIDFilterValue
+""" Network policies filter """
+	since: InputTimeFilterValue
+}
+
 input InputResourceInventoryFilter {
 	serviceIds: InputIDFilterValue
 	environmentIds: InputIDFilterValue
@@ -1503,11 +1521,6 @@ type Invite {
 enum InviteStatus {
 	PENDING
 	ACCEPTED
-}
-
-input IpBlockInput {
-	cidr: String!
-	except: [String!]
 }
 
 enum IpFamilyPolicy {
@@ -1997,10 +2010,6 @@ type Mutation {
 		intents: [IntentInput!]!
 		ossClusterId: String
 	): Boolean!
-	reportNetworkPolicies(
-		namespace: String!
-		policies: [NetworkPolicyInput!]!
-	): Boolean!
 	reportExternallyAccessibleServices(
 		namespace: String!
 		services: [ExternallyAccessibleServiceInput!]!
@@ -2042,6 +2051,14 @@ type Mutation {
 		id: ID!
 		environmentId: ID
 	): Namespace!
+	reportNamespaceLabels(
+		name: String!
+		labels: [LabelInput!]
+	): Boolean!
+	reportNetworkPolicies(
+		namespace: String!
+		networkPolicies: [NetworkPolicyInput!]
+	): Boolean!
 """Create a new organization"""
 	createOrganization(
 		name: String
@@ -2159,20 +2176,39 @@ enum NetworkPoliciesStep {
 	COMPLETED
 }
 
-input NetworkPolicyEgressRuleInput {
-	to: [PeerInput!]!
+type NetworkPolicy {
+	id: ID!
+	name: String!
+	kind: NetworkPolicyKind!
+	cluster: Cluster!
+	namespace: Namespace
+	environment: Environment!
+	hits: Int!
+	workloads: [NetworkPolicyWorkload!]!
+	workloadsAffected: Int!
+	spec: String!
+	lastUsed: Time!
 }
 
 input NetworkPolicyInput {
-	namespace: String!
 	name: String!
-	serverName: String!
-	externalNetworkTrafficPolicy: Boolean!
-	spec: NetworkPolicySpecInput
+	yaml: String!
 }
 
-input NetworkPolicySpecInput {
-	egress: [NetworkPolicyEgressRuleInput!]
+enum NetworkPolicyKind {
+	NETWORK_POLICY
+	CILIUM_NETWORK_POLICY
+}
+
+enum NetworkPolicyScope {
+	PRIMARY
+	EGRESS
+	INGRESS
+}
+
+type NetworkPolicyWorkload {
+	scope: NetworkPolicyScope!
+	service: Service!
 }
 
 type Organization {
@@ -2212,10 +2248,6 @@ enum PathType {
 	IMPLEMENTATION_SPECIFIC
 	PREFIX
 	EXACT
-}
-
-input PeerInput {
-	ipBlock: IpBlockInput!
 }
 
 input PortStatusInput {
@@ -2262,6 +2294,10 @@ type Query {
 		targetServiceId: ID!
 		lastSeenAfter: Time!
 	): [String!]!
+	edgeNetworkPolicies(
+		clientServiceId: ID!
+		serverServiceId: ID!
+	): [NetworkPolicy!]!
 """Get access log"""
 	accessLog(
 		filter: InputAccessLogFilter
@@ -2387,6 +2423,12 @@ type Query {
 		clusterId: ID
 		name: String
 	): Namespace!
+	networkPolicy(
+		id: ID!
+	): NetworkPolicy
+	networkPolicies(
+		filter: InputNetworkPolicyFilter
+	): [NetworkPolicy!]!
 """List organizations"""
 	organizations: [Organization!]!
 """Get organization"""
@@ -2589,6 +2631,7 @@ type Service {
 	aliases: [ServerAlias!]
 	namespace: Namespace
 	environment: Environment!
+	networkPolicies: [NetworkPolicy!]
 """If service is Kafka, its KafkaServerConfig."""
 	kafkaServerConfig: KafkaServerConfig
 	certificateInformation: CertificateInformation
@@ -2652,6 +2695,7 @@ input ServiceIdentityInput {
 	name: String!
 	namespace: String!
 	kind: String!
+	nameResolvedUsingAnnotation: Boolean
 }
 
 enum ServiceInternalTrafficPolicy {
@@ -2662,6 +2706,7 @@ enum ServiceInternalTrafficPolicy {
 input ServiceMetadataInput {
 	tags: [String!]
 	awsRoles: [String!]
+	labels: [LabelInput!]
 }
 
 enum ServiceType {

--- a/src/mapper/pkg/networkpolicyreport/network_policies_reconciler.go
+++ b/src/mapper/pkg/networkpolicyreport/network_policies_reconciler.go
@@ -1,0 +1,78 @@
+package networkpolicyreport
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
+	"github.com/samber/lo"
+	"gopkg.in/yaml.v3"
+	networkingv1 "k8s.io/api/networking/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+type NetworkPolicyReconciler struct {
+	client.Client
+	otterizeCloud cloudclient.CloudClient
+}
+
+func NewNetworkPolicyReconciler(client client.Client, otterizeCloudClient cloudclient.CloudClient) *NetworkPolicyReconciler {
+	return &NetworkPolicyReconciler{
+		Client:        client,
+		otterizeCloud: otterizeCloudClient,
+	}
+}
+
+func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&networkingv1.NetworkPolicy{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	namespace := req.Namespace
+	var netpolList networkingv1.NetworkPolicyList
+	err := r.List(ctx, &netpolList, client.InNamespace(namespace))
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	netpolsToReport, err := r.convertToNetworkPolicyInputs(netpolList.Items)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	err = r.otterizeCloud.ReportNetworkPolicies(ctx, namespace, netpolsToReport)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *NetworkPolicyReconciler) convertToNetworkPolicyInputs(netpols []networkingv1.NetworkPolicy) ([]cloudclient.NetworkPolicyInput, error) {
+	var netpolsToReport []cloudclient.NetworkPolicyInput
+	for _, netpol := range netpols {
+		netpolToReport, err := r.convertToNetworkPolicyInput(netpol)
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+		netpolsToReport = append(netpolsToReport, netpolToReport)
+	}
+	return netpolsToReport, nil
+}
+
+func (r *NetworkPolicyReconciler) convertToNetworkPolicyInput(netpol networkingv1.NetworkPolicy) (cloudclient.NetworkPolicyInput, error) {
+	netpol.ManagedFields = nil
+	netpol.OwnerReferences = nil
+	netpol.Finalizers = nil
+	yamlBytes, err := yaml.Marshal(netpol)
+	if err != nil {
+		return cloudclient.NetworkPolicyInput{}, errors.Wrap(err)
+	}
+	return cloudclient.NetworkPolicyInput{
+		Name: netpol.Name,
+		Yaml: string(yamlBytes),
+	}, nil
+}

--- a/src/mapper/pkg/networkpolicyreport/network_policies_reconciler.go
+++ b/src/mapper/pkg/networkpolicyreport/network_policies_reconciler.go
@@ -5,11 +5,11 @@ import (
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
 	"github.com/samber/lo"
-	"gopkg.in/yaml.v3"
 	networkingv1 "k8s.io/api/networking/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/yaml"
 )
 
 type NetworkPolicyReconciler struct {

--- a/src/mapper/pkg/networkpolicyreport/network_policy_reconciler_test.go
+++ b/src/mapper/pkg/networkpolicyreport/network_policy_reconciler_test.go
@@ -1,0 +1,87 @@
+package networkpolicyreport
+
+import (
+	"context"
+	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
+	cloudclientmocks "github.com/otterize/network-mapper/src/mapper/pkg/cloudclient/mocks"
+	"github.com/otterize/network-mapper/src/mapper/pkg/mocks"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"gopkg.in/yaml.v3"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+type NetworkPolicyReconcilerTestSuite struct {
+	suite.Suite
+	cloudClient *cloudclientmocks.MockCloudClient
+	k8sClient   *mocks.K8sClient
+	reconciler  *NetworkPolicyReconciler
+}
+
+func (s *NetworkPolicyReconcilerTestSuite) SetupTest() {
+	controller := gomock.NewController(s.T())
+	s.cloudClient = cloudclientmocks.NewMockCloudClient(controller)
+	s.k8sClient = mocks.NewK8sClient(controller)
+	s.reconciler = NewNetworkPolicyReconciler(s.k8sClient, s.cloudClient)
+}
+
+func (s *NetworkPolicyReconcilerTestSuite) TestNetworkPolicyUpload() {
+	resourceName := "test-networkpolicy"
+	testNamespace := "test-namespace"
+	expectedNetworkPolicy := networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceName,
+			Namespace: testNamespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test-app",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "test-app",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	s.k8sClient.EXPECT().List(gomock.Any(), gomock.Eq(&networkingv1.NetworkPolicyList{}), gomock.Eq(client.InNamespace(testNamespace))).DoAndReturn(
+		func(ctx context.Context, list *networkingv1.NetworkPolicyList, opts ...client.ListOption) error {
+			list.Items = append(list.Items, expectedNetworkPolicy)
+			return nil
+		})
+
+	expectedContent, err := yaml.Marshal(expectedNetworkPolicy)
+	s.Require().NoError(err)
+	cloudInput := cloudclient.NetworkPolicyInput{
+		Name: resourceName,
+		Yaml: string(expectedContent),
+	}
+
+	s.cloudClient.EXPECT().ReportNetworkPolicies(gomock.Any(), testNamespace, gomock.Eq([]cloudclient.NetworkPolicyInput{cloudInput})).Return(nil)
+
+	res, err := s.reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceName, Namespace: testNamespace}})
+	s.NoError(err)
+	s.True(res.IsZero())
+}
+
+func TestNetworkPolicyReconcilerTestSuite(t *testing.T) {
+	suite.Run(t, new(NetworkPolicyReconcilerTestSuite))
+}

--- a/src/mapper/pkg/networkpolicyreport/network_policy_reconciler_test.go
+++ b/src/mapper/pkg/networkpolicyreport/network_policy_reconciler_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/mocks"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
-	"gopkg.in/yaml.v3"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 	"testing"
 )
 


### PR DESCRIPTION
### Description

Enhance cloud network policy analysis by reporting the network policies to the cloud. This will enable Otterize to provide better insights regarding unused policies and blocked network traffic.


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
