### PR TITLE
Report traffic originated from control plane

### DIFF
--- a/src/mapper/pkg/config/config.go
+++ b/src/mapper/pkg/config/config.go
@@ -53,6 +53,9 @@ const (
 
 	ControlPlaneIPv4CidrPrefixLength        = "control-plane-ipv4-cidr-prefix-length"
 	ControlPlaneIPv4CidrPrefixLengthDefault = 32
+
+	TCPDestResolveOnlyControlPlaneByIp        = "tcp-dest-resolve-only-control-plane-by-ip"
+	TCPDestResolveOnlyControlPlaneByIpDefault = true
 )
 
 var excludedNamespaces *goset.Set[string]
@@ -84,6 +87,7 @@ func init() {
 	viper.SetDefault(MetricsCollectionTrafficCacheSizeKey, MetricsCollectionTrafficCacheSizeDefault)
 	viper.SetDefault(TimeServerHasToLiveBeforeWeTrustItKey, TimeServerHasToLiveBeforeWeTrustItDefault)
 	viper.SetDefault(ControlPlaneIPv4CidrPrefixLength, ControlPlaneIPv4CidrPrefixLengthDefault)
+	viper.SetDefault(TCPDestResolveOnlyControlPlaneByIp, TCPDestResolveOnlyControlPlaneByIpDefault)
 
 	excludedNamespaces = goset.FromSlice(viper.GetStringSlice(ExcludedNamespacesKey))
 }

--- a/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
+++ b/src/mapper/pkg/resolvers/schema.helpers.resolvers.go
@@ -63,14 +63,14 @@ func updateTelemetriesCounters(sourceType SourceType, intent model.Intent) {
 }
 
 func getDestIp(dest model.Destination, srcIdentity model.OtterizeServiceIdentity) string {
-	if srcIdentity.Name != controlPlaneServerName || srcIdentity.Namespace != controlPlaneNamespace {
+	if viper.GetBool(config.TCPDestResolveOnlyControlPlaneByIp) &&
+		(srcIdentity.Name != controlPlaneServerName || srcIdentity.Namespace != controlPlaneNamespace) {
+		// Yep, you are right, this feels a bit hacky.
+		// We do this because we do not know how many new flows this bugfix will introduce, so we want to control
+		// the rollout of this fix.
 		return dest.Destination
 	}
 
-	// Yep, you are right, this is not trivial to have this logic only when the control plane is the source.
-	// The reason we do this, is because we had a bugfix that reduced a lot of noise when reporting on traffic.
-	// That bugfix caused a bug - where we did not report the traffic from the control plane. Since we don't want
-	// to risk it and introduce a lot of noise again, we currently apply this fix only when the source is the control plane.
 	if dest.DestinationIP != nil {
 		return *dest.DestinationIP
 	}


### PR DESCRIPTION
### Description
Up until now, we did not report traffic when the source of this traffic was the control plane. After this fix, we will start report such traffic.

### Testing

If you deploy older version of the network mapper, you would see that no traffic is being reported from the control plane to any other service.
To simulate such traffic, you can simple deploy `Otterize` on a cluster and apply client intent.
When you apply client intent, the control plane communicates with `intents-operator-webhook-server`.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
