### PR TITLE
Fix bug where reporting network policies from a namespace without any policies could cause an error

### DIFF
--- a/src/mapper/pkg/networkpolicyreport/network_policies_reconciler.go
+++ b/src/mapper/pkg/networkpolicyreport/network_policies_reconciler.go
@@ -52,7 +52,7 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *NetworkPolicyReconciler) convertToNetworkPolicyInputs(netpols []networkingv1.NetworkPolicy) ([]cloudclient.NetworkPolicyInput, error) {
-	var netpolsToReport []cloudclient.NetworkPolicyInput
+	netpolsToReport := make([]cloudclient.NetworkPolicyInput, 0)
 	for _, netpol := range netpols {
 		netpolToReport, err := r.convertToNetworkPolicyInput(netpol)
 		if err != nil {

--- a/src/mapper/pkg/networkpolicyreport/network_policy_reconciler_test.go
+++ b/src/mapper/pkg/networkpolicyreport/network_policy_reconciler_test.go
@@ -82,6 +82,16 @@ func (s *NetworkPolicyReconcilerTestSuite) TestNetworkPolicyUpload() {
 	s.True(res.IsZero())
 }
 
+func (s *NetworkPolicyReconcilerTestSuite) TestNetworkPolicyUpload_EmptyNamespace() {
+	emptyList := networkingv1.NetworkPolicyList{}
+	s.k8sClient.EXPECT().List(gomock.Any(), gomock.Eq(&emptyList), gomock.Eq(client.InNamespace("test-namespace"))).Return(nil)
+	s.cloudClient.EXPECT().ReportNetworkPolicies(gomock.Any(), "test-namespace", gomock.Eq(make([]cloudclient.NetworkPolicyInput, 0))).Return(nil)
+
+	res, err := s.reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-networkpolicy", Namespace: "test-namespace"}})
+	s.NoError(err)
+	s.True(res.IsZero())
+}
+
 func TestNetworkPolicyReconcilerTestSuite(t *testing.T) {
 	suite.Run(t, new(NetworkPolicyReconcilerTestSuite))
 }


### PR DESCRIPTION

### Description

Fixed a bug where reporting network policies from a namespace without any policies could cause an error


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
