### PR TITLE
Improve blocked traffic detection in Otterize Cloud by reporting container port names

### DIFF
--- a/src/mapper/pkg/cloudclient/generated.go
+++ b/src/mapper/pkg/cloudclient/generated.go
@@ -601,8 +601,9 @@ func (v *K8sResourceLoadBalancerIngressInput) GetHostname() nilable.Nilable[stri
 func (v *K8sResourceLoadBalancerIngressInput) GetPorts() []PortStatusInput { return v.Ports }
 
 type K8sResourceServiceInput struct {
-	Spec   K8sResourceServiceSpecInput                    `json:"spec"`
-	Status nilable.Nilable[K8sResourceServiceStatusInput] `json:"status"`
+	Spec             K8sResourceServiceSpecInput                    `json:"spec"`
+	Status           nilable.Nilable[K8sResourceServiceStatusInput] `json:"status"`
+	TargetNamedPorts []NamedPortInput                               `json:"targetNamedPorts"`
 }
 
 // GetSpec returns K8sResourceServiceInput.Spec, and is useful for accessing the field via an interface.
@@ -612,6 +613,9 @@ func (v *K8sResourceServiceInput) GetSpec() K8sResourceServiceSpecInput { return
 func (v *K8sResourceServiceInput) GetStatus() nilable.Nilable[K8sResourceServiceStatusInput] {
 	return v.Status
 }
+
+// GetTargetNamedPorts returns K8sResourceServiceInput.TargetNamedPorts, and is useful for accessing the field via an interface.
+func (v *K8sResourceServiceInput) GetTargetNamedPorts() []NamedPortInput { return v.TargetNamedPorts }
 
 type K8sResourceServiceLoadBalancerIngressInput struct {
 	Ip       nilable.Nilable[string]             `json:"ip"`
@@ -856,6 +860,21 @@ const (
 	LoadBalancerIPModeVip   LoadBalancerIPMode = "VIP"
 	LoadBalancerIPModeProxy LoadBalancerIPMode = "PROXY"
 )
+
+type NamedPortInput struct {
+	Name     string          `json:"name"`
+	Port     int             `json:"port"`
+	Protocol K8sPortProtocol `json:"protocol"`
+}
+
+// GetName returns NamedPortInput.Name, and is useful for accessing the field via an interface.
+func (v *NamedPortInput) GetName() string { return v.Name }
+
+// GetPort returns NamedPortInput.Port, and is useful for accessing the field via an interface.
+func (v *NamedPortInput) GetPort() int { return v.Port }
+
+// GetProtocol returns NamedPortInput.Protocol, and is useful for accessing the field via an interface.
+func (v *NamedPortInput) GetProtocol() K8sPortProtocol { return v.Protocol }
 
 type NetworkPolicyInput struct {
 	Name string `json:"name"`

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -313,6 +313,12 @@ enum AutomateThirdPartyNetworkPolicy {
 	IF_BLOCKED_BY_OTTERIZE
 }
 
+enum AutomatedThirdPartyPolicyTypes {
+	EXTERNAL_TRAFFIC
+	METRICS_TRAFFIC
+	WEBHOOK_TRAFFIC
+}
+
 enum AwsIamStep {
 	CREATE_CLUSTER
 	CONNECT_CLUSTER
@@ -777,6 +783,8 @@ enum EdgeAccessStatusReason {
 	ALLOWED_BY_EXTERNALLY_MANAGED_NETWORK_POLICY
 	ALLOWED_BY_METRICS_COLLECTION_TRAFFIC_NETWORK_POLICY
 	WOULD_BE_ALLOWED_BY_METRICS_COLLECTION_TRAFFIC_NETWORK_POLICY
+	ALLOWED_BY_WEBHOOK_TRAFFIC_NETWORK_POLICY
+	WOULD_BE_ALLOWED_BY_WEBHOOK_TRAFFIC_NETWORK_POLICY
 }
 
 enum EdgeAccessStatusVerdict {
@@ -1602,6 +1610,7 @@ input IntentsOperatorConfigurationInput {
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 	prometheusServerConfigs: [PrometheusServerConfigInput!]
+	automatedThirdPartyPolicyTypes: [AutomatedThirdPartyPolicyTypes!]
 }
 
 type IntentsOperatorState {
@@ -1794,6 +1803,12 @@ enum K8sServiceType {
 	NODE_PORT
 	LOAD_BALANCER
 	EXTERNAL_NAME
+}
+
+input K8sWebhookServiceInput {
+	identity: ServiceIdentityInput!
+	webhookName: String!
+	webhookType: WebhookType!
 }
 
 type KafkaConfig {
@@ -2195,6 +2210,9 @@ type Mutation {
 		namespace: String!
 		reason: EligibleForMetricsCollectionReason!
 		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
+	): Boolean!
+	reportK8sWebhookServices(
+		services: [K8sWebhookServiceInput!]!
 	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!
@@ -3292,6 +3310,12 @@ type ValidIDFilter {
 	namespaceIds: IDFilterValue
 	regulationIds: IDFilterValue
 	environmentIds: IDFilterValue
+}
+
+enum WebhookType {
+	VALIDATING_WEBHOOK
+	MUTATING_WEBHOOK
+	CONVERSION_WEBHOOK
 }
 
 type Workload {

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -899,6 +899,7 @@ type FeatureFlags {
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
 	enableNetworkPoliciesInAccessGraph: Boolean
+	enableTrafficFromTCPResolveDestBugfixInAccessGraph: Boolean
 }
 
 type Finding {
@@ -1248,6 +1249,7 @@ input InputFeatureFlags {
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
 	enableNetworkPoliciesInAccessGraph: Boolean
+	enableTrafficFromTCPResolveDestBugfixInAccessGraph: Boolean
 }
 
 """ Findings filter """
@@ -1740,6 +1742,7 @@ input K8sResourceLoadBalancerIngressInput {
 input K8sResourceServiceInput {
 	spec: K8sResourceServiceSpecInput!
 	status: K8sResourceServiceStatusInput
+	targetNamedPorts: [NamedPortInput!]
 }
 
 input K8sResourceServiceLoadBalancerIngressInput {
@@ -2314,6 +2317,12 @@ type Mutation {
 	): Boolean!
 }
 
+input NamedPortInput {
+	name: String!
+	port: Int!
+	protocol: K8sPortProtocol!
+}
+
 type Namespace {
 	id: ID!
 	name: String!
@@ -2555,6 +2564,9 @@ type Query {
 	edgeNetworkPolicies(
 		clientServiceId: ID!
 		serverServiceId: ID!
+	): [NetworkPolicy!]!
+	serviceNetworkPolicies(
+		serviceId: ID!
 	): [NetworkPolicy!]!
 """ Get edge connections count """
 	edgeConnectionsCount(
@@ -3115,6 +3127,8 @@ scalar String
 type TLSConfiguration {
 	caCertificate: String
 	certificate: String
+	caCertificateFingerprint: String
+	certificateFingerprint: String
 }
 
 input TLSConfigurationInput {

--- a/src/mapper/pkg/cloudclient/schema.graphql
+++ b/src/mapper/pkg/cloudclient/schema.graphql
@@ -154,6 +154,7 @@ input AWSVisibilitySettingsInput {
 
 type AccessApprovalRuleset {
 	id: ID!
+	order: Int!
 	origin: AccessApprovalRulesetFilter!
 	target: AccessApprovalRulesetFilter!
 	action: AccessApprovalRulesetAction!
@@ -299,6 +300,11 @@ type AppliedIntentsRequestWithDetails {
 enum AuthRole {
 	ADMIN
 	VIEWER
+}
+
+type AutoApproveMoreRestrictiveIntentsByEnv {
+	environmentId: ID!
+	enabled: Boolean!
 }
 
 enum AutomateThirdPartyNetworkPolicy {
@@ -618,7 +624,7 @@ enum CustomConstraint {
 }
 
 input DNSIPPairInput {
-	dnsName: String!
+	dnsName: String
 	ips: [String!]
 }
 
@@ -884,6 +890,8 @@ type FeatureFlags {
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
+	enableNetworkPoliciesInAccessGraph: Boolean
+	enableTrafficFromTCPResolveDestBugfixInAccessGraph: Boolean
 }
 
 type Finding {
@@ -1004,12 +1012,14 @@ type GitHubRepoInfo {
 	repository: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 input GitHubRepoInfoInput {
 	repository: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 type GitHubSettings {
@@ -1044,6 +1054,7 @@ input GitLabRepoInfoInput {
 	projectPath: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 type GitLabSettings {
@@ -1131,6 +1142,8 @@ input InputAccessApprovalRuleset {
 """Ruleset"""
 	id: ID!
 """Ruleset"""
+	order: Int!
+"""Ruleset"""
 	origin: InputAccessApprovalRulesetConfigFilter!
 """Ruleset"""
 	target: InputAccessApprovalRulesetConfigFilter!
@@ -1209,6 +1222,11 @@ input InputAppliedIntentsRequestFilter {
 	approvalStatuses: InputIDFilterValue
 }
 
+input InputAutoApproveMoreRestrictiveIntentsByEnv {
+	environmentId: ID!
+	enabled: Boolean!
+}
+
 input InputDefaultIntentsApprovalActionByEnv {
 	environmentId: ID!
 	action: AccessApprovalRulesetAction!
@@ -1222,6 +1240,8 @@ input InputFeatureFlags {
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
+	enableNetworkPoliciesInAccessGraph: Boolean
+	enableTrafficFromTCPResolveDestBugfixInAccessGraph: Boolean
 }
 
 """ Findings filter """
@@ -1290,6 +1310,11 @@ input InputNumericFilterValue {
 	operator: NumericFilterOperators!
 }
 
+input InputOffsetPagination {
+	page: Int
+	size: Int
+}
+
 input InputResourceInventoryFilter {
 	serviceIds: InputIDFilterValue
 	environmentIds: InputIDFilterValue
@@ -1313,15 +1338,21 @@ input InputServiceFilter {
 	integrationIds: [ID!]
 }
 
+input InputTerraformAwsInlinePolicyInfo {
+	name: String!
+	policy: String!
+}
+
 input InputTerraformAwsPolicyInfo {
 	arn: String!
+	policy: String!
 	address: String!
 }
 
 input InputTerraformAwsRoleInfo {
 	arn: String!
 	address: String!
-	inlinePolicy: String!
+	inlinePolicy: [InputTerraformAwsInlinePolicyInfo!]
 	attachedPolicies: [InputTerraformAwsPolicyInfo!]
 }
 
@@ -1542,10 +1573,12 @@ type IntentsOperatorConfiguration {
 	gcpIAMPolicyEnforcementEnabled: Boolean!
 	azureIAMPolicyEnforcementEnabled: Boolean!
 	databaseEnforcementEnabled: Boolean!
+	strictModeEnabled: Boolean!
 	protectedServicesEnabled: Boolean!
 	protectedServices: [Service!]!
 	egressNetworkPolicyEnforcementEnabled: Boolean!
 	enforcedNamespaces: [String!]
+	excludedStrictModeNamespaces: [String!]
 }
 
 input IntentsOperatorConfigurationInput {
@@ -1560,6 +1593,8 @@ input IntentsOperatorConfigurationInput {
 	gcpIAMPolicyEnforcementEnabled: Boolean
 	azureIAMPolicyEnforcementEnabled: Boolean
 	databaseEnforcementEnabled: Boolean
+	strictModeEnabled: Boolean
+	excludedStrictModeNamespaces: [String!]
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
 	awsALBLoadBalancerExemptionEnabled: Boolean
@@ -1577,7 +1612,7 @@ type IntentsOperatorState {
 
 type InternetConfig {
 	appliedDomains: [String!]
-	dnsName: String!
+	dnsName: String
 	ips: [String!]
 	ports: [Int!]
 }
@@ -1598,6 +1633,11 @@ type Invite {
 	created: Time!
 	acceptedAt: Time
 	status: InviteStatus!
+}
+
+input InviteOrgMembershipInput {
+	inviteId: ID!
+	membership: OrganizationMembershipInput!
 }
 
 enum InviteStatus {
@@ -1693,6 +1733,7 @@ input K8sResourceLoadBalancerIngressInput {
 input K8sResourceServiceInput {
 	spec: K8sResourceServiceSpecInput!
 	status: K8sResourceServiceStatusInput
+	targetNamedPorts: [NamedPortInput!]
 }
 
 input K8sResourceServiceLoadBalancerIngressInput {
@@ -1867,6 +1908,7 @@ or, for users with a single organization, this is that single selected organizat
 This is selected by the X-Otterize-Organization header,
 or, for users with a single organization, this is that single selected organization."""
 	selectedUserOrganization: UserOrganizationAssociation!
+	selectedOrganizationRestrictionResources: OrganizationMembershipRestrictionResources
 }
 
 type MeMutation {
@@ -2138,6 +2180,9 @@ type Mutation {
 	acceptInvite(
 		id: ID!
 	): Invite!
+	saveInviteOrgMemberships(
+		memberships: [InviteOrgMembershipInput!]!
+	): Boolean!
 	reportK8sServices(
 		namespace: String!
 		services: [K8sServiceInput!]!
@@ -2254,6 +2299,12 @@ type Mutation {
 	): Boolean!
 }
 
+input NamedPortInput {
+	name: String!
+	port: Int!
+	protocol: K8sPortProtocol!
+}
+
 type Namespace {
 	id: ID!
 	name: String!
@@ -2277,6 +2328,11 @@ input NamespacedPodOwner {
 type NetworkMapperComponent {
 	type: ComponentType!
 	status: ComponentStatus!
+}
+
+type NetworkPoliciesPage {
+	data: [NetworkPolicy!]!
+	meta: PaginationMeta
 }
 
 enum NetworkPoliciesStep {
@@ -2336,7 +2392,7 @@ enum NetworkPolicyScope {
 }
 
 type NetworkPolicyWorkload {
-	scope: NetworkPolicyScope!
+	scopes: [NetworkPolicyScope!]!
 	service: Service!
 }
 
@@ -2365,6 +2421,7 @@ type Organization {
 }
 
 type OrganizationMembership {
+	organizationId: ID!
 	role: AuthRole!
 	restrictions: OrganizationMembershipRestrictions
 	restrictionResources: OrganizationMembershipRestrictionResources
@@ -2403,6 +2460,8 @@ type OrganizationSettings {
 	defaultIntentsApprovalActionByEnv: [DefaultIntentsApprovalActionByEnv!]!
 	ignoreInternetIntents: Boolean
 	domainsDefaultRole: AuthRole!
+	defaultInviteMembership: OrganizationMembership!
+	autoApproveMoreRestrictiveIntentsByEnv: [AutoApproveMoreRestrictiveIntentsByEnv!]!
 }
 
 input OrganizationSettingsInput {
@@ -2411,6 +2470,8 @@ input OrganizationSettingsInput {
 	ignoredCloudDomains: [String!]
 	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
 	ignoreInternetIntents: Boolean
+	defaultInviteMembership: OrganizationMembershipInput
+	autoApproveMoreRestrictiveIntentsByEnv: [InputAutoApproveMoreRestrictiveIntentsByEnv!]
 }
 
 input PaginationInput {
@@ -2455,6 +2516,9 @@ type Query {
 	accessGraphServices(
 		filter: InputAccessGraphFilter
 	): [Service!]!
+	accessGraphNamespaces(
+		filter: InputAccessGraphFilter
+	): [Namespace!]!
 	serviceAccessGraph(
 		id: ID!
 	): ServiceAccessGraph!
@@ -2482,6 +2546,9 @@ type Query {
 	edgeNetworkPolicies(
 		clientServiceId: ID!
 		serverServiceId: ID!
+	): [NetworkPolicy!]!
+	serviceNetworkPolicies(
+		serviceId: ID!
 	): [NetworkPolicy!]!
 """ Get edge connections count """
 	edgeConnectionsCount(
@@ -2620,7 +2687,8 @@ type Query {
 	): NetworkPolicy
 	networkPolicies(
 		filter: InputNetworkPolicyFilter
-	): [NetworkPolicy!]!
+		pagination: InputOffsetPagination
+	): NetworkPoliciesPage
 """List organizations"""
 	organizations: [Organization!]!
 """Get organization"""
@@ -2670,8 +2738,6 @@ type Query {
 	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
-"""List users with restriction resources"""
-	orgUsersWithRestrictionResources: UsersWithRestrictionResources!
 	orgUsers: [UserOrganizationAssociation!]!
 """Get user"""
 	user(
@@ -2740,6 +2806,7 @@ type Resource {
 enum RowDiff {
 	ADDED
 	REMOVED
+	STRICT_MODE_WARNING
 }
 
 type RulesetsWithResources {
@@ -2962,6 +3029,7 @@ enum ServiceType {
 	KUBERNETES_LOAD_BALANCER
 	AWS_VISIBILITY_EKS
 	DETECTED_CLOUD_SERVER
+	CONTROL_PLANE
 }
 
 type ServicesResponse {
@@ -3040,13 +3108,15 @@ scalar String
 
 type TLSConfiguration {
 	caCertificate: String
-	certificate: String!
+	certificate: String
+	caCertificateFingerprint: String
+	certificateFingerprint: String
 }
 
 input TLSConfigurationInput {
 	caCertificate: String
-	certificate: String!
-	key: String!
+	certificate: String
+	key: String
 }
 
 enum TelemetryComponentType {
@@ -3069,21 +3139,28 @@ input TelemetryInput {
 	data: TelemetryData!
 }
 
+type TerraformAwsInlinePolicyInfo {
+	name: String!
+	policy: String!
+}
+
 type TerraformAwsPolicyInfo {
 	arn: String!
+	policy: String!
 	address: String!
 }
 
 type TerraformAwsRoleInfo {
 	arn: String!
 	address: String!
-	inlinePolicy: String!
+	inlinePolicy: [TerraformAwsInlinePolicyInfo!]
 	attachedPolicies: [TerraformAwsPolicyInfo!]
 }
 
 type TerraformResourceInfo {
 	modulePath: String!
-	gitOriginUrl: String!
+	gitPlatform: String!
+	gitOrigin: String!
 	gitCommitHash: String!
 	awsRoles: [TerraformAwsRoleInfo!]
 }
@@ -3206,11 +3283,6 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
-}
-
-type UsersWithRestrictionResources {
-	orgUsers: [UserOrganizationAssociation!]!
-	restrictionResources: OrganizationMembershipRestrictionResources
 }
 
 """ Used to validate ID based filters """

--- a/src/mapper/pkg/resourcevisibility/svc_reconciler_test.go
+++ b/src/mapper/pkg/resourcevisibility/svc_reconciler_test.go
@@ -83,6 +83,36 @@ func (s *ServiceVisibilityTestSuite) TestServiceUpload() {
 	}
 	s.kubeFinder.EXPECT().ResolveOtterizeIdentityForService(gomock.Any(), &service, gomock.Any()).Return(serviceIdentity, true, nil)
 
+	// Expect pod listing for TargetNamedPorts
+	podList := corev1.PodList{}
+	s.k8sClient.EXPECT().List(gomock.Any(), gomock.Eq(&podList), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, list *corev1.PodList, opts ...client.ListOption) error {
+			list.Items = []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-1",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"app": deploymentName},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container-1",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 8080,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			return nil
+		})
+
 	serviceInput := cloudclient.K8sServiceInput{
 		OtterizeServer: deploymentName,
 		Namespace:      testNamespace,
@@ -97,6 +127,13 @@ func (s *ServiceVisibilityTestSuite) TestServiceUpload() {
 					},
 				},
 				Selector: []cloudclient.SelectorKeyValueInput{{Key: nilable.From("app"), Value: nilable.From(deploymentName)}},
+			},
+			TargetNamedPorts: []cloudclient.NamedPortInput{
+				{
+					Name:     "http",
+					Port:     8080,
+					Protocol: cloudclient.K8sPortProtocol(corev1.ProtocolTCP),
+				},
 			},
 		},
 	}
@@ -125,6 +162,35 @@ func (s *ServiceVisibilityTestSuite) TestServiceUpload() {
 		})
 
 	s.kubeFinder.EXPECT().ResolveOtterizeIdentityForService(gomock.Any(), &service, gomock.Any()).Return(serviceIdentity, true, nil)
+
+	// Expect pod listing for TargetNamedPorts again
+	s.k8sClient.EXPECT().List(gomock.Any(), gomock.Eq(&podList), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, list *corev1.PodList, opts ...client.ListOption) error {
+			list.Items = []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-1",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"app": deploymentName},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container-1",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 8080,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			return nil
+		})
 
 	// Reconcile again should not upload cause re-upload due to caching
 	res, err = s.reconciler.Reconcile(context.Background(), req)
@@ -169,6 +235,36 @@ func (s *ServiceVisibilityTestSuite) TestServiceReUploadOnIdentityChange() {
 	}
 	s.kubeFinder.EXPECT().ResolveOtterizeIdentityForService(gomock.Any(), &service, gomock.Any()).Return(serviceIdentity, true, nil)
 
+	// Expect pod listing for TargetNamedPorts
+	podList := corev1.PodList{}
+	s.k8sClient.EXPECT().List(gomock.Any(), gomock.Eq(&podList), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, list *corev1.PodList, opts ...client.ListOption) error {
+			list.Items = []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-1",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"app": deploymentName},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container-1",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 8080,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			return nil
+		})
+
 	serviceInput := cloudclient.K8sServiceInput{
 		OtterizeServer: deploymentName,
 		Namespace:      testNamespace,
@@ -184,6 +280,13 @@ func (s *ServiceVisibilityTestSuite) TestServiceReUploadOnIdentityChange() {
 					},
 				},
 				Selector: []cloudclient.SelectorKeyValueInput{{Key: nilable.From("app"), Value: nilable.From(deploymentName)}},
+			},
+			TargetNamedPorts: []cloudclient.NamedPortInput{
+				{
+					Name:     "http",
+					Port:     8080,
+					Protocol: cloudclient.K8sPortProtocol(corev1.ProtocolTCP),
+				},
 			},
 		},
 	}
@@ -220,6 +323,35 @@ func (s *ServiceVisibilityTestSuite) TestServiceReUploadOnIdentityChange() {
 
 	s.kubeFinder.EXPECT().ResolveOtterizeIdentityForService(gomock.Any(), &service, gomock.Any()).Return(newIdentity, true, nil)
 
+	// Expect pod listing for TargetNamedPorts again
+	s.k8sClient.EXPECT().List(gomock.Any(), gomock.Eq(&podList), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, list *corev1.PodList, opts ...client.ListOption) error {
+			list.Items = []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-1",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"app": deploymentName},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container-1",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 8080,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			return nil
+		})
+
 	newServiceInput := cloudclient.K8sServiceInput{
 		OtterizeServer: "another-server",
 		Namespace:      testNamespace,
@@ -235,6 +367,13 @@ func (s *ServiceVisibilityTestSuite) TestServiceReUploadOnIdentityChange() {
 					},
 				},
 				Selector: []cloudclient.SelectorKeyValueInput{{Key: nilable.From("app"), Value: nilable.From(deploymentName)}},
+			},
+			TargetNamedPorts: []cloudclient.NamedPortInput{
+				{
+					Name:     "http",
+					Port:     8080,
+					Protocol: cloudclient.K8sPortProtocol(corev1.ProtocolTCP),
+				},
 			},
 		},
 	}
@@ -277,6 +416,35 @@ func (s *ServiceVisibilityTestSuite) TestServiceReUploadOnIdentityChange() {
 
 	s.kubeFinder.EXPECT().ResolveOtterizeIdentityForService(gomock.Any(), &nodePortService, gomock.Any()).Return(newIdentity, true, nil)
 
+	// Expect pod listing for TargetNamedPorts for nodePortService
+	s.k8sClient.EXPECT().List(gomock.Any(), gomock.Eq(&podList), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, list *corev1.PodList, opts ...client.ListOption) error {
+			list.Items = []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-1",
+						Namespace: testNamespace,
+						Labels:    map[string]string{"app": deploymentName},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container-1",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 8080,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			return nil
+		})
+
 	nodePortServiceInput := cloudclient.K8sServiceInput{
 		OtterizeServer: "another-server",
 		Namespace:      testNamespace,
@@ -292,6 +460,13 @@ func (s *ServiceVisibilityTestSuite) TestServiceReUploadOnIdentityChange() {
 					},
 				},
 				Selector: []cloudclient.SelectorKeyValueInput{{Key: nilable.From("app"), Value: nilable.From(deploymentName)}},
+			},
+			TargetNamedPorts: []cloudclient.NamedPortInput{
+				{
+					Name:     "http",
+					Port:     8080,
+					Protocol: cloudclient.K8sPortProtocol(corev1.ProtocolTCP),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### Description

Named ports are essential to understand if traffic is being allowed/blocked in cases where services or network polcies reference ports by their names


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
