### PR TITLE
Fixed bug where invalid Kafka servers configuration produced an empty error log

### DIFF
--- a/src/kafka-watcher/cmd/main.go
+++ b/src/kafka-watcher/cmd/main.go
@@ -74,10 +74,10 @@ func main() {
 			logrus.WithError(err).Panic("could not initialize log file watcher")
 		}
 	case config.KubernetesLogReadMode:
-		kafkaServers, parseErr := parseKafkaServers(viper.GetStringSlice(config.KafkaServersKey))
+		kafkaServers, err := parseKafkaServers(viper.GetStringSlice(config.KafkaServersKey))
 		logrus.Infof("Reading from k8s logs - %d servers", len(kafkaServers))
 
-		if parseErr != nil {
+		if err != nil {
 			logrus.WithError(err).Panic("could not parse Kafka servers list")
 		}
 


### PR DESCRIPTION


### Description

Fixed bug where invalid Kafka servers configuration produced an empty error log


### References

Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- StackOverflow post
- Related pull requests/issues from other repos

If there are no references, simply delete this section.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
