### PR TITLE
Fix bug where indexes were used before being initialized by the metadataReporter

### DIFF
--- a/src/mapper/pkg/metadatareporter/setup.go
+++ b/src/mapper/pkg/metadatareporter/setup.go
@@ -13,6 +13,11 @@ import (
 func Setup(client client.Client, cloudClient cloudclient.CloudClient, resolver serviceidresolver.ServiceResolver, mgr ctrl.Manager) error {
 	reporter := NewMetadataReporter(client, cloudClient, resolver)
 
+	// Initialize indexes
+	if err := initIndexes(mgr); err != nil {
+		return errors.Wrap(err)
+	}
+
 	// Initialize the EndpointsReconciler
 	endpointsReconciler := NewEndpointsReconciler(client, resolver, reporter)
 	if err := endpointsReconciler.SetupWithManager(mgr); err != nil {
@@ -28,11 +33,6 @@ func Setup(client client.Client, cloudClient cloudclient.CloudClient, resolver s
 	// Initialize the NamespaceReconciler
 	namespaceReconciler := NewNamespaceReconciler(mgr.GetClient(), cloudClient)
 	if err := namespaceReconciler.SetupWithManager(mgr); err != nil {
-		return errors.Wrap(err)
-	}
-
-	// Initialize indexes
-	if err := initIndexes(mgr); err != nil {
 		return errors.Wrap(err)
 	}
 


### PR DESCRIPTION
### Description

Fix bug where indexes were used before being initialized by the metadataReporter. 



### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
