### PR TITLE
Fixed bugs where kafka server metadata was not reported properly to cloud and another bug that dropped kafka intents from being reported

### DIFF
--- a/src/mapper/pkg/intentsstore/holder.go
+++ b/src/mapper/pkg/intentsstore/holder.go
@@ -162,11 +162,14 @@ func (i *IntentsHolder) addIntentToStore(store IntentsStore, newTimestamp time.T
 	existingIntent.Intent.Client.Labels = intent.Client.Labels
 	existingIntent.Intent.Server.Labels = intent.Server.Labels
 
-	if existingIntent.Intent.Server.ResolutionData.TCPDestResolveFixData == nil || intent.Server.ResolutionData.TCPDestResolveFixData == nil {
+	if (existingIntent.Intent.Server.ResolutionData != nil && existingIntent.Intent.Server.ResolutionData.TCPDestResolveFixData == nil) ||
+		(intent.Server.ResolutionData != nil && intent.Server.ResolutionData.TCPDestResolveFixData == nil) {
 		// One of the intents was not discovered using the bugfix, so we want to keep it that way.
 		// This is important because we might drop some of the discovered intents using the bugfix in Otterize-cloud, based on
 		// the fact they were discovered using the bugfix.
-		existingIntent.Intent.Server.ResolutionData.TCPDestResolveFixData = nil
+		if existingIntent.Intent.Server.ResolutionData != nil {
+			existingIntent.Intent.Server.ResolutionData.TCPDestResolveFixData = nil
+		}
 	}
 
 	store[key] = existingIntent

--- a/src/mapper/pkg/metadatareporter/metadata_reporter.go
+++ b/src/mapper/pkg/metadatareporter/metadata_reporter.go
@@ -185,7 +185,7 @@ func (r *MetadataReporter) fetchServiceIPs(ctx context.Context, serviceIdentity 
 		}
 
 		for _, ip := range service.Spec.ClusterIPs {
-			if ip != "" {
+			if ip != "" && ip != "None" {
 				serviceIps.Add(ip)
 			}
 		}


### PR DESCRIPTION
### Description
We had 2 different bugs that affected Kafka:
1. We did not reported the service IPs properly - thus failed to update the server data on Otterize cloud
2. We failed from reporting some of kafka intents to cloud

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
