### PR TITLE
Upgrade the runner machine for the golangci-lint CI step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,9 +32,10 @@ jobs:
         working-directory: src/
       - name: check git diff
         run: git diff --exit-code
+
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -59,13 +60,13 @@ jobs:
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.
-#          skip-cache: true
+          # skip-cache: true
 
           # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-#          skip-pkg-cache: true
+          # skip-pkg-cache: true
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-#          skip-build-cache: true
+          # skip-build-cache: true
 
   markdownlint:
     name: Check for Markdown errors


### PR DESCRIPTION
### Description
According to https://github.com/actions/runner-images/issues/11101, Ubuntu  20.04 LTS runner will be removed on 2025-04-15. This is currently failing CI

### References

https://github.com/actions/runner-images/issues/11101

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
