### PR TITLE
Support reporting webhook services to Otterize cloud, for supporting auto-allow traffic to webhook services in cloud shadow mode

### DIFF
--- a/src/mapper/cmd/main.go
+++ b/src/mapper/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/otterize/network-mapper/src/mapper/pkg/metrics_collection_traffic"
 	"github.com/otterize/network-mapper/src/mapper/pkg/networkpolicyreport"
 	"github.com/otterize/network-mapper/src/mapper/pkg/resourcevisibility"
+	"github.com/otterize/network-mapper/src/mapper/pkg/webhook_traffic"
 	"github.com/otterize/network-mapper/src/shared/echologrus"
 	"golang.org/x/sync/errgroup"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -256,6 +257,11 @@ func main() {
 		metricsCollectorEndpointsReconciler := metrics_collection_traffic.NewEndpointsReconciler(metricsCollectionTrafficHandler)
 		if err = metricsCollectorEndpointsReconciler.SetupWithManager(mgr); err != nil {
 			logrus.WithError(err).Panic("unable to create endpoints reconciler")
+		}
+
+		validatingWebhooksReconciler := webhook_traffic.NewValidatingWebhookReconciler(mgr.GetClient(), cloudClient, kubeFinder)
+		if err = validatingWebhooksReconciler.SetupWithManager(mgr); err != nil {
+			logrus.WithError(err).Panic("unable to create validating webhooks reconciler")
 		}
 
 		netpolReconciler := networkpolicyreport.NewNetworkPolicyReconciler(mgr.GetClient(), cloudClient)

--- a/src/mapper/pkg/cloudclient/cloud_client.go
+++ b/src/mapper/pkg/cloudclient/cloud_client.go
@@ -21,6 +21,7 @@ type CloudClient interface {
 	ReportK8sResourceEligibleForMetricsCollection(ctx context.Context, namespace string, reason EligibleForMetricsCollectionReason, resources []K8sResourceEligibleForMetricsCollectionInput) error
 	ReportNetworkPolicies(ctx context.Context, namespace string, policies []NetworkPolicyInput) error
 	ReportCiliumClusterWideNetworkPolicies(ctx context.Context, policies []NetworkPolicyInput) error
+	ReportK8sWebhookServices(ctx context.Context, services []K8sWebhookServiceInput) error
 }
 
 type CloudClientImpl struct {
@@ -196,6 +197,17 @@ func (c *CloudClientImpl) ReportCiliumClusterWideNetworkPolicies(
 		c.client,
 		policies,
 	)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func (c *CloudClientImpl) ReportK8sWebhookServices(ctx context.Context, services []K8sWebhookServiceInput) error {
+	logrus.Infof("Reporting webhook services")
+
+	_, err := ReportK8sWebhookServices(ctx, c.client, services)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -812,6 +812,29 @@ const (
 	K8sServiceTypeExternalName K8sServiceType = "EXTERNAL_NAME"
 )
 
+type K8sWebhookServiceInput struct {
+	OtterizeName string      `json:"otterizeName"`
+	ServiceName  string      `json:"serviceName"`
+	Namespace    string      `json:"namespace"`
+	WebhookName  string      `json:"webhookName"`
+	WebhookType  WebhookType `json:"webhookType"`
+}
+
+// GetOtterizeName returns K8sWebhookServiceInput.OtterizeName, and is useful for accessing the field via an interface.
+func (v *K8sWebhookServiceInput) GetOtterizeName() string { return v.OtterizeName }
+
+// GetServiceName returns K8sWebhookServiceInput.ServiceName, and is useful for accessing the field via an interface.
+func (v *K8sWebhookServiceInput) GetServiceName() string { return v.ServiceName }
+
+// GetNamespace returns K8sWebhookServiceInput.Namespace, and is useful for accessing the field via an interface.
+func (v *K8sWebhookServiceInput) GetNamespace() string { return v.Namespace }
+
+// GetWebhookName returns K8sWebhookServiceInput.WebhookName, and is useful for accessing the field via an interface.
+func (v *K8sWebhookServiceInput) GetWebhookName() string { return v.WebhookName }
+
+// GetWebhookType returns K8sWebhookServiceInput.WebhookType, and is useful for accessing the field via an interface.
+func (v *K8sWebhookServiceInput) GetWebhookType() WebhookType { return v.WebhookType }
+
 type KafkaConfigInput struct {
 	Name       *string           `json:"name"`
 	Operations []*KafkaOperation `json:"operations"`
@@ -967,6 +990,16 @@ type ReportK8sServicesResponse struct {
 
 // GetReportK8sServices returns ReportK8sServicesResponse.ReportK8sServices, and is useful for accessing the field via an interface.
 func (v *ReportK8sServicesResponse) GetReportK8sServices() bool { return v.ReportK8sServices }
+
+// ReportK8sWebhookServicesResponse is returned by ReportK8sWebhookServices on success.
+type ReportK8sWebhookServicesResponse struct {
+	ReportK8sWebhookServices bool `json:"reportK8sWebhookServices"`
+}
+
+// GetReportK8sWebhookServices returns ReportK8sWebhookServicesResponse.ReportK8sWebhookServices, and is useful for accessing the field via an interface.
+func (v *ReportK8sWebhookServicesResponse) GetReportK8sWebhookServices() bool {
+	return v.ReportK8sWebhookServices
+}
 
 // ReportNamespaceLabelsResponse is returned by ReportNamespaceLabels on success.
 type ReportNamespaceLabelsResponse struct {
@@ -1151,6 +1184,14 @@ func (v *TrafficLevelInput) GetDataBytesPerSecond() int { return v.DataBytesPerS
 // GetFlowsCountPerSecond returns TrafficLevelInput.FlowsCountPerSecond, and is useful for accessing the field via an interface.
 func (v *TrafficLevelInput) GetFlowsCountPerSecond() int { return v.FlowsCountPerSecond }
 
+type WebhookType string
+
+const (
+	WebhookTypeValidatingWebhook WebhookType = "VALIDATING_WEBHOOK"
+	WebhookTypeMutatingWebhook   WebhookType = "MUTATING_WEBHOOK"
+	WebhookTypeConversionWebhook WebhookType = "CONVERSION_WEBHOOK"
+)
+
 // __ReportCiliumClusterWideNetworkPoliciesInput is used internally by genqlient
 type __ReportCiliumClusterWideNetworkPoliciesInput struct {
 	NetworkPolicies []NetworkPolicyInput `json:"networkPolicies"`
@@ -1242,6 +1283,14 @@ func (v *__ReportK8sServicesInput) GetNamespace() string { return v.Namespace }
 
 // GetServices returns __ReportK8sServicesInput.Services, and is useful for accessing the field via an interface.
 func (v *__ReportK8sServicesInput) GetServices() []K8sServiceInput { return v.Services }
+
+// __ReportK8sWebhookServicesInput is used internally by genqlient
+type __ReportK8sWebhookServicesInput struct {
+	Services []K8sWebhookServiceInput `json:"services"`
+}
+
+// GetServices returns __ReportK8sWebhookServicesInput.Services, and is useful for accessing the field via an interface.
+func (v *__ReportK8sWebhookServicesInput) GetServices() []K8sWebhookServiceInput { return v.Services }
 
 // __ReportNamespaceLabelsInput is used internally by genqlient
 type __ReportNamespaceLabelsInput struct {
@@ -1548,6 +1597,39 @@ func ReportK8sServices(
 	var err_ error
 
 	var data_ ReportK8sServicesResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by ReportK8sWebhookServices.
+const ReportK8sWebhookServices_Operation = `
+mutation ReportK8sWebhookServices ($services: [K8sWebhookServiceInput!]!) {
+	reportK8sWebhookServices(services: $services)
+}
+`
+
+func ReportK8sWebhookServices(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	services []K8sWebhookServiceInput,
+) (*ReportK8sWebhookServicesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportK8sWebhookServices",
+		Query:  ReportK8sWebhookServices_Operation,
+		Variables: &__ReportK8sWebhookServicesInput{
+			Services: services,
+		},
+	}
+	var err_ error
+
+	var data_ ReportK8sWebhookServicesResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/src/mapper/pkg/cloudclient/genqlient.graphql
+++ b/src/mapper/pkg/cloudclient/genqlient.graphql
@@ -48,3 +48,7 @@ mutation ReportNetworkPolicies($namespace: String!, $networkPolicies: [NetworkPo
 mutation ReportCiliumClusterWideNetworkPolicies($networkPolicies: [NetworkPolicyInput!]!) {
     reportNetworkPolicies(networkPolicies: $networkPolicies)
 }
+
+mutation ReportK8sWebhookServices($services: [K8sWebhookServiceInput!]!) {
+    reportK8sWebhookServices(services: $services)
+}

--- a/src/mapper/pkg/cloudclient/mocks/mocks.go
+++ b/src/mapper/pkg/cloudclient/mocks/mocks.go
@@ -147,6 +147,20 @@ func (mr *MockCloudClientMockRecorder) ReportK8sServices(ctx, namespace, service
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportK8sServices", reflect.TypeOf((*MockCloudClient)(nil).ReportK8sServices), ctx, namespace, services)
 }
 
+// ReportK8sWebhookServices mocks base method.
+func (m *MockCloudClient) ReportK8sWebhookServices(ctx context.Context, services []cloudclient.K8sWebhookServiceInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReportK8sWebhookServices", ctx, services)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReportK8sWebhookServices indicates an expected call of ReportK8sWebhookServices.
+func (mr *MockCloudClientMockRecorder) ReportK8sWebhookServices(ctx, services interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportK8sWebhookServices", reflect.TypeOf((*MockCloudClient)(nil).ReportK8sWebhookServices), ctx, services)
+}
+
 // ReportNamespaceLabels mocks base method.
 func (m *MockCloudClient) ReportNamespaceLabels(ctx context.Context, namespace string, labels []cloudclient.LabelInput) error {
 	m.ctrl.T.Helper()

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -154,6 +154,7 @@ input AWSVisibilitySettingsInput {
 
 type AccessApprovalRuleset {
 	id: ID!
+	order: Int!
 	origin: AccessApprovalRulesetFilter!
 	target: AccessApprovalRulesetFilter!
 	action: AccessApprovalRulesetAction!
@@ -299,6 +300,11 @@ type AppliedIntentsRequestWithDetails {
 enum AuthRole {
 	ADMIN
 	VIEWER
+}
+
+type AutoApproveMoreRestrictiveIntentsByEnv {
+	environmentId: ID!
+	enabled: Boolean!
 }
 
 enum AutomateThirdPartyNetworkPolicy {
@@ -884,6 +890,7 @@ type FeatureFlags {
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
+	enableNetworkPoliciesInAccessGraph: Boolean
 }
 
 type Finding {
@@ -1004,12 +1011,14 @@ type GitHubRepoInfo {
 	repository: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 input GitHubRepoInfoInput {
 	repository: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 type GitHubSettings {
@@ -1044,6 +1053,7 @@ input GitLabRepoInfoInput {
 	projectPath: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 type GitLabSettings {
@@ -1131,6 +1141,8 @@ input InputAccessApprovalRuleset {
 """Ruleset"""
 	id: ID!
 """Ruleset"""
+	order: Int!
+"""Ruleset"""
 	origin: InputAccessApprovalRulesetConfigFilter!
 """Ruleset"""
 	target: InputAccessApprovalRulesetConfigFilter!
@@ -1209,6 +1221,11 @@ input InputAppliedIntentsRequestFilter {
 	approvalStatuses: InputIDFilterValue
 }
 
+input InputAutoApproveMoreRestrictiveIntentsByEnv {
+	environmentId: ID!
+	enabled: Boolean!
+}
+
 input InputDefaultIntentsApprovalActionByEnv {
 	environmentId: ID!
 	action: AccessApprovalRulesetAction!
@@ -1222,6 +1239,7 @@ input InputFeatureFlags {
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
+	enableNetworkPoliciesInAccessGraph: Boolean
 }
 
 """ Findings filter """
@@ -1290,6 +1308,11 @@ input InputNumericFilterValue {
 	operator: NumericFilterOperators!
 }
 
+input InputOffsetPagination {
+	page: Int
+	size: Int
+}
+
 input InputResourceInventoryFilter {
 	serviceIds: InputIDFilterValue
 	environmentIds: InputIDFilterValue
@@ -1313,15 +1336,21 @@ input InputServiceFilter {
 	integrationIds: [ID!]
 }
 
+input InputTerraformAwsInlinePolicyInfo {
+	name: String!
+	policy: String!
+}
+
 input InputTerraformAwsPolicyInfo {
 	arn: String!
+	policy: String!
 	address: String!
 }
 
 input InputTerraformAwsRoleInfo {
 	arn: String!
 	address: String!
-	inlinePolicy: String!
+	inlinePolicy: [InputTerraformAwsInlinePolicyInfo!]
 	attachedPolicies: [InputTerraformAwsPolicyInfo!]
 }
 
@@ -1542,10 +1571,12 @@ type IntentsOperatorConfiguration {
 	gcpIAMPolicyEnforcementEnabled: Boolean!
 	azureIAMPolicyEnforcementEnabled: Boolean!
 	databaseEnforcementEnabled: Boolean!
+	strictModeEnabled: Boolean!
 	protectedServicesEnabled: Boolean!
 	protectedServices: [Service!]!
 	egressNetworkPolicyEnforcementEnabled: Boolean!
 	enforcedNamespaces: [String!]
+	excludedStrictModeNamespaces: [String!]
 }
 
 input IntentsOperatorConfigurationInput {
@@ -1560,6 +1591,8 @@ input IntentsOperatorConfigurationInput {
 	gcpIAMPolicyEnforcementEnabled: Boolean
 	azureIAMPolicyEnforcementEnabled: Boolean
 	databaseEnforcementEnabled: Boolean
+	strictModeEnabled: Boolean
+	excludedStrictModeNamespaces: [String!]
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
 	awsALBLoadBalancerExemptionEnabled: Boolean
@@ -1598,6 +1631,11 @@ type Invite {
 	created: Time!
 	acceptedAt: Time
 	status: InviteStatus!
+}
+
+input InviteOrgMembershipInput {
+	inviteId: ID!
+	membership: OrganizationMembershipInput!
 }
 
 enum InviteStatus {
@@ -1867,6 +1905,7 @@ or, for users with a single organization, this is that single selected organizat
 This is selected by the X-Otterize-Organization header,
 or, for users with a single organization, this is that single selected organization."""
 	selectedUserOrganization: UserOrganizationAssociation!
+	selectedOrganizationRestrictionResources: OrganizationMembershipRestrictionResources
 }
 
 type MeMutation {
@@ -2138,6 +2177,9 @@ type Mutation {
 	acceptInvite(
 		id: ID!
 	): Invite!
+	saveInviteOrgMemberships(
+		memberships: [InviteOrgMembershipInput!]!
+	): Boolean!
 	reportK8sServices(
 		namespace: String!
 		services: [K8sServiceInput!]!
@@ -2279,6 +2321,11 @@ type NetworkMapperComponent {
 	status: ComponentStatus!
 }
 
+type NetworkPoliciesPage {
+	data: [NetworkPolicy!]!
+	meta: PaginationMeta
+}
+
 enum NetworkPoliciesStep {
 """Connect cluster"""
 	CREATE_CLUSTER
@@ -2365,6 +2412,7 @@ type Organization {
 }
 
 type OrganizationMembership {
+	organizationId: ID!
 	role: AuthRole!
 	restrictions: OrganizationMembershipRestrictions
 	restrictionResources: OrganizationMembershipRestrictionResources
@@ -2403,6 +2451,8 @@ type OrganizationSettings {
 	defaultIntentsApprovalActionByEnv: [DefaultIntentsApprovalActionByEnv!]!
 	ignoreInternetIntents: Boolean
 	domainsDefaultRole: AuthRole!
+	defaultInviteMembership: OrganizationMembership!
+	autoApproveMoreRestrictiveIntentsByEnv: [AutoApproveMoreRestrictiveIntentsByEnv!]!
 }
 
 input OrganizationSettingsInput {
@@ -2411,6 +2461,8 @@ input OrganizationSettingsInput {
 	ignoredCloudDomains: [String!]
 	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
 	ignoreInternetIntents: Boolean
+	defaultInviteMembership: OrganizationMembershipInput
+	autoApproveMoreRestrictiveIntentsByEnv: [InputAutoApproveMoreRestrictiveIntentsByEnv!]
 }
 
 input PaginationInput {
@@ -2620,7 +2672,8 @@ type Query {
 	): NetworkPolicy
 	networkPolicies(
 		filter: InputNetworkPolicyFilter
-	): [NetworkPolicy!]!
+		pagination: InputOffsetPagination
+	): NetworkPoliciesPage
 """List organizations"""
 	organizations: [Organization!]!
 """Get organization"""
@@ -2670,8 +2723,6 @@ type Query {
 	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
-"""List users with restriction resources"""
-	orgUsersWithRestrictionResources: UsersWithRestrictionResources!
 	orgUsers: [UserOrganizationAssociation!]!
 """Get user"""
 	user(
@@ -2740,6 +2791,7 @@ type Resource {
 enum RowDiff {
 	ADDED
 	REMOVED
+	STRICT_MODE_WARNING
 }
 
 type RulesetsWithResources {
@@ -2962,6 +3014,7 @@ enum ServiceType {
 	KUBERNETES_LOAD_BALANCER
 	AWS_VISIBILITY_EKS
 	DETECTED_CLOUD_SERVER
+	CONTROL_PLANE
 }
 
 type ServicesResponse {
@@ -3040,13 +3093,13 @@ scalar String
 
 type TLSConfiguration {
 	caCertificate: String
-	certificate: String!
+	certificate: String
 }
 
 input TLSConfigurationInput {
 	caCertificate: String
-	certificate: String!
-	key: String!
+	certificate: String
+	key: String
 }
 
 enum TelemetryComponentType {
@@ -3069,21 +3122,28 @@ input TelemetryInput {
 	data: TelemetryData!
 }
 
+type TerraformAwsInlinePolicyInfo {
+	name: String!
+	policy: String!
+}
+
 type TerraformAwsPolicyInfo {
 	arn: String!
+	policy: String!
 	address: String!
 }
 
 type TerraformAwsRoleInfo {
 	arn: String!
 	address: String!
-	inlinePolicy: String!
+	inlinePolicy: [TerraformAwsInlinePolicyInfo!]
 	attachedPolicies: [TerraformAwsPolicyInfo!]
 }
 
 type TerraformResourceInfo {
 	modulePath: String!
-	gitOriginUrl: String!
+	gitPlatform: String!
+	gitOrigin: String!
 	gitCommitHash: String!
 	awsRoles: [TerraformAwsRoleInfo!]
 }
@@ -3206,11 +3266,6 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
-}
-
-type UsersWithRestrictionResources {
-	orgUsers: [UserOrganizationAssociation!]!
-	restrictionResources: OrganizationMembershipRestrictionResources
 }
 
 """ Used to validate ID based filters """

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -1793,6 +1793,14 @@ enum K8sServiceType {
 	EXTERNAL_NAME
 }
 
+input K8sWebhookServiceInput {
+	otterizeName: String!
+	serviceName: String!
+	namespace: String!
+	webhookName: String!
+	webhookType: WebhookType!
+}
+
 type KafkaConfig {
 	name: String!
 	operations: [KafkaOperation!]
@@ -2192,6 +2200,9 @@ type Mutation {
 		namespace: String!
 		reason: EligibleForMetricsCollectionReason!
 		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
+	): Boolean!
+	reportK8sWebhookServices(
+		services: [K8sWebhookServiceInput!]!
 	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!
@@ -3275,6 +3286,12 @@ type ValidIDFilter {
 	namespaceIds: IDFilterValue
 	regulationIds: IDFilterValue
 	environmentIds: IDFilterValue
+}
+
+enum WebhookType {
+	VALIDATING_WEBHOOK
+	MUTATING_WEBHOOK
+	CONVERSION_WEBHOOK
 }
 
 type Workload {

--- a/src/mapper/pkg/webhook_traffic/validating_webhook_reconciler.go
+++ b/src/mapper/pkg/webhook_traffic/validating_webhook_reconciler.go
@@ -1,0 +1,106 @@
+package webhook_traffic
+
+import (
+	"context"
+	"fmt"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/network-mapper/src/mapper/pkg/cloudclient"
+	"github.com/otterize/network-mapper/src/mapper/pkg/graph/model"
+	"github.com/samber/lo"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"time"
+)
+
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch
+
+type KubeFinder interface {
+	ResolveOtterizeIdentityForService(ctx context.Context, service *corev1.Service, now time.Time) (model.OtterizeServiceIdentity, bool, error)
+}
+
+type ValidatingWebhookReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	kubeFinder          KubeFinder
+	otterizeCloudClient cloudclient.CloudClient
+}
+
+func NewValidatingWebhookReconciler(client client.Client, otterizeCloudClient cloudclient.CloudClient, kubeFinder KubeFinder) *ValidatingWebhookReconciler {
+	return &ValidatingWebhookReconciler{Client: client, kubeFinder: kubeFinder, otterizeCloudClient: otterizeCloudClient}
+}
+
+func (r *ValidatingWebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&admissionv1.ValidatingWebhookConfiguration{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *ValidatingWebhookReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *ValidatingWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	validatingWebhookConfigurationList := &admissionv1.ValidatingWebhookConfigurationList{}
+	err := r.Client.List(ctx, validatingWebhookConfigurationList)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	validatingWebhookServices := make([]cloudclient.K8sWebhookServiceInput, 0)
+	for _, webhookConfiguration := range validatingWebhookConfigurationList.Items {
+		for _, webhook := range webhookConfiguration.Webhooks {
+			if webhook.ClientConfig.Service != nil {
+				service := corev1.Service{}
+				err := r.Client.Get(ctx, types.NamespacedName{Name: webhook.ClientConfig.Service.Name, Namespace: webhook.ClientConfig.Service.Namespace}, &service)
+				if k8sErr := &(k8serrors.StatusError{}); errors.As(err, &k8sErr) {
+					if k8serrors.IsNotFound(k8sErr) {
+						continue
+					}
+				}
+
+				if err != nil {
+					return ctrl.Result{}, errors.Wrap(err)
+				}
+
+				identity, found, err := r.kubeFinder.ResolveOtterizeIdentityForService(ctx, &service, time.Now())
+				if err != nil {
+					return ctrl.Result{}, errors.Wrap(err)
+				}
+
+				if !found {
+					continue
+				}
+
+				validatingWebhookServices = append(validatingWebhookServices, cloudclient.K8sWebhookServiceInput{
+					OtterizeName: identity.Name,
+					ServiceName:  webhook.ClientConfig.Service.Name,
+					Namespace:    webhook.ClientConfig.Service.Namespace,
+					WebhookName:  webhookConfiguration.Name,
+					WebhookType:  cloudclient.WebhookTypeValidatingWebhook,
+				})
+			}
+		}
+	}
+
+	validatingWebhookServices = lo.UniqBy(validatingWebhookServices, func(service cloudclient.K8sWebhookServiceInput) string {
+		return fmt.Sprintf("%s#%s#%s#%s", service.Namespace, service.ServiceName, service.WebhookName, service.WebhookType)
+
+	})
+	err = r.otterizeCloudClient.ReportK8sWebhookServices(ctx, validatingWebhookServices)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	return ctrl.Result{}, nil
+}


### PR DESCRIPTION
### Description
Otterize now also supporting auto-allow traffic to services backing webhooks in the cluster (with regards to `automateThirdPartyNetworkPolicies` configuration).
Now, we also report those services to Otterize cloud, in order to support shadow-mode in Otterize cloud.

### References
- [Support webhook traffic in intents-operator](https://github.com/otterize/intents-operator/commit/18009db8da0b1086c509cbe85a2498a71d5ef7b9)

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
