### PR TITLE
Improve efficiency of network policies reporter by filtering large annotations before sending them to the cloud

### DIFF
--- a/src/mapper/pkg/networkpolicyreport/cilium_clusterwide_policies_reconciler.go
+++ b/src/mapper/pkg/networkpolicyreport/cilium_clusterwide_policies_reconciler.go
@@ -67,9 +67,7 @@ func (r *CiliumClusterWideNetworkPolicyReconciler) convertToNetworkPolicyInputs(
 }
 
 func (r *CiliumClusterWideNetworkPolicyReconciler) convertToNetworkPolicyInput(ciliumClusterWideNetpol ciliumv2.CiliumClusterwideNetworkPolicy) (cloudclient.NetworkPolicyInput, error) {
-	ciliumClusterWideNetpol.ManagedFields = nil
-	ciliumClusterWideNetpol.OwnerReferences = nil
-	ciliumClusterWideNetpol.Finalizers = nil
+	ciliumClusterWideNetpol.ObjectMeta = filterObjectMetadata(ciliumClusterWideNetpol.ObjectMeta)
 	ciliumClusterWideNetpol.Status = ciliumv2.CiliumNetworkPolicyStatus{}
 
 	yamlString, err := yaml.Marshal(ciliumClusterWideNetpol)

--- a/src/mapper/pkg/networkpolicyreport/helpers.go
+++ b/src/mapper/pkg/networkpolicyreport/helpers.go
@@ -1,0 +1,24 @@
+package networkpolicyreport
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func filterLargeAnnotations(annotations map[string]string) {
+	for k, v := range annotations {
+		if len(v) <= 100 {
+			// Skip annotations with values longer than 100 characters
+			continue
+		}
+		delete(annotations, k)
+	}
+}
+
+func filterObjectMetadata(objectMeta metav1.ObjectMeta) metav1.ObjectMeta {
+	objectMeta.Finalizers = nil
+	objectMeta.ManagedFields = nil
+	objectMeta.OwnerReferences = nil
+	filterLargeAnnotations(objectMeta.Annotations)
+
+	return objectMeta
+}

--- a/src/mapper/pkg/networkpolicyreport/network_policies_reconciler.go
+++ b/src/mapper/pkg/networkpolicyreport/network_policies_reconciler.go
@@ -64,9 +64,7 @@ func (r *NetworkPolicyReconciler) convertToNetworkPolicyInputs(netpols []network
 }
 
 func (r *NetworkPolicyReconciler) convertToNetworkPolicyInput(netpol networkingv1.NetworkPolicy) (cloudclient.NetworkPolicyInput, error) {
-	netpol.ManagedFields = nil
-	netpol.OwnerReferences = nil
-	netpol.Finalizers = nil
+	netpol.ObjectMeta = filterObjectMetadata(netpol.ObjectMeta)
 	yamlBytes, err := yaml.Marshal(netpol)
 	if err != nil {
 		return cloudclient.NetworkPolicyInput{}, errors.Wrap(err)


### PR DESCRIPTION


### Description

Improve efficiency of network policies reporter by filtering large annotations before sending them to the cloud


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
