### PR TITLE
Improve kubefinder tests stability

### DIFF
--- a/src/mapper/pkg/kubefinder/kubefinder_test.go
+++ b/src/mapper/pkg/kubefinder/kubefinder_test.go
@@ -128,9 +128,7 @@ func (s *KubeFinderTestSuite) TestIsSrcIpClusterInternal() {
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	// Check pod doesn't exist in the manager's cache
-	pod, err = s.kubeFinder.ResolveIPToPod(context.Background(), "1.1.1.1")
-	s.Require().Nil(pod)
-	s.Require().Error(err)
+	s.WaitForObjectToBeDeleted(pod)
 
 	// Check isInternal with the deleted pod's ip
 	isInternal, err = s.kubeFinder.IsSrcIpClusterInternal(context.Background(), "1.1.1.1")

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -24,8 +24,8 @@ import (
 	"time"
 )
 
-const waitForCreationInterval = 200 * time.Millisecond
-const waitForCreationTimeout = 3 * time.Second
+const waitForInterval = 200 * time.Millisecond
+const waitForTimeout = 3 * time.Second
 
 type ControllerManagerTestSuiteBase struct {
 	suite.Suite
@@ -92,8 +92,8 @@ func (s *ControllerManagerTestSuiteBase) TearDownTest() {
 // waitForObjectToBeCreated tries to get an object multiple times until it is available in the k8s API server
 func (s *ControllerManagerTestSuiteBase) waitForObjectToBeCreated(obj client.Object) {
 	s.Require().NoError(wait.PollUntilContextTimeout(context.Background(),
-		waitForCreationInterval,
-		waitForCreationTimeout,
+		waitForInterval,
+		waitForTimeout,
 		true,
 		func(ctx context.Context) (done bool, err error) {
 			err = s.Mgr.GetClient().Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
@@ -104,6 +104,24 @@ func (s *ControllerManagerTestSuiteBase) waitForObjectToBeCreated(obj client.Obj
 				return false, errors.Wrap(err)
 			}
 			return true, nil
+		}),
+	)
+}
+
+func (s *ControllerManagerTestSuiteBase) WaitForObjectToBeDeleted(obj client.Object) {
+	s.Require().NoError(wait.PollUntilContextTimeout(context.Background(),
+		waitForInterval,
+		waitForTimeout,
+		true,
+		func(ctx context.Context) (done bool, err error) {
+			err = s.Mgr.GetClient().Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
+			if k8serrors.IsNotFound(err) {
+				return true, nil
+			}
+			if err != nil {
+				return false, errors.Wrap(err)
+			}
+			return false, nil
 		}),
 	)
 }
@@ -305,8 +323,8 @@ func (s *ControllerManagerTestSuiteBase) AddIngress(name string, serviceName str
 func (s *ControllerManagerTestSuiteBase) GetAPIServerService() *corev1.Service {
 	service := &corev1.Service{}
 	s.Require().NoError(wait.PollUntilContextTimeout(context.Background(),
-		waitForCreationInterval,
-		waitForCreationTimeout,
+		waitForInterval,
+		waitForTimeout,
 		true,
 		func(ctx context.Context) (done bool, err error) {
 			err = s.Mgr.GetClient().Get(ctx, types.NamespacedName{Name: "kubernetes", Namespace: "default"}, service)
@@ -325,8 +343,8 @@ func (s *ControllerManagerTestSuiteBase) GetAPIServerService() *corev1.Service {
 func (s *ControllerManagerTestSuiteBase) GetAPIServerEndpoints() *corev1.Endpoints {
 	endpoints := &corev1.Endpoints{}
 	s.Require().NoError(wait.PollUntilContextTimeout(context.Background(),
-		waitForCreationInterval,
-		waitForCreationTimeout,
+		waitForInterval,
+		waitForTimeout,
 		true,
 		func(ctx context.Context) (done bool, err error) {
 			err = s.Mgr.GetClient().Get(ctx, types.NamespacedName{Name: "kubernetes", Namespace: "default"}, endpoints)


### PR DESCRIPTION
### Description

Fix test flakiness of TestIsSrcIpClusterInternal

### References

https://github.com/otterize/network-mapper/actions/runs/15427866008/job/43419161728?pr=308

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
