### PR TITLE
Istio - changing metric collection from sidecar to include server source as well

### DIFF
--- a/src/istio-watcher/pkg/watcher/watcher.go
+++ b/src/istio-watcher/pkg/watcher/watcher.go
@@ -41,7 +41,7 @@ Envoy metric sample
 	}
 */
 const (
-	IstioProxyTotalRequestsCMD = "pilot-agent request GET stats?format=json&filter=istio_requests_total\\.*reporter\\.source"
+	IstioProxyTotalRequestsCMD = "pilot-agent request GET stats?format=json&filter=istio_requests_total"
 	IstioSidecarContainerName  = "istio-proxy"
 	IstioPodsLabelSelector     = "security.istio.io/tlsMode"
 	MetricsBufferedChannelSize = 100


### PR DESCRIPTION
### Description
Istio - changing metric collection from sidecar to include server source as well. This addresses missing HTTP methods & paths when reporting to Otterize cloud in a scenario where Istio's `VirtualService` and `Gateway` routing is involved.