### PR TITLE
Fixed bug where discovered intents were dropped in the mapper when collecting and parsing data from the sniffer

### DIFF
--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -133,6 +133,7 @@ type ExternalTrafficIntentInput struct {
 	ClientName       string                            `json:"clientName"`
 	Target           DNSIPPairInput                    `json:"target"`
 	ConnectionsCount nilable.Nilable[ConnectionsCount] `json:"connectionsCount"`
+	Ttl              nilable.Nilable[time.Time]        `json:"ttl"`
 }
 
 // GetNamespace returns ExternalTrafficIntentInput.Namespace, and is useful for accessing the field via an interface.
@@ -148,6 +149,9 @@ func (v *ExternalTrafficIntentInput) GetTarget() DNSIPPairInput { return v.Targe
 func (v *ExternalTrafficIntentInput) GetConnectionsCount() nilable.Nilable[ConnectionsCount] {
 	return v.ConnectionsCount
 }
+
+// GetTtl returns ExternalTrafficIntentInput.Ttl, and is useful for accessing the field via an interface.
+func (v *ExternalTrafficIntentInput) GetTtl() nilable.Nilable[time.Time] { return v.Ttl }
 
 type HTTPConfigInput struct {
 	Path    *string       `json:"path"`
@@ -1078,9 +1082,11 @@ const (
 )
 
 type ServiceMetadataInput struct {
-	Tags     []string     `json:"tags"`
-	AwsRoles []string     `json:"awsRoles"`
-	Labels   []LabelInput `json:"labels"`
+	Tags       []string     `json:"tags"`
+	AwsRoles   []string     `json:"awsRoles"`
+	Labels     []LabelInput `json:"labels"`
+	PodIps     []string     `json:"podIps"`
+	ServiceIps []string     `json:"serviceIps"`
 }
 
 // GetTags returns ServiceMetadataInput.Tags, and is useful for accessing the field via an interface.
@@ -1091,6 +1097,12 @@ func (v *ServiceMetadataInput) GetAwsRoles() []string { return v.AwsRoles }
 
 // GetLabels returns ServiceMetadataInput.Labels, and is useful for accessing the field via an interface.
 func (v *ServiceMetadataInput) GetLabels() []LabelInput { return v.Labels }
+
+// GetPodIps returns ServiceMetadataInput.PodIps, and is useful for accessing the field via an interface.
+func (v *ServiceMetadataInput) GetPodIps() []string { return v.PodIps }
+
+// GetServiceIps returns ServiceMetadataInput.ServiceIps, and is useful for accessing the field via an interface.
+func (v *ServiceMetadataInput) GetServiceIps() []string { return v.ServiceIps }
 
 type SessionAffinity string
 

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -7,17 +7,14 @@ directive @constraint(
 	example: String!
 ) on ENUM_VALUE
 
-"""Directs the executor to defer this fragment when the `if` argument is true or undefined."""
+"""The @defer directive may be specified on a fragment spread to imply de-prioritization, that causes the fragment to be omitted in the initial response, and delivered as a subsequent response afterward. A query with @defer directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred delivered in a subsequent response. @include and @skip take precedence over @defer."""
 directive @defer(
-"""Deferred when true or undefined."""
 	if: Boolean
-"""Unique name"""
 	label: String
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""Marks an element of a GraphQL schema as no longer supported."""
+"""The @deprecated built-in directive is used within the type system definition language to indicate deprecated portions of a GraphQL service's schema, such as deprecated fields on a type, arguments on a field, input fields on an input type, or values of an enum type."""
 directive @deprecated(
-"""Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/)."""
 	reason: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
@@ -30,9 +27,8 @@ directive @httpError(
 	statusCode: Int!
 ) on ENUM_VALUE
 
-"""Directs the executor to include this field or fragment only when the `if` argument is true."""
+"""The @include directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument."""
 directive @include(
-"""Included when true."""
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
@@ -44,9 +40,6 @@ directive @noRole on FIELD_DEFINITION
 user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION.
 user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION."""
 directive @noauth on FIELD_DEFINITION
-
-"""Indicates exactly one field must be supplied and this field must not be `null`."""
-directive @oneOf on INPUT_OBJECT
 
 """@requiresRole indicates that the specified query / mutation / subscription requires any of the provided roles to be executed.
 Users without any of the specified roles will not be able to execute the query / mutation / subscription."""
@@ -64,15 +57,13 @@ directive @restApiRoute(
 	tags: [String!]!
 ) on FIELD_DEFINITION
 
-"""Directs the executor to skip this field or fragment when the `if` argument is true."""
+"""The @skip directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument."""
 directive @skip(
-"""Skipped when true."""
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""Exposes a URL that specifies the behavior of this scalar."""
+"""The @specifiedBy built-in directive is used within the type system definition language to provide a scalar specification URL for specifying the behavior of custom scalar types."""
 directive @specifiedBy(
-"""The URL that specifies the behavior of this scalar."""
 	url: String!
 ) on SCALAR
 

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -7,14 +7,17 @@ directive @constraint(
 	example: String!
 ) on ENUM_VALUE
 
-"""The @defer directive may be specified on a fragment spread to imply de-prioritization, that causes the fragment to be omitted in the initial response, and delivered as a subsequent response afterward. A query with @defer directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred delivered in a subsequent response. @include and @skip take precedence over @defer."""
+"""Directs the executor to defer this fragment when the `if` argument is true or undefined."""
 directive @defer(
+"""Deferred when true or undefined."""
 	if: Boolean
+"""Unique name"""
 	label: String
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""The @deprecated built-in directive is used within the type system definition language to indicate deprecated portions of a GraphQL service's schema, such as deprecated fields on a type, arguments on a field, input fields on an input type, or values of an enum type."""
+"""Marks an element of a GraphQL schema as no longer supported."""
 directive @deprecated(
+"""Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/)."""
 	reason: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
@@ -27,8 +30,9 @@ directive @httpError(
 	statusCode: Int!
 ) on ENUM_VALUE
 
-"""The @include directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument."""
+"""Directs the executor to include this field or fragment only when the `if` argument is true."""
 directive @include(
+"""Included when true."""
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
@@ -40,6 +44,9 @@ directive @noRole on FIELD_DEFINITION
 user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION.
 user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION."""
 directive @noauth on FIELD_DEFINITION
+
+"""Indicates exactly one field must be supplied and this field must not be `null`."""
+directive @oneOf on INPUT_OBJECT
 
 """@requiresRole indicates that the specified query / mutation / subscription requires any of the provided roles to be executed.
 Users without any of the specified roles will not be able to execute the query / mutation / subscription."""
@@ -57,13 +64,15 @@ directive @restApiRoute(
 	tags: [String!]!
 ) on FIELD_DEFINITION
 
-"""The @skip directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument."""
+"""Directs the executor to skip this field or fragment when the `if` argument is true."""
 directive @skip(
+"""Skipped when true."""
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""The @specifiedBy built-in directive is used within the type system definition language to provide a scalar specification URL for specifying the behavior of custom scalar types."""
+"""Exposes a URL that specifies the behavior of this scalar."""
 directive @specifiedBy(
+"""The URL that specifies the behavior of this scalar."""
 	url: String!
 ) on SCALAR
 
@@ -845,6 +854,7 @@ input ExternalTrafficIntentInput {
 	clientName: String!
 	target: DNSIPPairInput!
 	connectionsCount: ConnectionsCount
+	ttl: Time
 }
 
 input ExternallyAccessibleServiceInput {
@@ -2149,6 +2159,7 @@ type Mutation {
 		namespace: String
 		networkPolicies: [NetworkPolicyInput!]
 	): Boolean!
+	computeNetworkPoliciesForOrg: Boolean!
 """Create a new organization"""
 	createOrganization(
 		name: String
@@ -2207,6 +2218,9 @@ type Mutation {
 	saveOnboardingFeedback(
 		userEmail: String!
 		feedback: String!
+	): Boolean!
+	saveOrgMemberships(
+		memberships: [UserOrgMembershipInput!]!
 	): Boolean!
 	createOrActivateTutorial(
 		tutorialName: TutorialName!
@@ -2335,11 +2349,19 @@ type Organization {
 type OrganizationMembership {
 	role: AuthRole!
 	restrictions: OrganizationMembershipRestrictions
+	restrictionResources: OrganizationMembershipRestrictionResources
 }
 
 input OrganizationMembershipInput {
 	role: AuthRole!
 	restrictions: OrganizationMembershipRestrictionsInput
+}
+
+type OrganizationMembershipRestrictionResources {
+	clusters: [Cluster!]!
+	services: [Service!]!
+	namespaces: [Namespace!]!
+	environments: [Environment!]!
 }
 
 type OrganizationMembershipRestrictions {
@@ -2630,6 +2652,8 @@ type Query {
 	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
+"""List users with restriction resources"""
+	orgUsersWithRestrictionResources: UsersWithRestrictionResources!
 	orgUsers: [UserOrganizationAssociation!]!
 """Get user"""
 	user(
@@ -2902,6 +2926,8 @@ input ServiceMetadataInput {
 	tags: [String!]
 	awsRoles: [String!]
 	labels: [LabelInput!]
+	podIps: [String!]
+	serviceIps: [String!]
 }
 
 enum ServiceType {
@@ -3141,6 +3167,11 @@ enum UserErrorType {
 	TIMEOUT
 }
 
+input UserOrgMembershipInput {
+	userId: ID!
+	membership: OrganizationMembershipInput!
+}
+
 type UserOrganizationAssociation {
 	org: Organization!
 	user: User!
@@ -3157,6 +3188,11 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
+}
+
+type UsersWithRestrictionResources {
+	orgUsers: [UserOrganizationAssociation!]!
+	restrictionResources: OrganizationMembershipRestrictionResources
 }
 
 """ Used to validate ID based filters """

--- a/src/mapper/pkg/clouduploader/cloud_uploader_test.go
+++ b/src/mapper/pkg/clouduploader/cloud_uploader_test.go
@@ -50,7 +50,7 @@ func (s *CloudUploaderTestSuite) addIntent(source string, srcNamespace string, d
 		testTimestamp,
 		model.Intent{
 			Client:         &model.OtterizeServiceIdentity{Name: source, Namespace: srcNamespace},
-			Server:         &model.OtterizeServiceIdentity{Name: destination, Namespace: dstNamespace},
+			Server:         &model.OtterizeServiceIdentity{Name: destination, Namespace: dstNamespace, ResolutionData: lo.ToPtr(model.IdentityResolutionData{})},
 			ResolutionData: lo.ToPtr("handleInternalTrafficTCPResult"),
 		},
 		[]int64{int64(20205)},
@@ -145,7 +145,7 @@ func (s *CloudUploaderTestSuite) TestUploadIncomingTrafficIntents() {
 func (s *CloudUploaderTestSuite) TestUploadIntentsWithOperations() {
 	discoveredProduce := model.Intent{
 		Client: &model.OtterizeServiceIdentity{Name: "client1", Namespace: s.testNamespace},
-		Server: &model.OtterizeServiceIdentity{Name: "server1", Namespace: s.testNamespace},
+		Server: &model.OtterizeServiceIdentity{Name: "server1", Namespace: s.testNamespace, ResolutionData: lo.ToPtr(model.IdentityResolutionData{})},
 		Type:   lo.ToPtr(model.IntentTypeKafka),
 		KafkaTopics: []model.KafkaConfig{
 			{
@@ -159,7 +159,7 @@ func (s *CloudUploaderTestSuite) TestUploadIntentsWithOperations() {
 
 	discoveredConsume := model.Intent{
 		Client: &model.OtterizeServiceIdentity{Name: "client1", Namespace: s.testNamespace},
-		Server: &model.OtterizeServiceIdentity{Name: "server1", Namespace: s.testNamespace},
+		Server: &model.OtterizeServiceIdentity{Name: "server1", Namespace: s.testNamespace, ResolutionData: lo.ToPtr(model.IdentityResolutionData{})},
 		Type:   lo.ToPtr(model.IntentTypeKafka),
 		KafkaTopics: []model.KafkaConfig{
 			{

--- a/src/mapper/pkg/graph/generated/generated.go
+++ b/src/mapper/pkg/graph/generated/generated.go
@@ -59,15 +59,16 @@ type ComplexityRoot struct {
 	}
 
 	IdentityResolutionData struct {
-		ExtraInfo         func(childComplexity int) int
-		HasLinkerdSidecar func(childComplexity int) int
-		Host              func(childComplexity int) int
-		IsService         func(childComplexity int) int
-		LastSeen          func(childComplexity int) int
-		PodHostname       func(childComplexity int) int
-		Port              func(childComplexity int) int
-		ProcfsHostname    func(childComplexity int) int
-		Uptime            func(childComplexity int) int
+		ExtraInfo             func(childComplexity int) int
+		HasLinkerdSidecar     func(childComplexity int) int
+		Host                  func(childComplexity int) int
+		IsService             func(childComplexity int) int
+		LastSeen              func(childComplexity int) int
+		PodHostname           func(childComplexity int) int
+		Port                  func(childComplexity int) int
+		ProcfsHostname        func(childComplexity int) int
+		TCPDestResolveFixData func(childComplexity int) int
+		Uptime                func(childComplexity int) int
 	}
 
 	Intent struct {
@@ -122,6 +123,11 @@ type ComplexityRoot struct {
 	ServiceIntents struct {
 		Client  func(childComplexity int) int
 		Intents func(childComplexity int) int
+	}
+
+	TCPDestResolveBugfixData struct {
+		IsSrcControlPlane func(childComplexity int) int
+		ResolvedUsingIP   func(childComplexity int) int
 	}
 }
 
@@ -252,6 +258,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.IdentityResolutionData.ProcfsHostname(childComplexity), true
+
+	case "IdentityResolutionData.tcpDestResolveFixData":
+		if e.complexity.IdentityResolutionData.TCPDestResolveFixData == nil {
+			break
+		}
+
+		return e.complexity.IdentityResolutionData.TCPDestResolveFixData(childComplexity), true
 
 	case "IdentityResolutionData.uptime":
 		if e.complexity.IdentityResolutionData.Uptime == nil {
@@ -546,6 +559,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceIntents.Intents(childComplexity), true
 
+	case "TCPDestResolveBugfixData.isSrcControlPlane":
+		if e.complexity.TCPDestResolveBugfixData.IsSrcControlPlane == nil {
+			break
+		}
+
+		return e.complexity.TCPDestResolveBugfixData.IsSrcControlPlane(childComplexity), true
+
+	case "TCPDestResolveBugfixData.resolvedUsingIp":
+		if e.complexity.TCPDestResolveBugfixData.ResolvedUsingIP == nil {
+			break
+		}
+
+		return e.complexity.TCPDestResolveBugfixData.ResolvedUsingIP(childComplexity), true
+
 	}
 	return 0, false
 }
@@ -712,6 +739,11 @@ type GroupVersionKind {
     kind: String!
 }
 
+type TCPDestResolveBugfixData {
+    isSrcControlPlane: Boolean!
+    resolvedUsingIp: Boolean!
+}
+
 type IdentityResolutionData {
     host: String
     podHostname: String
@@ -722,6 +754,7 @@ type IdentityResolutionData {
     lastSeen: String
     extraInfo: String
     hasLinkerdSidecar: Boolean
+    tcpDestResolveFixData: TCPDestResolveBugfixData
 }
 
 type OtterizeServiceIdentity {
@@ -1770,6 +1803,53 @@ func (ec *executionContext) fieldContext_IdentityResolutionData_hasLinkerdSideca
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _IdentityResolutionData_tcpDestResolveFixData(ctx context.Context, field graphql.CollectedField, obj *model.IdentityResolutionData) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IdentityResolutionData_tcpDestResolveFixData(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TCPDestResolveFixData, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.TCPDestResolveBugfixData)
+	fc.Result = res
+	return ec.marshalOTCPDestResolveBugfixData2ᚖgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐTCPDestResolveBugfixData(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IdentityResolutionData_tcpDestResolveFixData(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IdentityResolutionData",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "isSrcControlPlane":
+				return ec.fieldContext_TCPDestResolveBugfixData_isSrcControlPlane(ctx, field)
+			case "resolvedUsingIp":
+				return ec.fieldContext_TCPDestResolveBugfixData_resolvedUsingIp(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TCPDestResolveBugfixData", field.Name)
 		},
 	}
 	return fc, nil
@@ -2966,6 +3046,8 @@ func (ec *executionContext) fieldContext_OtterizeServiceIdentity_resolutionData(
 				return ec.fieldContext_IdentityResolutionData_extraInfo(ctx, field)
 			case "hasLinkerdSidecar":
 				return ec.fieldContext_IdentityResolutionData_hasLinkerdSidecar(ctx, field)
+			case "tcpDestResolveFixData":
+				return ec.fieldContext_IdentityResolutionData_tcpDestResolveFixData(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IdentityResolutionData", field.Name)
 		},
@@ -3571,6 +3653,94 @@ func (ec *executionContext) fieldContext_ServiceIntents_intents(ctx context.Cont
 				return ec.fieldContext_OtterizeServiceIdentity_kubernetesService(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type OtterizeServiceIdentity", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TCPDestResolveBugfixData_isSrcControlPlane(ctx context.Context, field graphql.CollectedField, obj *model.TCPDestResolveBugfixData) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TCPDestResolveBugfixData_isSrcControlPlane(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsSrcControlPlane, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TCPDestResolveBugfixData_isSrcControlPlane(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TCPDestResolveBugfixData",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TCPDestResolveBugfixData_resolvedUsingIp(ctx context.Context, field graphql.CollectedField, obj *model.TCPDestResolveBugfixData) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TCPDestResolveBugfixData_resolvedUsingIp(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ResolvedUsingIP, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TCPDestResolveBugfixData_resolvedUsingIp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TCPDestResolveBugfixData",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -6150,6 +6320,8 @@ func (ec *executionContext) _IdentityResolutionData(ctx context.Context, sel ast
 			out.Values[i] = ec._IdentityResolutionData_extraInfo(ctx, field, obj)
 		case "hasLinkerdSidecar":
 			out.Values[i] = ec._IdentityResolutionData_hasLinkerdSidecar(ctx, field, obj)
+		case "tcpDestResolveFixData":
+			out.Values[i] = ec._IdentityResolutionData_tcpDestResolveFixData(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -6612,6 +6784,50 @@ func (ec *executionContext) _ServiceIntents(ctx context.Context, sel ast.Selecti
 			}
 		case "intents":
 			out.Values[i] = ec._ServiceIntents_intents(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tCPDestResolveBugfixDataImplementors = []string{"TCPDestResolveBugfixData"}
+
+func (ec *executionContext) _TCPDestResolveBugfixData(ctx context.Context, sel ast.SelectionSet, obj *model.TCPDestResolveBugfixData) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tCPDestResolveBugfixDataImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TCPDestResolveBugfixData")
+		case "isSrcControlPlane":
+			out.Values[i] = ec._TCPDestResolveBugfixData_isSrcControlPlane(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "resolvedUsingIp":
+			out.Values[i] = ec._TCPDestResolveBugfixData_resolvedUsingIp(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -8215,6 +8431,13 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	}
 	res := graphql.MarshalString(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOTCPDestResolveBugfixData2ᚖgithubᚗcomᚋotterizeᚋnetworkᚑmapperᚋsrcᚋmapperᚋpkgᚋgraphᚋmodelᚐTCPDestResolveBugfixData(ctx context.Context, sel ast.SelectionSet, v *model.TCPDestResolveBugfixData) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TCPDestResolveBugfixData(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {

--- a/src/mapper/pkg/graph/model/models_gen.go
+++ b/src/mapper/pkg/graph/model/models_gen.go
@@ -61,15 +61,16 @@ type HTTPResource struct {
 }
 
 type IdentityResolutionData struct {
-	Host              *string `json:"host,omitempty"`
-	PodHostname       *string `json:"podHostname,omitempty"`
-	ProcfsHostname    *string `json:"procfsHostname,omitempty"`
-	Port              *int64  `json:"port,omitempty"`
-	IsService         *bool   `json:"isService,omitempty"`
-	Uptime            *string `json:"uptime,omitempty"`
-	LastSeen          *string `json:"lastSeen,omitempty"`
-	ExtraInfo         *string `json:"extraInfo,omitempty"`
-	HasLinkerdSidecar *bool   `json:"hasLinkerdSidecar,omitempty"`
+	Host                  *string                   `json:"host,omitempty"`
+	PodHostname           *string                   `json:"podHostname,omitempty"`
+	ProcfsHostname        *string                   `json:"procfsHostname,omitempty"`
+	Port                  *int64                    `json:"port,omitempty"`
+	IsService             *bool                     `json:"isService,omitempty"`
+	Uptime                *string                   `json:"uptime,omitempty"`
+	LastSeen              *string                   `json:"lastSeen,omitempty"`
+	ExtraInfo             *string                   `json:"extraInfo,omitempty"`
+	HasLinkerdSidecar     *bool                     `json:"hasLinkerdSidecar,omitempty"`
+	TCPDestResolveFixData *TCPDestResolveBugfixData `json:"tcpDestResolveFixData,omitempty"`
 }
 
 type Intent struct {
@@ -161,6 +162,11 @@ type ServiceIntents struct {
 
 type SocketScanResults struct {
 	Results []RecordedDestinationsForSrc `json:"results"`
+}
+
+type TCPDestResolveBugfixData struct {
+	IsSrcControlPlane bool `json:"isSrcControlPlane"`
+	ResolvedUsingIP   bool `json:"resolvedUsingIp"`
 }
 
 type TrafficLevelResult struct {

--- a/src/mapper/pkg/intentsstore/holder.go
+++ b/src/mapper/pkg/intentsstore/holder.go
@@ -164,6 +164,13 @@ func (i *IntentsHolder) addIntentToStore(store IntentsStore, newTimestamp time.T
 	existingIntent.Intent.Client.Labels = intent.Client.Labels
 	existingIntent.Intent.Server.Labels = intent.Server.Labels
 
+	if existingIntent.Intent.Server.ResolutionData.TCPDestResolveFixData == nil || intent.Server.ResolutionData.TCPDestResolveFixData == nil {
+		// One of the intents was not discovered using the bugfix, so we want to keep it that way.
+		// This is important because we might drop some of the discovered intents using the bugfix in Otterize-cloud, based on
+		// the fact they were discovered using the bugfix.
+		existingIntent.Intent.Server.ResolutionData.TCPDestResolveFixData = nil
+	}
+
 	store[key] = existingIntent
 }
 

--- a/src/mappergraphql/schema.graphql
+++ b/src/mappergraphql/schema.graphql
@@ -43,6 +43,11 @@ type GroupVersionKind {
     kind: String!
 }
 
+type TCPDestResolveBugfixData {
+    isSrcControlPlane: Boolean!
+    resolvedUsingIp: Boolean!
+}
+
 type IdentityResolutionData {
     host: String
     podHostname: String
@@ -53,6 +58,7 @@ type IdentityResolutionData {
     lastSeen: String
     extraInfo: String
     hasLinkerdSidecar: Boolean
+    tcpDestResolveFixData: TCPDestResolveBugfixData
 }
 
 type OtterizeServiceIdentity {


### PR DESCRIPTION
### Description

Before this fix, we sometimes didn't resolve the destination properly, which result in dropping discovered intents in the mapper.
The cause of the error is that the sniffer sometimes pass on the destination the hostname of the workload it detects, and not the ip, while the mapper tries to resolve the destination assuming it is an ip address.
So in cases we do have the IP set from the sniffer - we want to use it to resolve the workload that is attached to the address.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
